### PR TITLE
Fix injector hediffs so that they always give the hediff

### DIFF
--- a/Defs/Morphs/Bear/Grizzly Bear/GrizzlyBear_Injector.xml
+++ b/Defs/Morphs/Bear/Grizzly Bear/GrizzlyBear_Injector.xml
@@ -5,10 +5,8 @@
 		<description>A mutagenic injector filled with mechanites and grizzly bear DNA. Use with caution, as leaving the mechanites unchecked may transform the user.</description>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffRandom">
-					<hediffDefs>
-						<li>PawnmorphBearTF</li>
-					</hediffDefs>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>PawnmorphBearTF</hediffDef>
 					<severity>1.00</severity>
 				</li>
 			</outcomeDoers>

--- a/Defs/Morphs/Bear/Polar Bear/PolarBear_Injector.xml
+++ b/Defs/Morphs/Bear/Polar Bear/PolarBear_Injector.xml
@@ -5,10 +5,8 @@
 		<description>A mutagenic injector filled with mechanites and polar bear DNA. Use with caution, as leaving the mechanites unchecked may transform the user.</description>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffRandom">
-					<hediffDefs>
-						<li>PawnmorphPolarBearTF</li>
-					</hediffDefs>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>PawnmorphPolarBearTF</hediffDef>
 					<severity>1.00</severity>
 				</li>
 			</outcomeDoers>

--- a/Defs/Morphs/Boar/Boar_Injector.xml
+++ b/Defs/Morphs/Boar/Boar_Injector.xml
@@ -5,10 +5,8 @@
 		<description>A mutagenic injector filled with mechanites and boar DNA. Use with caution, as leaving the mechanites unchecked may transform the user.</description>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffRandom">
-					<hediffDefs>
-						<li>PawnmorphBoarTF</li>
-					</hediffDefs>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>PawnmorphBoarTF</hediffDef>
 					<severity>1.00</severity>
 				</li>
 			</outcomeDoers>

--- a/Defs/Morphs/Boomalope/Boomalope_Injector.xml
+++ b/Defs/Morphs/Boomalope/Boomalope_Injector.xml
@@ -5,10 +5,8 @@
 		<description>A mutagenic injector filled with mechanites and boomalope DNA. Use with caution, as leaving the mechanites unchecked may transform the user.</description>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffRandom">
-					<hediffDefs>
-						<li>PawnmorphBoomalopeTF</li>
-					</hediffDefs>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>PawnmorphBoomalopeTF</hediffDef>
 					<severity>1.00</severity>
 				</li>
 			</outcomeDoers>

--- a/Defs/Morphs/Cassowary/Cassowary_Injector.xml
+++ b/Defs/Morphs/Cassowary/Cassowary_Injector.xml
@@ -5,10 +5,8 @@
 		<description>A mutagenic injector filled with mechanites and cassowary DNA. Use with caution, as leaving the mechanites unchecked may transform the user.</description>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffRandom">
-					<hediffDefs>
-						<li>PawnmorphCassowaryTF</li>
-					</hediffDefs>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>PawnmorphCassowaryTF</hediffDef>
 					<severity>1.00</severity>
 				</li>
 			</outcomeDoers>

--- a/Defs/Morphs/Cat/Cat_Injector.xml
+++ b/Defs/Morphs/Cat/Cat_Injector.xml
@@ -5,10 +5,8 @@
 		<description>A mutagenic injector filled with mechanites and cat DNA. Use with caution, as leaving the mechanites unchecked may transform the user.</description>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffRandom">
-					<hediffDefs>
-						<li>PawnmorphCatTF</li>
-					</hediffDefs>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>PawnmorphCatTF</hediffDef>
 					<severity>1.00</severity>
 				</li>
 			</outcomeDoers>

--- a/Defs/Morphs/Chicken/Chicken_Injector.xml
+++ b/Defs/Morphs/Chicken/Chicken_Injector.xml
@@ -5,10 +5,8 @@
 		<description>A mutagenic injector filled with mechanites and chicken DNA. Use with caution, as leaving the mechanites unchecked may transform the user.</description>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffRandom">
-					<hediffDefs>
-						<li>PawnmorphChickenTF</li>
-					</hediffDefs>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>PawnmorphChickenTF</hediffDef>
 					<severity>1.00</severity>
 				</li>
 			</outcomeDoers>

