### PR TITLE
Backport performance fixes to 1.2

### DIFF
--- a/Source/Pawnmorphs/Esoteria/Hediffs/Comp_MutationSeverityAdjust.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Comp_MutationSeverityAdjust.cs
@@ -116,7 +116,7 @@ namespace Pawnmorph.Hediffs
             StatAdjust = new Cached<float>(() => Pawn.GetStatValue(PMStatDefOf.MutagenSensitivity));
             MutationAdaptability = new Cached<float>(() => Pawn.GetStatValue(PMStatDefOf.MutationAdaptability));
             IsReverting = new Cached<bool>(() => Pawn.health?.hediffSet?.HasHediff(MorphTransformationDefOf.PM_Reverting) == true);
-            ShouldRemove = new Cached<bool>(() => parent.CurStageIndex == 0 && SeverityChangePerDay() < 0);
+            ShouldRemove = new Cached<bool>(() => IsReverting.Value && parent.Severity <= 0);
         }
 
         /// <summary>

--- a/Source/Pawnmorphs/Esoteria/Hediffs/Comp_MutationSeverityAdjust.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Comp_MutationSeverityAdjust.cs
@@ -18,43 +18,12 @@ namespace Pawnmorph.Hediffs
     /// <seealso cref="Pawnmorph.Utilities.HediffCompBase{T}" />
     public class Comp_MutationSeverityAdjust : HediffComp_SeverityPerDay
     {
+        private const float EPSILON = 0.001f;
         private bool _halted;
 
-        private float? _statAdjust;
+        private int _curStageIndex = -1;
 
-        float StatAdjust
-        {
-            get
-            {
-                if (_statAdjust == null)
-                {
-                    _statAdjust = Pawn.GetStatValue(PMStatDefOf.MutagenSensitivity); //make mutagen sensitivity influence how fast the adjustment works 
-                }
-
-                return _statAdjust.Value; 
-            }
-        }
-
-        [NotNull]
-        private CompProperties_MutationSeverityAdjust Props
-        {
-            get
-            {
-                try
-                {
-                    var p = (CompProperties_MutationSeverityAdjust) props;
-                    if (p == null)
-                        throw new InvalidOperationException($"props on {parent.def.defName} on {Pawn.Name} has not props");
-                    return p;
-                }
-                catch (InvalidCastException e) //just incase the properties get miss assigned somehow 
-                {
-                    throw new
-                        InvalidCastException($"could not convert hediff comp props of type {props.GetType().Name} to {nameof(CompProperties_MutationSeverityAdjust)}",
-                                             e);
-                }
-            }
-        }
+        private bool _checkForReversionHediff;
 
 
         /// <summary>
@@ -65,25 +34,6 @@ namespace Pawnmorph.Hediffs
         ///     The natural severity limit.
         /// </value>
         public float NaturalSeverityLimit => Props.GetNaturalSeverityLimitFor(Pawn);
-
-        /// <summary>
-        ///     called to save/load data for this comp.
-        /// </summary>
-        public override void CompExposeData()
-        {
-            base.CompExposeData();
-            Scribe_Values.Look(ref _halted, nameof(_halted));
-            Scribe_Values.Look(ref _curStageIndex, nameof(_curStageIndex));
-        }
-
-        /// <summary>
-        /// Restarts this instance.
-        /// </summary>
-        public void Restart()
-        {
-            Halted = false;
-            _statAdjust = null; 
-        }
 
         /// <summary>
         ///     Gets or sets a value indicating whether this <see cref="Comp_MutationSeverityAdjust" /> is halted.
@@ -106,7 +56,6 @@ namespace Pawnmorph.Hediffs
                             sevComp._halted =
                                 value; //use the private variable so we don't trigger an infinite loop of comps setting each other
                             allSimilarMutation.Severity = parent.Severity; //make sure they have the same severity to 
-
                         }
                     }
 
@@ -115,24 +64,80 @@ namespace Pawnmorph.Hediffs
             }
         }
 
