### PR TITLE
Fix muzzle reversion graphics

### DIFF
--- a/1.2/Patches/Core_HumanHedifGraphics.xml
+++ b/1.2/Patches/Core_HumanHedifGraphics.xml
@@ -20,6 +20,7 @@
 							<a0.5>Parts/COMBINATIONS/Wolfspike/Wolfspike</a0.5>
 							<a0.3>Parts/Partials/PartialMuzzle/PartialMuzzle</a0.3>
 							<a0.1>Parts/Partials/PartialMuzzle/TinyMuzzle</a0.1>
+							<a0.0>Parts/None/None</a0.0>
 						</severity>
 					</EtherComboWolfSpike>
 					<PM_HellhoundSnout>
@@ -28,6 +29,7 @@
 							<a0.5>Parts/COMBINATIONS/Hellhound/Hellhound_Jaw</a0.5>
 							<a0.3>Parts/Partials/PartialMuzzle/PartialMuzzle</a0.3>
 							<a0.1>Parts/Partials/PartialMuzzle/TinyMuzzle</a0.1>
+							<a0.0>Parts/None/None</a0.0>
 						</severity>
 					</PM_HellhoundSnout>
 					<EtherAlpacaSnout>
@@ -36,6 +38,7 @@
 							<a0.5>Parts/Alpaca/Alpaca_Jaw</a0.5>
 							<a0.3>Parts/Partials/PartialMuzzle/PartialSnoutOvine</a0.3>
 							<a0.1>Parts/Partials/PartialMuzzle/TinySnout</a0.1>
+							<a0.0>Parts/None/None</a0.0>
 						</severity>
 					</EtherAlpacaSnout>
 					<EtherArcticWolfJaw>
@@ -44,6 +47,7 @@
 							<a0.5>Parts/wolfface/wolfface</a0.5>
 							<a0.3>Parts/Partials/PartialMuzzle/PartialMuzzle</a0.3>
 							<a0.1>Parts/Partials/PartialMuzzle/TinyMuzzle</a0.1>
+							<a0.0>Parts/None/None</a0.0>
 						</severity>
 					</EtherArcticWolfJaw>
 					<EtherBearMuzzle>
@@ -52,6 +56,7 @@
 							<a0.5>Parts/Bear/Bear_Jaw</a0.5>
 							<a0.3>Parts/Partials/PartialMuzzle/PartialMuzzle</a0.3>
 							<a0.1>Parts/Partials/PartialMuzzle/TinyMuzzle</a0.1>
+							<a0.0>Parts/None/None</a0.0>
 						</severity>
 					</EtherBearMuzzle>
 					<EtherPolarBearMuzzle>
@@ -60,6 +65,7 @@
 							<a0.5>Parts/Bear/Bear_Jaw</a0.5>
 							<a0.3>Parts/Partials/PartialMuzzle/PartialMuzzle</a0.3>
 							<a0.1>Parts/Partials/PartialMuzzle/TinyMuzzle</a0.1>
+							<a0.0>Parts/None/None</a0.0>
 						</severity>
 					</EtherPolarBearMuzzle>
 					<EtherBoarSnout>
@@ -68,6 +74,7 @@
 							<a0.5>Parts/Boar/Boar_Jaw</a0.5>
 							<a0.3>Parts/Partials/PartialMuzzle/PartialSnoutPorcine</a0.3>
 							<a0.1>Parts/Partials/PartialMuzzle/TinySnoutPorcine</a0.1>
+							<a0.0>Parts/None/None</a0.0>
 						</severity>
 					</EtherBoarSnout>
 					<EtherBoomalopeSnout>
@@ -76,6 +83,7 @@
 							<a0.5>Parts/boomalopeface/boomalopeface</a0.5>
 							<a0.3>Parts/Partials/PartialMuzzle/PartialSnout</a0.3>
 							<a0.1>Parts/Partials/PartialMuzzle/TinySnout</a0.1>