--- a/Defs/Morphs/Cougar/Cougar_Injector.xml
+++ b/Defs/Morphs/Cougar/Cougar_Injector.xml
@@ -5,10 +5,8 @@
 		<description>A mutagenic injector filled with mechanites and cougar DNA. Use with caution, as leaving the mechanites unchecked may transform the user.</description>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffRandom">
-					<hediffDefs>
-						<li>PawnmorphCougarTF</li>
-					</hediffDefs>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>PawnmorphCougarTF</hediffDef>
 					<severity>1.00</severity>
 				</li>
 			</outcomeDoers>

--- a/Defs/Morphs/Cow/Cow_Injector.xml
+++ b/Defs/Morphs/Cow/Cow_Injector.xml
@@ -5,10 +5,8 @@
 		<description>A mutagenic injector filled with mechanites and cow DNA. Use with caution, as leaving the mechanites unchecked may transform the user.</description>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffRandom">
-					<hediffDefs>
-						<li>PawnmorphCowTF</li>
-					</hediffDefs>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>PawnmorphCowTF</hediffDef>
 					<severity>1.00</severity>
 				</li>
 			</outcomeDoers>

--- a/Defs/Morphs/Deer/Deer_Injector.xml
+++ b/Defs/Morphs/Deer/Deer_Injector.xml
@@ -5,10 +5,8 @@
 		<description>A mutagenic injector filled with mechanites and deer DNA. Use with caution, as leaving the mechanites unchecked may transform the user.</description>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffRandom">
-					<hediffDefs>
-						<li>PawnmorphDeerTF</li>
-					</hediffDefs>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>PawnmorphDeerTF</hediffDef>
 					<severity>1.00</severity>
 				</li>
 			</outcomeDoers>

--- a/Defs/Morphs/Donkey/Donkey_Injector.xml
+++ b/Defs/Morphs/Donkey/Donkey_Injector.xml
@@ -5,10 +5,8 @@
 		<description>A mutagenic injector filled with mechanites and donkey DNA. Use with caution, as leaving the mechanites unchecked may transform the user.</description>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffRandom">
-					<hediffDefs>
-						<li>PawnmorphDonkeyTF</li>
-					</hediffDefs>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>PawnmorphDonkeyTF</hediffDef>
 					<severity>1.00</severity>
 				</li>
 			</outcomeDoers>

--- a/Defs/Morphs/Duck/Duck_Injector.xml
+++ b/Defs/Morphs/Duck/Duck_Injector.xml
@@ -5,10 +5,8 @@
 		<description>A mutagenic injector filled with mechanites and duck DNA. Use with caution, as leaving the mechanites unchecked may transform the user.</description>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffRandom">
-					<hediffDefs>
-						<li>PawnmorphDuckTF</li>
-					</hediffDefs>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>PawnmorphDuckTF</hediffDef>
 					<severity>1.00</severity>
 				</li>
 			</outcomeDoers>

--- a/Defs/Morphs/Elephant/Elephant_Injector.xml
+++ b/Defs/Morphs/Elephant/Elephant_Injector.xml
@@ -5,10 +5,8 @@
 		<description>A mutagenic injector filled with mechanites and elephant DNA. Use with caution, as leaving the mechanites unchecked may transform the user.</description>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffRandom">
-					<hediffDefs>
-						<li>PawnmorphElephantTF</li>
-					</hediffDefs>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>PawnmorphElephantTF</hediffDef>
 					<severity>1.00</severity>
 				</li>
 			</outcomeDoers>

--- a/Defs/Morphs/Emu/Emu_Injector.xml
+++ b/Defs/Morphs/Emu/Emu_Injector.xml
@@ -5,10 +5,8 @@
 		<description>A mutagenic injector filled with mechanites and emu DNA. Use with caution, as leaving the mechanites unchecked may transform the user.</description>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffRandom">
-					<hediffDefs>
-						<li>PawnmorphEmuTF</li>
-					</hediffDefs>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>PawnmorphEmuTF</hediffDef>
 					<severity>1.00</severity>
 				</li>
 			</outcomeDoers>

--- a/Defs/Morphs/Fox/Arctic Fox/ArcticFox_Injector.xml
+++ b/Defs/Morphs/Fox/Arctic Fox/ArcticFox_Injector.xml
@@ -5,10 +5,8 @@
 		<description>A mutagenic injector filled with mechanites and arctic fox DNA. Use with caution, as leaving the mechanites unchecked may transform the user.</description>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffRandom">