-        [NotNull]
-        private IEnumerable<Hediff_AddedMutation> GetAllSimilarMutations()
-        {
-            List<Hediff> hediffSet = Pawn.health?.hediffSet?.hediffs;
-            foreach (Hediff_AddedMutation hediff in hediffSet.MakeSafe().OfType<Hediff_AddedMutation>())
-                if (hediff != parent && hediff.def == parent.def)
-                    yield return hediff;
-        }
 
-        private int _curStageIndex = -1;
 
         /// <summary>
-        /// Gets a value indicating whether the parent hediff should be removed.
+        ///     Gets a value indicating whether the parent hediff should be removed.
         /// </summary>
         /// <value>
-        ///   <c>true</c> if [comp should remove]; otherwise, <c>false</c>.
+        ///     <c>true</c> if [comp should remove]; otherwise, <c>false</c>.
         /// </value>
-        public override bool CompShouldRemove => SeverityChangePerDay() < 0 && parent.CurStageIndex == 0; 
+        public override bool CompShouldRemove => ShouldRemove.Value;
+
+        /// <summary>
+        ///     Gets the change per day.
+        /// </summary>
+        /// <value>
+        ///     The change per day.
+        /// </value>
+        public float ChangePerDay => SeverityChangePerDay();
+
+        [NotNull]
+        private CompProperties_MutationSeverityAdjust Props
+        {
+            get
+            {
+                try
+                {
+                    var p = (CompProperties_MutationSeverityAdjust)props;
+                    if (p == null)
+                        throw new InvalidOperationException($"props on {parent.def.defName} on {Pawn.Name} has not props");
+                    return p;
+                }
+                catch (InvalidCastException e) //just incase the properties get miss assigned somehow 
+                {
+                    throw new
+                        InvalidCastException($"could not convert hediff comp props of type {props.GetType().Name} to {nameof(CompProperties_MutationSeverityAdjust)}",
+                                             e);
+                }
+            }
+        }
+
+        // prioritize updating spawned pawns over world pawns 
+        private int TickRate => Pawn.SpawnedOrAnyParentSpawned ? 25 : 70;
+
+        // These values only get recalculated every so often because of how expensive they are to calculate
+        //TODO make some sort of unified caching system for stat lookups, easy way to cause lots of lag 
+        private readonly Cached<float> StatAdjust;
+        private readonly Cached<float> MutationAdaptability;
+        private readonly Cached<bool> ShouldRemove;
+
+        public Comp_MutationSeverityAdjust()
+        {
+            StatAdjust = new Cached<float>(() => Pawn.GetStatValue(PMStatDefOf.MutagenSensitivity));
+            MutationAdaptability = new Cached<float>(() => Pawn.GetStatValue(PMStatDefOf.MutationAdaptability));
+            ShouldRemove = new Cached<bool>(() => parent.CurStageIndex == 0 && SeverityChangePerDay() < 0);
+        }
+
+        /// <summary>
+        ///     called to save/load data for this comp.
+        /// </summary>
+        public override void CompExposeData()
+        {
+            base.CompExposeData();
+            Scribe_Values.Look(ref _halted, nameof(_halted));
+            Scribe_Values.Look(ref _curStageIndex, nameof(_curStageIndex));
+        }
+
+        /// <summary>
+        ///     called when the parent is merged with a new hediff of the same type
+        /// </summary>
+        /// <param name="other">The other.</param>
+        public override void CompPostMerged(Hediff other)
+        {
+            base.CompPostMerged(other);
+            Restart(); //restart adjusting if halted
+        }
 
         /// <summary>
         ///     called every tick
@@ -149,28 +154,84 @@ namespace Pawnmorph.Hediffs
                 CheckIfHalted();
             }
 