+							<a0.0>Parts/None/None</a0.0>
 						</severity>
 					</EtherBoomalopeSnout>
 					<EtherRaccoonJaw>
@@ -84,6 +92,7 @@
 							<a0.5>Parts/Raccoon/Raccoon_Jaw</a0.5>
 							<a0.3>Parts/Partials/PartialMuzzle/PartialMuzzle</a0.3>
 							<a0.1>Parts/Partials/PartialMuzzle/TinyMuzzle</a0.1>
+							<a0.0>Parts/None/None</a0.0>
 						</severity>
 					</EtherRaccoonJaw>
 					<EtherCatMuzzle>
@@ -92,6 +101,7 @@
 							<a0.5>Parts/catface/catface</a0.5>
 							<a0.3>Parts/Partials/PartialMuzzle/PartialMuzzle</a0.3>
 							<a0.1>Parts/Partials/PartialMuzzle/TinyMuzzle</a0.1>
+							<a0.0>Parts/None/None</a0.0>
 						</severity>
 					</EtherCatMuzzle>
 					<EtherBeak>
@@ -99,6 +109,7 @@
 						<severity>
 							<a0.5>Parts/chickenface/chickenface</a0.5>
 							<a0.1>Parts/Partials/PartialMuzzle/PartialBeak</a0.1>
+							<a0.0>Parts/None/None</a0.0>
 						</severity>
 					</EtherBeak>
 					<EtherTurkeyBeak>
@@ -106,6 +117,7 @@
 						<severity>
 							<a0.5>Parts/Turkey/Turkey_Jaw</a0.5>
 							<a0.1>Parts/Partials/PartialMuzzle/PartialBeak</a0.1>
+							<a0.0>Parts/None/None</a0.0>
 						</severity>
 					</EtherTurkeyBeak>
 					<EtherEmuBeak>
@@ -113,6 +125,7 @@
 						<severity>
 							<a0.5>Parts/Emu/Emu_Jaw</a0.5>
 							<a0.1>Parts/Partials/PartialMuzzle/PartialBeak</a0.1>
+							<a0.0>Parts/None/None</a0.0>
 						</severity>
 					</EtherEmuBeak>
 					<EtherOstrichBeak>
@@ -120,6 +133,7 @@
 						<severity>
 							<a0.5>Parts/Ostrich/Ostrich_Jaw</a0.5>
 							<a0.1>Parts/Partials/PartialMuzzle/PartialBeak</a0.1>
+							<a0.0>Parts/None/None</a0.0>
 						</severity>
 					</EtherOstrichBeak>
 					<EtherCassowaryBeak>
@@ -127,6 +141,7 @@
 						<severity>
 							<a0.5>Parts/Cassowary/Cassowary_Jaw</a0.5>
 							<a0.1>Parts/Partials/PartialMuzzle/PartialBeak</a0.1>
+							<a0.0>Parts/None/None</a0.0>
 						</severity>
 					</EtherCassowaryBeak>
 					<EtherDuckBeak>
@@ -134,6 +149,7 @@
 						<severity>
 							<a0.5>Parts/Duck/Duck_Jaw</a0.5>
 							<a0.1>Parts/Partials/PartialMuzzle/PartialBeak</a0.1>
+							<a0.0>Parts/None/None</a0.0>
 						</severity>
 					</EtherDuckBeak>
 					<EtherGooseBeak>
@@ -141,6 +157,7 @@
 						<severity>
 							<a0.5>Parts/Goose/Goose_Jaw</a0.5>
 							<a0.1>Parts/Partials/PartialMuzzle/PartialBeak</a0.1>
+							<a0.0>Parts/None/None</a0.0>
 						</severity>
 					</EtherGooseBeak>
 					<EtherSnakeJaw>Parts/Cobra/Cobra_Jaw</EtherSnakeJaw>
@@ -150,6 +167,7 @@
 							<a0.5>Parts/Cougar/Cougar_Jaw</a0.5>
 							<a0.3>Parts/Partials/PartialMuzzle/PartialMuzzle</a0.3>
 							<a0.1>Parts/Partials/PartialMuzzle/TinyMuzzle</a0.1>
