### PR TITLE
Reversion severity changes

### DIFF
--- a/1.3/Defs/Hediffs/Drugs.xml
+++ b/1.3/Defs/Hediffs/Drugs.xml
@@ -10,7 +10,7 @@
         <isBad>false</isBad>
         <comps>
             <li Class="HediffCompProperties_SeverityPerDay">
-                <severityPerDay>-0.8</severityPerDay>
+                <severityPerDay>-0.4</severityPerDay>
             </li>
             <li Class="Pawnmorph.Hediffs.CompProperties_RemoveType">
                 <removeType>Pawnmorph.Hediffs.MorphTf</removeType>

--- a/Source/Pawnmorphs/Esoteria/IngestionOutcomeDoer_EsotericRevert.cs
+++ b/Source/Pawnmorphs/Esoteria/IngestionOutcomeDoer_EsotericRevert.cs
@@ -74,6 +74,7 @@ namespace Pawnmorph
 
             //add reversion hediff 
             var hDiff = HediffMaker.MakeHediff(MorphTransformationDefOf.PM_Reverting, pawn);
+            hDiff.Severity = 1;
             hediffs.AddDirect(hDiff);
 
 


### PR DESCRIPTION
Previously, reversion serum started with only 0.5 severity, which meant fully-mutated morphs would not be reverted by a single serum.  I increased that to 1.0 severity, and additionally doubled the time it takes to dissipate so that even Paragon morphs will be fully reverted