-            if (Pawn.IsHashIntervalTick(60))
+            int tickRate = TickRate; //prioritize updating spawned pawns over world pawns 
+
+            if (Pawn.IsHashIntervalTick(tickRate))
             {
-                _statAdjust = null; //only check the stat every so often, this is expensive 
+                StatAdjust.Recalculate();
+                MutationAdaptability.Recalculate();
+                ShouldRemove.Recalculate();
             }
         }
 
         /// <summary>
-        ///     called when the parent is merged with a new hediff of the same type
+        ///     Recalcs the adjust speed.
         /// </summary>
-        /// <param name="other">The other.</param>
-        public override void CompPostMerged(Hediff other)
+        public void RecalcAdjustSpeed()
         {
-            base.CompPostMerged(other);
-            Halted = false; //restart adjusting if halted 
-            _statAdjust = null;
+            _checkForReversionHediff = true;
         }
 
-        private const float EPSILON = 0.001f;
+        /// <summary>
+        ///     Restarts this instance.
+        /// </summary>
+        public void Restart()
+        {
+            Halted = false;
+            StatAdjust.Recalculate();
+            MutationAdaptability.Recalculate();
+        }
+
+        /// <summary>
+        ///     get the change in severity per day
+        /// </summary>
+        /// <returns></returns>
+        protected override float SeverityChangePerDay()
+        {
+            if (_checkForReversionHediff || Pawn.IsHashIntervalTick(TickRate))
+            {
+                _checkForReversionHediff = false;
+                bool hasReversionHediff = Pawn.health?.hediffSet?.HasHediff(MorphTransformationDefOf.PM_Reverting) == true;
+                if (hasReversionHediff) return -1;
+            }
+
+            if (Halted) return 0;
+            float statValue = MutationAdaptability.Value;
+            float maxSeverity = Mathf.Max(statValue + 1, 1);
+            float minSeverity = Mathf.Min(statValue, 0); //have the stat influence how high or low the severity can be 
+            float sMult = Props.statEffectMult * (statValue + 1);
+            float sevPerDay = base.SeverityChangePerDay() * sMult;
+            //make sure the severity can only stay between the max and min 
+            if (parent.Severity > maxSeverity) sevPerDay = Mathf.Min(0, sevPerDay);
+            if (parent.Severity < minSeverity) sevPerDay = Mathf.Max(0, sevPerDay);
+
+
+            return sevPerDay * Mathf.Max(StatAdjust.Value, 0); //take the mutagen sensitivity stat into account 
+        }
+
+        private void CheckIfHalted()
+        {
+            if (parent.CurStage is MutationStage mStage)
+            {
+                float stopChance = mStage.stopChance * GetChanceMult() * Pawn.GetStatValue(PMStatDefOf.MutationHaltChance);
+
+                if (stopChance < 0.01f) return;
+                if (Rand.Value < stopChance) Halted = true;
+            }
+        }
+
+        [NotNull]
+        private IEnumerable<Hediff_AddedMutation> GetAllSimilarMutations()
+        {
+            List<Hediff> hediffSet = Pawn.health?.hediffSet?.hediffs;
+            foreach (Hediff_AddedMutation hediff in hediffSet.MakeSafe().OfType<Hediff_AddedMutation>())
+                if (hediff != parent && hediff.def == parent.def)
+                    yield return hediff;
+        }
 
         private float GetChanceMult()
         {
-            float sVal = Pawn.GetStatValue(PMStatDefOf.MutationAdaptability);
+            float sVal = MutationAdaptability.Value;
 
             float r = MutationUtilities.MaxMutationAdaptabilityValue - MutationUtilities.MinMutationAdaptabilityValue;
             sVal = Mathf.Abs(MutationUtilities.AverageMutationAdaptabilityValue - sVal)
@@ -181,79 +242,6 @@ namespace Pawnmorph.Hediffs
             sVal *= -2 / r; //shift the range again to [0,1], where a default stat value is 0, and either min or max is 0 
             sVal = Mathf.Max(sVal, 0); //make sure it doesn't go below zero, can happen if the default is not the center point of min and max
             return sVal;
-        }
-
-        //disabled because it caused large amounts of lag, enable only if debugging 
-#if false
-        /// <summary>
-        /// gets the debug string 
-        /// </summary>
-        /// <returns></returns>
-        public override string CompDebugString()
-        {
-            StringBuilder builder = new StringBuilder();
-            builder.AppendLine(base.CompDebugString());
-            builder.AppendLine($"stop multiplier is {GetChanceMult()}");
-            return builder.ToString(); 
-        }
-
-#endif
-
-        private void CheckIfHalted()
-        {
-            if (parent.CurStage is MutationStage mStage)
-            {
-                float stopChance = mStage.stopChance * GetChanceMult() * Pawn.GetStatValue(PMStatDefOf.MutationHaltChance);
-
-                if (stopChance < 0.01f) return; 
-                if (Rand.Value < stopChance) Halted = true;
-            }
-        }
-
-
-        /// <summary>
-        ///     get the change in severity per day
-        /// </summary>
-        /// <returns></returns>
-        protected override float SeverityChangePerDay()
-        {
-            if (_checkForReversionHediff || Pawn.IsHashIntervalTick(25))
-            {
-                var hasReversionHediff = Pawn.health?.hediffSet?.HasHediff(MorphTransformationDefOf.PM_Reverting) == true;
-                if (hasReversionHediff) return -1; 
-
-            }
-
-            if (Halted) return 0;
-            float statValue = Pawn.GetStatValue(PMStatDefOf.MutationAdaptability);
-            float maxSeverity = Mathf.Max(statValue + 1, 1);
-            float minSeverity = Mathf.Min(statValue, 0); //have the stat influence how high or low the severity can be 
-            float sMult = Props.statEffectMult * (statValue + 1);
-            var sevPerDay = base.SeverityChangePerDay() * sMult;
-            //make sure the severity can only stay between the max and min 
-            if (parent.Severity > maxSeverity) sevPerDay = Mathf.Min(0, sevPerDay);
-            if (parent.Severity < minSeverity) sevPerDay = Mathf.Max(0, sevPerDay);
-
-
-            return sevPerDay * Mathf.Max(StatAdjust, 0); //take the mutagen sensitivity stat into account 
-        }
-
-        /// <summary>
-        /// Gets the change per day.
-        /// </summary>
-        /// <value>
-        /// The change per day.
-        /// </value>
-        public float ChangePerDay => SeverityChangePerDay();
-
-        private bool _checkForReversionHediff;
-
-        /// <summary>
-        /// Recalcs the adjust speed.
-        /// </summary>
-        public void RecalcAdjustSpeed()
-        {
-            _checkForReversionHediff = true; 
         }
     }
 