-					<hediffDefs>
-						<li>PawnmorphArcticFoxTF</li>
-					</hediffDefs>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>PawnmorphArcticFoxTF</hediffDef>
 					<severity>1.00</severity>
 				</li>
 			</outcomeDoers>

--- a/Defs/Morphs/Fox/Fennec Fox/FennecFox_Injector.xml
+++ b/Defs/Morphs/Fox/Fennec Fox/FennecFox_Injector.xml
@@ -5,10 +5,8 @@
 		<description>A mutagenic injector filled with mechanites and fennec fox DNA. Use with caution, as leaving the mechanites unchecked may transform the user.</description>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffRandom">
-					<hediffDefs>
-						<li>PawnmorphFennecFoxTF</li>
-					</hediffDefs>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>PawnmorphFennecFoxTF</hediffDef>
 					<severity>1.00</severity>
 				</li>
 			</outcomeDoers>

--- a/Defs/Morphs/Fox/Red Fox/RedFox_Injector.xml
+++ b/Defs/Morphs/Fox/Red Fox/RedFox_Injector.xml
@@ -5,10 +5,8 @@
 		<description>A mutagenic injector filled with mechanites and red fox DNA. Use with caution, as leaving the mechanites unchecked may transform the user.</description>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffRandom">
-					<hediffDefs>
-						<li>PawnmorphFoxTF</li>
-					</hediffDefs>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>PawnmorphFoxTF</hediffDef>
 					<severity>1.00</severity>
 				</li>
 			</outcomeDoers>

--- a/Defs/Morphs/Goat/Goat_Injector.xml
+++ b/Defs/Morphs/Goat/Goat_Injector.xml
@@ -5,10 +5,8 @@
 		<description>A mutagenic injector filled with mechanites and goat DNA. Use with caution, as leaving the mechanites unchecked may transform the user.</description>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffRandom">
-					<hediffDefs>
-						<li>PawnmorphGoatTF</li>
-					</hediffDefs>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>PawnmorphGoatTF</hediffDef>
 					<severity>1.00</severity>
 				</li>
 			</outcomeDoers>

--- a/Defs/Morphs/Goose/Goose_Injector.xml
+++ b/Defs/Morphs/Goose/Goose_Injector.xml
@@ -5,10 +5,8 @@
 		<description>A mutagenic injector filled with mechanites and goose DNA. Use with caution, as leaving the mechanites unchecked may transform the user.</description>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffRandom">
-					<hediffDefs>
-						<li>PawnmorphGooseTF</li>
-					</hediffDefs>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>PawnmorphGooseTF</hediffDef>
 					<severity>1.00</severity>
 				</li>
 			</outcomeDoers>

--- a/Defs/Morphs/Hare/Hare/Hare_Injector.xml
+++ b/Defs/Morphs/Hare/Hare/Hare_Injector.xml
@@ -5,10 +5,8 @@
 		<description>A mutagenic injector filled with mechanites and hare DNA. Use with caution, as leaving the mechanites unchecked may transform the user.</description>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffRandom">
-					<hediffDefs>
-						<li>PawnmorphHareTF</li>
-					</hediffDefs>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>PawnmorphHareTF</hediffDef>
 					<severity>1.00</severity>
 				</li>
 			</outcomeDoers>

--- a/Defs/Morphs/Hare/Snowhare/Snowhare_Injector.xml
+++ b/Defs/Morphs/Hare/Snowhare/Snowhare_Injector.xml
@@ -5,10 +5,8 @@
 		<description>A mutagenic injector filled with mechanites and snowhare DNA. Use with caution, as leaving the mechanites unchecked may transform the user.</description>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffRandom">
-					<hediffDefs>
-						<li>PawnmorphSnowhareTF</li>
-					</hediffDefs>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>PawnmorphSnowhareTF</hediffDef>
 					<severity>1.00</severity>
 				</li>
 			</outcomeDoers>

--- a/Defs/Morphs/Horse/Horse_Injector.xml
+++ b/Defs/Morphs/Horse/Horse_Injector.xml
@@ -5,10 +5,8 @@
 		<description>A mutagenic injector filled with mechanites and horse DNA. Use with caution, as leaving the mechanites unchecked may transform the user.</description>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffRandom">