+							<a0.0>Parts/None/None</a0.0>
 						</severity>
 					</EtherCougarJaw>
 					<EtherDonkeySnout>
@@ -158,6 +176,7 @@
 							<a0.5>Parts/Donkey/Donkey_Jaw</a0.5>
 							<a0.3>Parts/Partials/PartialMuzzle/PartialMuzzle</a0.3>
 							<a0.1>Parts/Partials/PartialMuzzle/TinyMuzzle</a0.1>
+							<a0.0>Parts/None/None</a0.0>
 						</severity>
 					</EtherDonkeySnout>
 					<EtherCowSnout>
@@ -166,6 +185,7 @@
 							<a0.5>Parts/cowface/cowface</a0.5>
 							<a0.3>Parts/Partials/PartialMuzzle/PartialSnout</a0.3>
 							<a0.1>Parts/Partials/PartialMuzzle/TinySnout</a0.1>
+							<a0.0>Parts/None/None</a0.0>
 						</severity>
 					</EtherCowSnout>
 					<EtherDeerSnout>
@@ -174,6 +194,7 @@
 							<a0.5>Parts/deerface/deerface</a0.5>
 							<a0.3>Parts/Partials/PartialMuzzle/PartialSnout</a0.3>
 							<a0.1>Parts/Partials/PartialMuzzle/TinySnout</a0.1>
+							<a0.0>Parts/None/None</a0.0>
 						</severity>
 					</EtherDeerSnout>
 					<EtherTrunk>Parts/elephantface/elephantface</EtherTrunk>
@@ -183,6 +204,7 @@
 							<a0.5>Parts/FoxUpdated/RedFox_Jaw</a0.5>
 							<a0.3>Parts/Partials/PartialMuzzle/PartialMuzzle</a0.3>
 							<a0.1>Parts/Partials/PartialMuzzle/TinyMuzzle</a0.1>
+							<a0.0>Parts/None/None</a0.0>
 						</severity>
 					</EtherFoxMuzzle>
 					<EtherFennecFoxMuzzle>
@@ -191,6 +213,7 @@
 							<a0.5>Parts/FoxFennec/FennecFox_Jaw</a0.5>
 							<a0.3>Parts/Partials/PartialMuzzle/PartialMuzzle</a0.3>
 							<a0.1>Parts/Partials/PartialMuzzle/TinyMuzzle</a0.1>
+							<a0.0>Parts/None/None</a0.0>
 						</severity>
 					</EtherFennecFoxMuzzle>
 					<EtherArcticFoxMuzzle>
@@ -199,6 +222,7 @@
 							<a0.5>Parts/FoxArctic/ArcticFox_Jaw</a0.5>
 							<a0.3>Parts/Partials/PartialMuzzle/PartialMuzzle</a0.3>
 							<a0.1>Parts/Partials/PartialMuzzle/TinyMuzzle</a0.1>
+							<a0.0>Parts/None/None</a0.0>
 						</severity>
 					</EtherArcticFoxMuzzle>
 					<EtherHareJaw>
@@ -207,6 +231,7 @@
 							<a0.5>Parts/Hare/Hare_Jaw</a0.5>
 							<a0.3>Parts/Partials/PartialMuzzle/PartialMuzzle</a0.3>
 							<a0.1>Parts/Partials/PartialMuzzle/TinyMuzzle</a0.1>
+							<a0.0>Parts/None/None</a0.0>
 						</severity>
 					</EtherHareJaw>
 					<EtherSnowhareJaw>
@@ -215,6 +240,7 @@
 							<a0.5>Parts/Hare/Hare_Jaw</a0.5>
 							<a0.3>Parts/Partials/PartialMuzzle/PartialMuzzle</a0.3>
 							<a0.1>Parts/Partials/PartialMuzzle/TinyMuzzle</a0.1>