--- a/Source/Pawnmorphs/Esoteria/Hediffs/Comp_MutationSeverityAdjust.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Comp_MutationSeverityAdjust.cs
@@ -23,9 +23,6 @@ namespace Pawnmorph.Hediffs
 
         private int _curStageIndex = -1;
 
-        private bool _checkForReversionHediff;
-
-
         /// <summary>
         ///     Gets the natural severity limit.
         /// </summary>
@@ -103,19 +100,22 @@ namespace Pawnmorph.Hediffs
             }
         }
 
-        // prioritize updating spawned pawns over world pawns 
-        private int TickRate => Pawn.SpawnedOrAnyParentSpawned ? 25 : 70;
+        // HediffComp_SeverityPerDay only updates severity once every 200 ticks so faster tickrates do nothing
+        // World pawns get a slower tickrate here so that large numbers of world morphs don't slow the game down
+        private int TickRate => Pawn.SpawnedOrAnyParentSpawned ? 200 : 600;
 
         // These values only get recalculated every so often because of how expensive they are to calculate
         //TODO make some sort of unified caching system for stat lookups, easy way to cause lots of lag 
         private readonly Cached<float> StatAdjust;
         private readonly Cached<float> MutationAdaptability;
+        private readonly Cached<bool> IsReverting;
         private readonly Cached<bool> ShouldRemove;
 
         public Comp_MutationSeverityAdjust()
         {
             StatAdjust = new Cached<float>(() => Pawn.GetStatValue(PMStatDefOf.MutagenSensitivity));
             MutationAdaptability = new Cached<float>(() => Pawn.GetStatValue(PMStatDefOf.MutationAdaptability));
+            IsReverting = new Cached<bool>(() => Pawn.health?.hediffSet?.HasHediff(MorphTransformationDefOf.PM_Reverting) == true);
             ShouldRemove = new Cached<bool>(() => parent.CurStageIndex == 0 && SeverityChangePerDay() < 0);
         }
 