-					<hediffDefs>
-						<li>PawnmorphHorseTF</li>
-					</hediffDefs>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>PawnmorphHorseTF</hediffDef>
 					<severity>1.00</severity>
 				</li>
 			</outcomeDoers>

--- a/Defs/Morphs/Husky/Husky_Injector.xml
+++ b/Defs/Morphs/Husky/Husky_Injector.xml
@@ -5,10 +5,8 @@
 		<description>A mutagenic injector filled with mechanites and husky DNA. Use with caution, as leaving the mechanites unchecked may transform the user.</description>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffRandom">
-					<hediffDefs>
-						<li>PawnmorphHuskyTF</li>
-					</hediffDefs>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>PawnmorphHuskyTF</hediffDef>
 					<severity>1.00</severity>
 				</li>
 			</outcomeDoers>

--- a/Defs/Morphs/Iguana/Iguana_Injector.xml
+++ b/Defs/Morphs/Iguana/Iguana_Injector.xml
@@ -5,10 +5,8 @@
 		<description>A mutagenic injector filled with mechanites and iguana DNA. Use with caution, as leaving the mechanites unchecked may transform the user.</description>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffRandom">
-					<hediffDefs>
-						<li>PawnmorphIguanaTF</li>
-					</hediffDefs>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>PawnmorphIguanaTF</hediffDef>
 					<severity>1.00</severity>
 				</li>
 			</outcomeDoers>

--- a/Defs/Morphs/LabradorRetriever/LabradorRetriever_Injector.xml
+++ b/Defs/Morphs/LabradorRetriever/LabradorRetriever_Injector.xml
@@ -5,10 +5,8 @@
 		<description>A mutagenic injector filled with mechanites and labrador retriever DNA. Use with caution, as leaving the mechanites unchecked may transform the user.</description>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffRandom">
-					<hediffDefs>
-						<li>PawnmorphLabradorRetrieverTF</li>
-					</hediffDefs>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>PawnmorphLabradorRetrieverTF</hediffDef>
 					<severity>1.00</severity>
 				</li>
 			</outcomeDoers>

--- a/Defs/Morphs/Lynx/Lynx_Injector.xml
+++ b/Defs/Morphs/Lynx/Lynx_Injector.xml
@@ -5,10 +5,8 @@
 		<description>A mutagenic injector filled with mechanites and lynx DNA. Use with caution, as leaving the mechanites unchecked may transform the user.</description>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffRandom">
-					<hediffDefs>
-						<li>PawnmorphLynxTF</li>
-					</hediffDefs>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>PawnmorphLynxTF</hediffDef>
 					<severity>1.00</severity>
 				</li>
 			</outcomeDoers>

--- a/Defs/Morphs/Megasloth/Megasloth_Injector.xml
+++ b/Defs/Morphs/Megasloth/Megasloth_Injector.xml
@@ -5,10 +5,8 @@
 		<description>A mutagenic injector filled with mechanites and megasloth DNA. Use with caution, as leaving the mechanites unchecked may transform the user.</description>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffRandom">
-					<hediffDefs>
-						<li>PawnmorphMegaslothTF</li>
-					</hediffDefs>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>PawnmorphMegaslothTF</hediffDef>
 					<severity>1.00</severity>
 				</li>
 			</outcomeDoers>

--- a/Defs/Morphs/Monkey/Monkey_Injector.xml
+++ b/Defs/Morphs/Monkey/Monkey_Injector.xml
@@ -5,10 +5,8 @@
 		<description>A mutagenic injector filled with mechanites and monkey DNA. Use with caution, as leaving the mechanites unchecked may transform the user.</description>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffRandom">
-					<hediffDefs>
-						<li>PawnmorphMonkeyTF</li>
-					</hediffDefs>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>PawnmorphMonkeyTF</hediffDef>
 					<severity>1.00</severity>
 				</li>
 			</outcomeDoers>

--- a/Defs/Morphs/Ostrich/Ostrich_Injector.xml
+++ b/Defs/Morphs/Ostrich/Ostrich_Injector.xml
@@ -5,10 +5,8 @@
 		<description>A mutagenic injector filled with mechanites and Ostrich DNA. Use with caution, as leaving the mechanites unchecked may transform the user.</description>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffRandom">
