### PR TITLE
New distribution for sapiency

### DIFF
--- a/1.2/Defs/Mutagens/defaultMutagen.xml
+++ b/1.2/Defs/Mutagens/defaultMutagen.xml
@@ -35,7 +35,8 @@
 	-->
 	<Pawnmorph.MutagenDef ParentName="AspectGivingMutagenBase">
 		<defName>ChaoticMutagen</defName>
-		<transformedSapienceDrop>0.4~0.9</transformedSapienceDrop>
+		<transformedSapienceDropMean>0.5</transformedSapienceDropMean>
+		<transformedSapienceDropStd>0.05</transformedSapienceDropStd>
 		<aspectGivers>
 			<li Class="Pawnmorph.Aspects.RandomGiver">
 				<entries>

--- a/Source/Pawnmorphs/Esoteria/MutagenDef.cs
+++ b/Source/Pawnmorphs/Esoteria/MutagenDef.cs
@@ -40,10 +40,16 @@ namespace Pawnmorph
         public ThoughtDef revertedThoughtBad;
 
         /// <summary>
-        /// the sapience drop range when a pawn is transformed by this mutagen
+        /// the average sapience drop when a pawn is transformed by this mutagen
         /// </summary>
         /// note, values returned by this range will be clamped to [0,1] 
-        public FloatRange transformedSapienceDrop = new FloatRange(-.1f,0.3f); 
+        public float transformedSapienceDropMean = 0.5f;
+
+        /// <summary>
+        /// the standard deviation of the sapience drop when a pawn is transformed by this mutagen
+        /// </summary>
+        /// note, values returned by this range will be clamped to [0,1] 
+        public float transformedSapienceDropStd = 0.05f;
 
         /// <summary>
         /// the reversion thought for pawns with primal wish 

--- a/Source/Pawnmorphs/Esoteria/Pawnmorph.csproj
+++ b/Source/Pawnmorphs/Esoteria/Pawnmorph.csproj
@@ -776,6 +776,7 @@
     <Compile Include="User Interface\MutationData.cs" />
     <Compile Include="Utilities\CompCacher.cs" />
     <Compile Include="Utilities\Filter.cs" />
+    <Compile Include="Utilities\GaussianRandom.cs" />
     <Compile Include="Utilities\HediffCompBase.cs" />
     <Compile Include="Utilities\HediffDefUtilities.cs" />
     <Compile Include="Utilities\LinqUtils.cs" />

--- a/Source/Pawnmorphs/Esoteria/TfSys/Mutagen.cs
+++ b/Source/Pawnmorphs/Esoteria/TfSys/Mutagen.cs
@@ -18,6 +18,20 @@ namespace Pawnmorph.TfSys
     /// </summary>
     public abstract class Mutagen
     {
+        /// <summary>
+        /// the influence of mood on the sapience level drop.
+        /// </summary>
+        private const float influenceMood = 0.4f;
+
+        /// <summary>
+        /// the influence of mutagen on the sapience level drop.
+        /// </summary>
+        private const float influenceMutagen = 0.6f;
+
+        /// <summary>
+        /// minimal value of mood so the formula determining the sapiance only considers mood.
+        /// </summary>
+        private const float minimalMoodLowerSapience = 0.8f;
 
         //do this here so all the derived code doesn't have to         
         /// <summary>Gets the game comp.</summary>
@@ -364,7 +378,9 @@ namespace Pawnmorph.TfSys
             if (sTracker?.CurrentState == null) initialSapience = 1;
             else initialSapience = sTracker.Sapience;
 
-            return Mathf.Max(initialSapience - Mathf.Max(def.transformedSapienceDrop.RandomInRange, 0), 0); 
+            float mood = original.needs.mood.CurInstantLevel;
+            float averageGaussian = mood > minimalMoodLowerSapience ? (1 - Mathf.Pow(mood, 2)):influenceMutagen * def.transformedSapienceDropMean + influenceMood * (1-mood);
+            return Mathf.Min(initialSapience - Mathf.Clamp(GaussianRandom.generateNormalRandom(averageGaussian, def.transformedSapienceDropStd), 0.1f, 1f), 0);
         }
     }
 