@@ -160,26 +160,29 @@ namespace Pawnmorph.Hediffs
             {
                 StatAdjust.Recalculate();
                 MutationAdaptability.Recalculate();
+                IsReverting.Recalculate();
                 ShouldRemove.Recalculate();
             }
         }
 
         /// <summary>
-        ///     Recalcs the adjust speed.
+        ///     manually purges all cached data to force the adjustment speed to be recalculated the next time it's called
         /// </summary>
         public void RecalcAdjustSpeed()
         {
-            _checkForReversionHediff = true;
+            StatAdjust.Recalculate();
+            MutationAdaptability.Recalculate();
+            IsReverting.Recalculate();
+            ShouldRemove.Recalculate();
         }
 
         /// <summary>
-        ///     Restarts this instance.
+        ///     restarts adjustment for this mutation if it was halted
         /// </summary>
         public void Restart()
         {
             Halted = false;
-            StatAdjust.Recalculate();
-            MutationAdaptability.Recalculate();
+            RecalcAdjustSpeed();
         }
 
         /// <summary>
@@ -188,13 +191,7 @@ namespace Pawnmorph.Hediffs
         /// <returns></returns>
         protected override float SeverityChangePerDay()
         {
-            if (_checkForReversionHediff || Pawn.IsHashIntervalTick(TickRate))
-            {
-                _checkForReversionHediff = false;
-                bool hasReversionHediff = Pawn.health?.hediffSet?.HasHediff(MorphTransformationDefOf.PM_Reverting) == true;
-                if (hasReversionHediff) return -1;
-            }
-
+            if (IsReverting.Value) return -1;
             if (Halted) return 0;
             float statValue = MutationAdaptability.Value;
             float maxSeverity = Mathf.Max(statValue + 1, 1);

--- a/Source/Pawnmorphs/Esoteria/Utilities/Cached.cs
+++ b/Source/Pawnmorphs/Esoteria/Utilities/Cached.cs
@@ -1,0 +1,36 @@
+﻿using System;
+namespace Pawnmorph.Utilities
+{
+    /// <summary>
+    /// A class to cache generic values rather than calculating them every time.
+    /// </summary>
+    public class Cached<T> where T : struct
+    {
+
+        private readonly Func<T> valueGetter;
+
+        private T? _value;
+        public T Value
+        {
+            get
+            {
+                if (_value == null) _value = valueGetter.Invoke();
+                return (T)_value;
+            }
+        }
+
+        public Cached(Func<T> valueGetter)
+        {
+            this.valueGetter = valueGetter;
+        }
+
+        /// <summary>
+        /// Purges the cache and causes the value to be recalculated the next time
+        /// it's accessed
+        /// </summary>
+        public void Recalculate()
+        {
+            _value = null;
+        }
+    }
+}


### PR DESCRIPTION
Backports the performance fixes to Comp_MutationSeverityAdjust back to 1.2.

Also fixes some additional bugs that were identified:
  - The presence/absence of the Reverter hediff is now properly cached as it was intended to be
  - Mutations are only removed if a pawn has the Reverter hediff and severity is 0.  Previously, mutations would be removed if adjustment speed was negative (regardless of cause) the moment the first stage was reached, effectively skipping past said stage.