-					<hediffDefs>
-						<li>PawnmorphOstrichTF</li>
-					</hediffDefs>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>PawnmorphOstrichTF</hediffDef>
 					<severity>1.00</severity>
 				</li>
 			</outcomeDoers>

--- a/Defs/Morphs/Panther/Panther_Injector.xml
+++ b/Defs/Morphs/Panther/Panther_Injector.xml
@@ -5,10 +5,8 @@
 		<description>A mutagenic injector filled with mechanites and panther DNA. Use with caution, as leaving the mechanites unchecked may transform the user.</description>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffRandom">
-					<hediffDefs>
-						<li>PawnmorphPantherTF</li>
-					</hediffDefs>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>PawnmorphPantherTF</hediffDef>
 					<severity>1.00</severity>
 				</li>
 			</outcomeDoers>

--- a/Defs/Morphs/Pig/Pig_Injector.xml
+++ b/Defs/Morphs/Pig/Pig_Injector.xml
@@ -5,10 +5,8 @@
 		<description>A mutagenic injector filled with mechanites and pig DNA. Use with caution, as leaving the mechanites unchecked may transform the user.</description>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffRandom">
-					<hediffDefs>
-						<li>PawnmorphPigTF</li>
-					</hediffDefs>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>PawnmorphPigTF</hediffDef>
 					<severity>1.00</severity>
 				</li>
 			</outcomeDoers>

--- a/Defs/Morphs/Raccoon/Raccoon_Injector.xml
+++ b/Defs/Morphs/Raccoon/Raccoon_Injector.xml
@@ -5,10 +5,8 @@
 		<description>A mutagenic injector filled with mechanites and raccoon DNA. Use with caution, as leaving the mechanites unchecked may transform the user.</description>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffRandom">
-					<hediffDefs>
-						<li>PawnmorphRaccoonTF</li>
-					</hediffDefs>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>PawnmorphRaccoonTF</hediffDef>
 					<severity>1.00</severity>
 				</li>
 			</outcomeDoers>

--- a/Defs/Morphs/Rat/Rat_Injector.xml
+++ b/Defs/Morphs/Rat/Rat_Injector.xml
@@ -5,10 +5,8 @@
 		<description>A mutagenic injector filled with mechanites and rat DNA. Use with caution, as leaving the mechanites unchecked may transform the user.</description>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffRandom">
-					<hediffDefs>
-						<li>PawnmorphRatTF</li>
-					</hediffDefs>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>PawnmorphRatTF</hediffDef>
 					<severity>1.00</severity>
 				</li>
 			</outcomeDoers>

--- a/Defs/Morphs/Rhinoceros/Rhinoceros_Injector.xml
+++ b/Defs/Morphs/Rhinoceros/Rhinoceros_Injector.xml
@@ -5,10 +5,8 @@
 		<description>A mutagenic injector filled with mechanites and rhinoceros DNA. Use with caution, as leaving the mechanites unchecked may transform the user.</description>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffRandom">
-					<hediffDefs>
-						<li>PawnmorphRhinocerosTF</li>
-					</hediffDefs>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>PawnmorphRhinocerosTF</hediffDef>
 					<severity>1.00</severity>
 				</li>
 			</outcomeDoers>

--- a/Defs/Morphs/Sheep/Sheep_Injector.xml
+++ b/Defs/Morphs/Sheep/Sheep_Injector.xml
@@ -5,10 +5,8 @@
 		<description>A mutagenic injector filled with mechanites and sheep DNA. Use with caution, as leaving the mechanites unchecked may transform the user.</description>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffRandom">
-					<hediffDefs>
-						<li>PawnmorphSheepTF</li>
-					</hediffDefs>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>PawnmorphSheepTF</hediffDef>
 					<severity>1.00</severity>
 				</li>
 			</outcomeDoers>

--- a/Defs/Morphs/Squirrel/Squirrel_Injector.xml
+++ b/Defs/Morphs/Squirrel/Squirrel_Injector.xml
@@ -5,10 +5,8 @@
 		<description>A mutagenic injector filled with mechanites and squirrel DNA. Use with caution, as leaving the mechanites unchecked may transform the user.</description>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffRandom">
-					<hediffDefs>
-						<li>PawnmorphSquirrelTF</li>
-					</hediffDefs>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>PawnmorphSquirrelTF</hediffDef>
 					<severity>1.00</severity>
 				</li>
 			</outcomeDoers>