+							<a0.0>Parts/None/None</a0.0>
 						</severity>
 					</EtherSnowhareJaw>
 					<EtherHorseSnout>
@@ -223,6 +249,7 @@
 							<a0.5>Parts/horseface/horseface</a0.5>
 							<a0.3>Parts/Partials/PartialMuzzle/PartialSnout</a0.3>
 							<a0.1>Parts/Partials/PartialMuzzle/TinySnout</a0.1>
+							<a0.0>Parts/None/None</a0.0>
 						</severity>
 					</EtherHorseSnout>
 					<EtherHuskyMuzzle>
@@ -231,6 +258,7 @@
 							<a0.5>Parts/huskyface/huskyface</a0.5>
 							<a0.3>Parts/Partials/PartialMuzzle/PartialMuzzle</a0.3>
 							<a0.1>Parts/Partials/PartialMuzzle/TinyMuzzle</a0.1>
+							<a0.0>Parts/None/None</a0.0>
 						</severity>
 					</EtherHuskyMuzzle>
 					<EtherIguanaSnout>Parts/iguanaface/iguanaface</EtherIguanaSnout>
@@ -240,6 +268,7 @@
 							<a0.5>Parts/Lynx/Lynx_Jaw</a0.5>
 							<a0.3>Parts/Partials/PartialMuzzle/PartialMuzzle</a0.3>
 							<a0.1>Parts/Partials/PartialMuzzle/TinyMuzzle</a0.1>
+							<a0.0>Parts/None/None</a0.0>
 						</severity>
 					</EtherLynxJaw>
 					<EtherMegaslothSnout>Parts/megaslothface/megaslothface</EtherMegaslothSnout>
@@ -250,6 +279,7 @@
 							<a0.5>Parts/Panther/Panther_Jaw</a0.5>
 							<a0.3>Parts/Partials/PartialMuzzle/PartialMuzzle</a0.3>
 							<a0.1>Parts/Partials/PartialMuzzle/TinyMuzzle</a0.1>
+							<a0.0>Parts/None/None</a0.0>
 						</severity>
 					</EtherPantherJaw>
 					<EtherPigSnout>
@@ -258,6 +288,7 @@
 							<a0.5>Parts/pigface/pigface</a0.5>
 							<a0.3>Parts/Partials/PartialMuzzle/PartialSnoutPorcine</a0.3>
 							<a0.1>Parts/Partials/PartialMuzzle/TinySnoutPorcine</a0.1>
+							<a0.0>Parts/None/None</a0.0>
 						</severity>
 					</EtherPigSnout>
 					<EtherRatSnout>
@@ -266,6 +297,7 @@
 							<a0.5>Parts/ratface/ratface</a0.5>
 							<a0.3>Parts/Partials/PartialMuzzle/PartialMuzzle</a0.3>
 							<a0.1>Parts/Partials/PartialMuzzle/TinyMuzzle</a0.1>
+							<a0.0>Parts/None/None</a0.0>
 						</severity>
 					</EtherRatSnout>
 					<EtherRhinocerosJaw>
@@ -274,6 +306,7 @@
 							<a0.5>Parts/Rhinoceros/Rhinoceros_Jaw</a0.5>
 							<a0.3>Parts/Partials/PartialMuzzle/PartialMuzzle</a0.3>
 							<a0.1>Parts/Partials/PartialMuzzle/TinyMuzzle</a0.1>
+							<a0.0>Parts/None/None</a0.0>
 						</severity>
 					</EtherRhinocerosJaw>
 					<EtherSheepSnout>
@@ -282,6 +315,7 @@
 							<a0.5>Parts/sheepface/sheepface</a0.5>
 							<a0.3>Parts/Partials/PartialMuzzle/PartialSnoutOvine</a0.3>
 							<a0.1>Parts/Partials/PartialMuzzle/TinySnout</a0.1>
+							<a0.0>Parts/None/None</a0.0>
 						</severity>
 					</EtherSheepSnout>
 					<EtherGoatSnout>
