### PR TITLE
Improve caching for Comp_MutationSeverityAdjust

### DIFF
--- a/Source/Pawnmorphs/Esoteria/Hediffs/Comp_MutationSeverityAdjust.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Comp_MutationSeverityAdjust.cs
@@ -72,7 +72,7 @@ namespace Pawnmorph.Hediffs
         /// <value>
         ///     <c>true</c> if [comp should remove]; otherwise, <c>false</c>.
         /// </value>
-        public override bool CompShouldRemove => SeverityChangePerDay() < 0 && parent.CurStageIndex == 0;
+        public override bool CompShouldRemove => ShouldRemove.Value;
 
         /// <summary>
         ///     Gets the change per day.
@@ -110,11 +110,13 @@ namespace Pawnmorph.Hediffs
         //TODO make some sort of unified caching system for stat lookups, easy way to cause lots of lag 
         private readonly Cached<float> StatAdjust;
         private readonly Cached<float> MutationAdaptability;
+        private readonly Cached<bool> ShouldRemove;
 
         public Comp_MutationSeverityAdjust()
         {
             StatAdjust = new Cached<float>(() => Pawn.GetStatValue(PMStatDefOf.MutagenSensitivity));
             MutationAdaptability = new Cached<float>(() => Pawn.GetStatValue(PMStatDefOf.MutationAdaptability));
+            ShouldRemove = new Cached<bool>(() => parent.CurStageIndex == 0 && SeverityChangePerDay() < 0);
         }
 
         /// <summary>
@@ -158,6 +160,7 @@ namespace Pawnmorph.Hediffs
             {
                 StatAdjust.Recalculate();
                 MutationAdaptability.Recalculate();
+                ShouldRemove.Recalculate();
             }
         }
 

--- a/Source/Pawnmorphs/Esoteria/Utilities/Cached.cs
+++ b/Source/Pawnmorphs/Esoteria/Utilities/Cached.cs
@@ -1,0 +1,34 @@
+﻿using System;
+namespace Pawnmorph.Utilities
+{
+    /// <summary>
+    /// A class to cache generic values rather than calculating them every time.
+    /// </summary>
+    public class Cached<T> where T : struct
+    {
+
+        private readonly Func<T> valueGetter;
+
+        private T? _value;
+        public T Value {
+            get {
+                if (_value == null) _value = valueGetter.Invoke();
+                return (T)_value;
+            }
+        }
+
+        public Cached(Func<T> valueGetter)
+        {
+            this.valueGetter = valueGetter;
+        }
+
+        /// <summary>
+        /// Purges the cache and causes the value to be recalculated the next time
+        /// it's accessed
+        /// </summary>
+        public void Recalculate()
+        {
+            _value = null;
+        }
+    }
+}


### PR DESCRIPTION
As discussed on the Discord, Comp_MutationSeverityAdjust is responsible for a significant amount of lag when large numbers of pawns are involved.  Iron Wolf added some caching to improve performance, but there was still a noticeable amount of lag due to CompShouldRemove calling SeverityChangePerDay() every single tick.

This PR does two things:

1) Add a simple cache class to avoid copy-pasting the same caching code everywhere
2) Additionally cache the result of CompShouldRemove in addition to the values already cached.

This squashes pretty much the last of the performance problems related to Comp_MutationSeverityAdjust.  Tick speed is still noticably limited by HealthTracker ticks when large numbers of pawns exist on the map, but after these changes I don't believe this class is responsible any longer.

Before
![image](https://user-images.githubusercontent.com/6283552/125234253-da174d80-e2cf-11eb-9d37-736944aab582.png)

After
![image](https://user-images.githubusercontent.com/6283552/125234333-0763fb80-e2d0-11eb-910e-c9af8c286d94.png)