--- a/Defs/Morphs/Thrumbo/Thrumbo_Injector.xml
+++ b/Defs/Morphs/Thrumbo/Thrumbo_Injector.xml
@@ -5,10 +5,8 @@
 		<description>A mutagenic injector filled with mechanites and thrumbo DNA. Use with caution, as leaving the mechanites unchecked may transform the user.</description>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffRandom">
-					<hediffDefs>
-						<li>PawnmorphThrumboTF</li>
-					</hediffDefs>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>PawnmorphThrumboTF</hediffDef>
 					<severity>1.00</severity>
 				</li>
 			</outcomeDoers>

--- a/Defs/Morphs/Tortoise/Tortoise_Injector.xml
+++ b/Defs/Morphs/Tortoise/Tortoise_Injector.xml
@@ -5,10 +5,8 @@
 		<description>A mutagenic injector filled with mechanites and tortoise DNA. Use with caution, as leaving the mechanites unchecked may transform the user.</description>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffRandom">
-					<hediffDefs>
-						<li>PawnmorphTortoiseTF</li>
-					</hediffDefs>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>PawnmorphTortoiseTF</hediffDef>
 					<severity>1.00</severity>
 				</li>
 			</outcomeDoers>

--- a/Defs/Morphs/Turkey/Turkey_Injector.xml
+++ b/Defs/Morphs/Turkey/Turkey_Injector.xml
@@ -5,10 +5,8 @@
 		<description>A mutagenic injector filled with mechanites and turkey DNA. Use with caution, as leaving the mechanites unchecked may transform the user.</description>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffRandom">
-					<hediffDefs>
-						<li>PawnmorphTurkeyTF</li>
-					</hediffDefs>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>PawnmorphTurkeyTF</hediffDef>
 					<severity>1.00</severity>
 				</li>
 			</outcomeDoers>

--- a/Defs/Morphs/Warg/Warg_Injector.xml
+++ b/Defs/Morphs/Warg/Warg_Injector.xml
@@ -5,10 +5,8 @@
 		<description>A mutagenic injector filled with mechanites and warg DNA. Use with caution, as leaving the mechanites unchecked may transform the user.</description>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffRandom">
-					<hediffDefs>
-						<li>PawnmorphWargTF</li>
-					</hediffDefs>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>PawnmorphWargTF</hediffDef>
 					<severity>1.00</severity>
 				</li>
 			</outcomeDoers>

--- a/Defs/Morphs/Wolf/Arctic Wolf/ArcticWolf_Injector.xml
+++ b/Defs/Morphs/Wolf/Arctic Wolf/ArcticWolf_Injector.xml
@@ -5,10 +5,8 @@
 		<description>A mutagenic injector filled with mechanites and arctic wolf DNA. Use with caution, as leaving the mechanites unchecked may transform the user.</description>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffRandom">
-					<hediffDefs>
-						<li>PawnmorphArcticWolfTF</li>
-					</hediffDefs>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>PawnmorphArcticWolfTF</hediffDef>
 					<severity>1.00</severity>
 				</li>
 			</outcomeDoers>

--- a/Defs/Morphs/Wolf/Timber Wolf/TimberWolf_Injector.xml
+++ b/Defs/Morphs/Wolf/Timber Wolf/TimberWolf_Injector.xml
@@ -5,10 +5,8 @@
 		<description>A mutagenic injector filled with mechanites and timber wolf DNA. Use with caution, as leaving the mechanites unchecked may transform the user.</description>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffRandom">
-					<hediffDefs>
-						<li>PawnmorphWolfTF</li>
-					</hediffDefs>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>PawnmorphWolfTF</hediffDef>
 					<severity>1.00</severity>
 				</li>
 			</outcomeDoers>


### PR DESCRIPTION
`IngestionOutcomeDoer_GiveHediffRandom` has built-in code to apply partial or full transformations based on a setting.  With species-specific injectors, the "full transformation" list was undefined, and so if the random chance applied (based on the "chance for eggs & milk to apply full transformation" setting), no hediff was added.  As a result, injectors would fail to work 5% of the time for no obvious reason with the default settings.

This changes the injectors to use the vanilla IngestionOutcomeDoer_GiveHediff that always gives the desired hediff.