@@ -290,6 +324,7 @@
 							<a0.5>Parts/Goat/Goat_Jaw</a0.5>
 							<a0.3>Parts/Partials/PartialMuzzle/PartialSnoutOvine</a0.3>
 							<a0.1>Parts/Partials/PartialMuzzle/TinySnout</a0.1>
+							<a0.0>Parts/None/None</a0.0>
 						</severity>
 					</EtherGoatSnout>
 					<EtherSquirrelJaw>
@@ -298,6 +333,7 @@
 							<a0.5>Parts/Squirrel/Squirrel_Jaw</a0.5>
 							<a0.3>Parts/Partials/PartialMuzzle/PartialMuzzle</a0.3>
 							<a0.1>Parts/Partials/PartialMuzzle/TinyMuzzle</a0.1>
+							<a0.0>Parts/None/None</a0.0>
 						</severity>
 					</EtherSquirrelJaw>
 					<EtherAlphabeaverJaw>
@@ -306,6 +342,7 @@
 							<a0.5>Parts/Alphabeaver/Alphabeaver_Jaw</a0.5>
 							<a0.3>Parts/Partials/PartialMuzzle/PartialMuzzle</a0.3>
 							<a0.1>Parts/Partials/PartialMuzzle/TinyMuzzle</a0.1>
+							<a0.0>Parts/None/None</a0.0>
 						</severity>
 					</EtherAlphabeaverJaw>
 					<EtherThrumboSnout>
@@ -314,6 +351,7 @@
 							<a0.5>Parts/thrumboface/thrumboface</a0.5>
 							<a0.3>Parts/Partials/PartialMuzzle/PartialSnout</a0.3>
 							<a0.1>Parts/Partials/PartialMuzzle/TinySnout</a0.1>
+							<a0.0>Parts/None/None</a0.0>
 						</severity>
 					</EtherThrumboSnout>
 					<EtherTortoiseJaw>Parts/Tortoise/Tortoise_Jaw</EtherTortoiseJaw>
@@ -323,6 +361,7 @@
 							<a0.5>Parts/wargface/wargface</a0.5>
 							<a0.3>Parts/Partials/PartialMuzzle/PartialMuzzle</a0.3>
 							<a0.1>Parts/Partials/PartialMuzzle/TinyMuzzle</a0.1>
+							<a0.0>Parts/None/None</a0.0>
 						</severity>
 					</EtherWargMuzzle>
 					<EtherLabradorRetrieverJaw>
@@ -331,6 +370,7 @@
 							<a0.5>Parts/LabradorRetriever/LabradorRetriever_Jaw</a0.5>
 							<a0.3>Parts/Partials/PartialMuzzle/PartialMuzzle</a0.3>
 							<a0.1>Parts/Partials/PartialMuzzle/TinyMuzzle</a0.1>
+							<a0.0>Parts/None/None</a0.0>
 						</severity>
 					</EtherLabradorRetrieverJaw>			
 					<EtherWolfMuzzle>
@@ -339,6 +379,7 @@
 							<a0.5>Parts/wolfface/wolfface</a0.5>
 							<a0.3>Parts/Partials/PartialMuzzle/PartialMuzzle</a0.3>
 							<a0.1>Parts/Partials/PartialMuzzle/TinyMuzzle</a0.1>
+							<a0.0>Parts/None/None</a0.0>
 						</severity>
 					</EtherWolfMuzzle>
 				</hediffGraphics>


### PR DESCRIPTION
Followup to #313.

While testing my changes to reversion in that PR, I realized that during reversion, shrinking muzzles would now appear to pop back into fully-formed muzzles momentarily just before completely disappearing.  This is because muzzle graphics had no defined graphic for severity <0.1, so they pulled the default graphic instead.  I just added an additional invisible stage for severities between 0 and 0.1 for all muzzle graphics.  As far as I can tell, only muzzles have this issue so I left the other mutation graphics alone.