--- a/Source/Pawnmorphs/Esoteria/TfSys/Mutagen.cs
+++ b/Source/Pawnmorphs/Esoteria/TfSys/Mutagen.cs
@@ -31,7 +31,7 @@ namespace Pawnmorph.TfSys
         /// <summary>
         /// minimal value of mood so the formula determining the sapiance only considers mood.
         /// </summary>
-        private const float minimalMoodLowerSapience = 0.8f;
+        private const float minimalMoodLowerSapience = 0.85f;
 
         //do this here so all the derived code doesn't have to         
         /// <summary>Gets the game comp.</summary>
@@ -379,8 +379,12 @@ namespace Pawnmorph.TfSys
             else initialSapience = sTracker.Sapience;
 
             float mood = original.needs.mood.CurInstantLevel;
-            float averageGaussian = mood > minimalMoodLowerSapience ? (1 - Mathf.Pow(mood, 2)):influenceMutagen * def.transformedSapienceDropMean + influenceMood * (1-mood);
-            return Mathf.Min(initialSapience - Mathf.Clamp(GaussianRandom.generateNormalRandom(averageGaussian, def.transformedSapienceDropStd), 0.1f, 1f), 0);
+            float averageGaussian = 0;
+            if (mood < minimalMoodLowerSapience)
+                averageGaussian = influenceMutagen * def.transformedSapienceDropMean + influenceMood * (1 - mood);
+            else //Mood having a higher impact when exceding the threshold.
+                averageGaussian = (1 - mood) / (1 - minimalMoodLowerSapience) * (influenceMutagen * def.transformedSapienceDropMean + influenceMood * (1 - mood));
+            return Mathf.Max(initialSapience - Mathf.Clamp(GaussianRandom.generateNormalRandom(averageGaussian, def.transformedSapienceDropStd), 0f, 0.9f), 0);
         }
     }
 

--- a/Source/Pawnmorphs/Esoteria/TfSys/SimpleMechaniteMutagen.cs
+++ b/Source/Pawnmorphs/Esoteria/TfSys/SimpleMechaniteMutagen.cs
@@ -161,12 +161,9 @@ namespace Pawnmorph.TfSys
             animalToSpawn.Name = original.Name; // Copies the original pawn's name to the animal's.
             float sapienceLevel = request.forcedSapienceLevel ?? GetSapienceLevel(original, animalToSpawn);
 
-           
-
-            
             GiveTransformedPawnSapienceState(animalToSpawn, sapienceLevel);
 
-            FormerHumanUtilities.InitializeTransformedPawn(original, animalToSpawn, sapienceLevel); //use a normal distribution? 
+            FormerHumanUtilities.InitializeTransformedPawn(original, animalToSpawn, sapienceLevel);
 
             Pawn spawnedAnimal = SpawnAnimal(original, animalToSpawn); // Spawns the animal into the map.
 

--- a/Source/Pawnmorphs/Esoteria/Utilities/GaussianRandom.cs
+++ b/Source/Pawnmorphs/Esoteria/Utilities/GaussianRandom.cs
@@ -1,0 +1,24 @@
+﻿using UnityEngine;
+
+namespace Pawnmorph.Utilities
+{
+    /// <summary> Generation of a random Gaussian with a Box–Muller transform. </summary>
+    public static class GaussianRandom
+    {
+        /// <summary>
+        ///     Generate a random number according to a Gaussian distribution.
+        /// </summary>
+        /// <param name="mu"> The mean.</param>
+        /// <param name="sigma">The Standard deviation.</param>
+        public static float generateNormalRandom(float mu = 0, float sigma = 1)
+        {
+            float rand1 = UnityEngine.Random.Range(0.0f, 1.0f);
+            float rand2 = UnityEngine.Random.Range(0.0f, 1.0f);
+
+            float n = Mathf.Sqrt(-2.0f * Mathf.Log(rand1)) * Mathf.Cos((2.0f * Mathf.PI) * rand2);
+
+            return (mu + sigma * n);
+        }
+    }
+
+}


### PR DESCRIPTION
Instead of an Uniform distribution between 0.1 and 0.6 for sapiency when a pawn is transformed, here is a new formula based on a Gaussian distribution. For now we have:

- When mood is below 0.85 : N(mu = 0.6 * meanMutagenSapiencyDrop + 0.4 * unhapiness, sigma = stdMutagenSapiencyDrop)
- When mood is over 0.85 : linear relation with mood.

Mutagen values can be modified in the corresponding XML.