### PR TITLE
Ascetic bedroom thoughts

### DIFF
--- a/1.3/Defs/Groups_Herd.xml
+++ b/1.3/Defs/Groups_Herd.xml
@@ -13,19 +13,19 @@
         <stages>
             <li>
                 <modifier>alone</modifier>
-				<description>I'm the only one of my kind, I feel unsafe being all alone.</description>
+				<description>I'm the only one of my kind. I feel so unsafe being all alone.</description>
             </li>
             <li>
                 <modifier>lonely</modifier>
-				<description>There's another like me, but we're still only a small herd.</description>
+				<description>There's another like me, but we're still only a small herd. I still don't feel very safe.</description>
             </li>
             <li>
                 <modifier>comfortable</modifier>
-				<description>There's lots of my kind, safety in numbers.</description>
+				<description>There's a decent number of people in my herd. Safety in numbers!</description>
             </li>
             <li>
                 <modifier>happy</modifier>
-				<description>There's plenty of people in my herd, there's nothing to fear!</description>
+				<description>There's plenty of people in my herd. There's nothing to fear!</description>
             </li>
         </stages>
     </Pawnmorph.AspectDef>
@@ -34,23 +34,23 @@
 		<defName>HerdMinded</defName>
 		<stages>
 			<li>
-				<label>alone</label> 
-				<description>I'm the only one of my kind, I feel unsafe being all alone.</description>
+				<label>no herd</label>
+				<description>I'm the only one of my kind. I feel so unsafe being all alone.</description>
 				<baseMoodEffect>-2</baseMoodEffect>
 			</li>
 			<li>
-				<label>lonely</label>
-				<description>There's another like me, but we're still only a small herd.</description>
+				<label>small herd</label>
+				<description>There's another like me, but we're still only a small herd. I still don't feel very safe.</description>
 				<baseMoodEffect>-1</baseMoodEffect>
 			</li>
 			<li>
-				<label>comfortable</label>
-				<description>There's lots of my kind, safety in numbers.</description>
+				<label>decent herd</label>
+				<description>There's a decent number of people in my herd. Safety in numbers!</description>
 				<baseMoodEffect>1</baseMoodEffect>
 			</li>
 			<li>
-				<label>happy</label>
-				<description>There's plenty of people in my herd, there's nothing to fear!</description>
+				<label>huge herd</label>
+				<description>There's plenty of people in my herd. There's nothing to fear!</description>
 				<baseMoodEffect>5</baseMoodEffect>
 			</li>
 		</stages>

--- a/1.3/Defs/Groups_Herd.xml
+++ b/1.3/Defs/Groups_Herd.xml
@@ -5,6 +5,7 @@
 		<aspectDef>HerdMind</aspectDef>
 		<barrakThoughtReplacement>PM_HerdMindedBarrack</barrakThoughtReplacement>
 		<bedroomThoughtReplacement>PM_HerdMindedBedroom</bedroomThoughtReplacement>
+		<asceticRoomThought>PM_HerdMindedAscetic</asceticRoomThought>
 	</Pawnmorph.MorphGroupDef>
 	
     <Pawnmorph.AspectDef ParentName="MorphGroupAspectBase">

--- a/1.3/Defs/Groups_Pack.xml
+++ b/1.3/Defs/Groups_Pack.xml
@@ -5,6 +5,7 @@
 		<aspectDef>CanidMind</aspectDef>
 		<barrakThoughtReplacement>PM_PackMindedBarrack</barrakThoughtReplacement>
 		<bedroomThoughtReplacement>PM_PackMindedBedroom</bedroomThoughtReplacement>
+		<asceticRoomThought>PM_PackMindedAscetic</asceticRoomThought>
 	</Pawnmorph.MorphGroupDef>
 	
     <Pawnmorph.AspectDef ParentName="MorphGroupAspectBase">

--- a/1.3/Defs/Groups_Pack.xml
+++ b/1.3/Defs/Groups_Pack.xml
@@ -13,19 +13,19 @@
         <stages>
             <li>
                 <modifier>alone</modifier>
-				<description>I'm the only one of my kind, I wish I had a proper pack.</description>
+				<description>I'm the only one of my kind. I feel so alone without a proper pack.</description>
             </li>
             <li>
                 <modifier>lonely</modifier>
-				<description>There's another like me, but we're still only a small pack.</description>
+				<description>There's another like me, but we're still only a small pack. It's a bit lonely.</description>
             </li>
             <li>
                 <modifier>comfortable</modifier>
-				<description>There's lots of my kind, strength in numbers.</description>
+				<description>There's a decent number people in my pack. I'm glad to have them.</description>
             </li>
             <li>
                 <modifier>happy</modifier>
-				<description>There's plenty of people in my pack, this is great!</description>
+				<description>There's plenty of people in my pack. This is great!</description>
             </li>
         </stages>
     </Pawnmorph.AspectDef>
@@ -34,23 +34,23 @@
 		<defName>PackMinded</defName>
 		<stages>
 			<li>
-				<label>alone</label> 
-				<description>I'm the only one of my kind, I wish I had a proper pack.</description>
+				<label>no pack</label>
+				<description>I'm the only one of my kind. I feel so alone without a proper pack.</description>
 				<baseMoodEffect>-2</baseMoodEffect>
 			</li>
 			<li>
-				<label>lonely</label>
-				<description>There's another like me, but we're still only a small pack.</description>
+				<label>small pack</label>
+				<description>There's another like me, but we're still only a small pack. It's a bit lonely.</description>
 				<baseMoodEffect>-1</baseMoodEffect>
 			</li>
 			<li>
-				<label>comfortable</label>
-				<description>There's lots of my kind, strength in numbers.</description>
+				<label>decent pack</label>
+				<description>There's a decent number people in my pack. I'm glad to have them.</description>
 				<baseMoodEffect>1</baseMoodEffect>
 			</li>
 			<li>
-				<label>happy</label>
-				<description>There's plenty of people in my pack, this is great!</description>
+				<label>huge pack</label>
+				<description>There's plenty of people in my pack. This is great!</description>
 				<baseMoodEffect>5</baseMoodEffect>
 			</li>
 		</stages>

--- a/Defs/Thoughts/GroupThoughts/HerdThoughts.xml
+++ b/Defs/Thoughts/GroupThoughts/HerdThoughts.xml
@@ -47,14 +47,14 @@
             <li>
                 <label>mediocre bedroom</label>
                 <description>I had to sleep in a room all by myself, away from the safety of the herd.</description>
-                <baseMoodEffect>-3</baseMoodEffect>
+                <baseMoodEffect>-4</baseMoodEffect>
 
             </li>
             <!-- mediocre -->
             <li>
                 <label>decent bedroom</label>
                 <description>I had to sleep in a room all by myself, away from the safety of the herd.</description>
-                <baseMoodEffect>-4</baseMoodEffect>
+                <baseMoodEffect>-3</baseMoodEffect>
             </li>
             <li>
                 <label>slightly impressive bedroom</label>

--- a/Defs/Thoughts/GroupThoughts/HerdThoughts.xml
+++ b/Defs/Thoughts/GroupThoughts/HerdThoughts.xml
@@ -146,5 +146,21 @@
             </li>
         </stages>
     </ThoughtDef>
-
+    
+    <ThoughtDef ParentName="SleptThoughtBase">
+        <defName>PM_HerdMindedAscetic</defName>
+        
+        <stages>
+            <li>
+                <label>ascetic slept alone</label>
+                <description>I had to sleep in a room by myself, away from the safety of my herd.</description>
+                <baseMoodEffect>-4</baseMoodEffect>
+            </li>
+            <li>
+                <label>ascetic slept with herd</label>
+                <description>I was able to share a barrack with my herd. It felt safe and comfy.</description>
+                <baseMoodEffect>4</baseMoodEffect>
+            </li>
+        </stages>
+    </ThoughtDef>
 </Defs>

--- a/Defs/Thoughts/GroupThoughts/HerdThoughts.xml
+++ b/Defs/Thoughts/GroupThoughts/HerdThoughts.xml
@@ -7,24 +7,24 @@
         <stages>
             <!-- should have the same number of stages as the aspect -->
             <li>
-                <label>alone</label>
-                <description>I'm the only one of my kind, I feel unsafe being all alone.</description>
+                <label>no herd</label>
+                <description>I'm the only one of my kind. I feel so unsafe being all alone.</description>
                 <baseMoodEffect>-2</baseMoodEffect>
             </li>
             <li>
-                <label>lonely</label>
-                <description>There's another like me, but we're still only a small herd.</description>
+                <label>small herd</label>
+                <description>There's another like me, but we're still only a small herd. I still don't feel very safe.</description>
                 <baseMoodEffect>-1</baseMoodEffect>
             </li>
             <li>
-                <label>comfortable</label>
-                <description>There's lots of my kind, safety in numbers.</description>
+                <label>decent herd</label>
+                <description>There's a decent number of people in my herd. Safety in numbers!</description>
                 <visible>true</visible>
                 <baseMoodEffect>1</baseMoodEffect>
             </li>
             <li>
-                <label>happy</label>
-                <description>There's plenty of people in my herd, there's nothing to fear!</description>
+                <label>huge herd</label>
+                <description>There's plenty of people in my herd. There's nothing to fear!</description>
                 <baseMoodEffect>5</baseMoodEffect>
             </li>
         </stages>
@@ -35,35 +35,35 @@
         <stages>
             <li>
                 <label>awful bedroom</label>
-                <description>I had to sleep in an awful room all by myself.</description>
+                <description>I had to sleep alone in an awful room, without even my herd to keep me safe.</description>
                 <baseMoodEffect>-7</baseMoodEffect>
             </li>
             <li>
                 <label>dull bedroom</label>
-                <description>I had to sleep in an dull room all by myself.</description>
+                <description>I had to sleep alone in an dull room, without even my herd to keep me safe.</description>
                 <baseMoodEffect>-5</baseMoodEffect>
             </li>
             <!-- dull -->
             <li>
                 <label>mediocre bedroom</label>
-                <description>I had to sleep in a room all by myself.</description>
+                <description>I had to sleep in a room all by myself, away from the safety of the herd.</description>
                 <baseMoodEffect>-3</baseMoodEffect>
 
             </li>
             <!-- mediocre -->
             <li>
                 <label>decent bedroom</label>
-                <description>I had to sleep on my own.</description>
+                <description>I had to sleep in a room all by myself, away from the safety of the herd.</description>
                 <baseMoodEffect>-4</baseMoodEffect>
             </li>
             <li>
                 <label>slightly impressive bedroom</label>
-                <description>I had to sleep on my own in a slightly impressive bedroom. It was alright.</description>
+                <description>I had to sleep on my own in a slightly impressive bedroom. It was alright, but I felt unsafe without the rest of my herd.</description>
                 <baseMoodEffect>-1</baseMoodEffect>
             </li>
             <li>
                 <label>impressive bedroom</label>
-                <description>I slept on my own in an impressive bedroom. It was ok.</description>
+                <description>I slept on my own in an impressive bedroom. It was fine, but I would have felt safer with the rest of my herd.</description>
                 <baseMoodEffect>1</baseMoodEffect>
             </li>
             <li>
@@ -73,17 +73,17 @@
             </li>
             <li>
                 <label>extremely impressive bedroom</label>
-                <description>I slept in an extremely impressive bedroom. It's great, but I wish there were others here.</description>
+                <description>I slept in an extremely impressive bedroom. It's great, but I wish my herdmates were there.</description>
                 <baseMoodEffect>3</baseMoodEffect>
             </li>
             <li>
                 <label>unbelievably impressive bedroom</label>
-                <description>I slept in an unbelievably impressive bedroom. It was marvelous, but I felt something was missing.</description>
+                <description>I slept in an unbelievably impressive bedroom. It was marvelous, but I felt like something was missing without my herd.</description>
                 <baseMoodEffect>4</baseMoodEffect>
             </li>
             <li>
                 <label>wondrously impressive bedroom</label>
-                <description>I slept in a heavenly bedroom. It was astounding, but it would have been better to share it with the herd.</description>
+                <description>I slept in a heavenly bedroom. It was so astounding, I didn't even mind sleeping away from the rest of the herd.</description>
                 <baseMoodEffect>5</baseMoodEffect>
             </li>
         </stages>
@@ -95,53 +95,53 @@
         <stages>
             <li>
                 <label>awful barrack</label>
-                <description>We had to sleep in an awful barrack, but the herd was there.</description>
+                <description>The herd had to sleep in an awful barrack, but at least we had safety in numbers.</description>
                 <baseMoodEffect>-4</baseMoodEffect>
             </li>
             <li>
                 <label>dull barrack</label>
-                <description>We had to sleep in a dull barrack. but the rest of the herd was there.</description>
+                <description>The herd had to sleep in a dull barrack, but at least we had safety in numbers.</description>
                 <baseMoodEffect>-2</baseMoodEffect>
             </li>
             <li>
                 <label>mediocre barrack</label>
-                <description>We slept in a mediocre barrack with my herd. Okay, I guess.</description>
+                <description>I slept together with the herd in a mediocre barrack. It's safer than sleeping alone, at least.</description>
                 <baseMoodEffect>0</baseMoodEffect>
                 <visible>true</visible>
             </li>
             <li>
                 <label>decent barrack</label>
-                <description>We slept in a decent barrack with my herd. This feels nice.</description>
+                <description>I slept together together with the herd in a decent barrack. It was safe and comforting.</description>
                 <baseMoodEffect>2</baseMoodEffect>
             </li>
             <li>
                 <label>slightly impressive barrack</label>
-                <description>We got to sleep in a pretty nice barrack with the herd.</description>
+                <description>I slept in a pretty nice barrack with the rest of my herd. This is great.</description>
                 <baseMoodEffect>3</baseMoodEffect>
             </li>
             <li>
                 <label>impressive barrack</label>
-                <description>We got to sleep in an impressive barrack. I even got to share it with the rest of the herd.</description>
+                <description>I slept in an impressive barrack with the rest of my herd. I love it.</description>
                 <baseMoodEffect>4</baseMoodEffect>
             </li>
             <li>
                 <label>very impressive barrack</label>
-                <description>We slept in a very impressive barrack with the herd. I love it.</description>
+                <description>I got to sleep in a very impressive barrack with my herd. It was wonderful.</description>
                 <baseMoodEffect>5</baseMoodEffect>
             </li>
             <li>
                 <label>extremely impressive barrack</label>
-                <description>We slept in an extremely impressive barrack with the herd. It was marvelous</description>
+                <description>I got to sleep in an extremely impressive barrack with my herd. It was truly marvelous.</description>
                 <baseMoodEffect>6</baseMoodEffect>
             </li>
             <li>
                 <label>unbelievably impressive barrack</label>
-                <description>The barrack we slept in was unbelievably impressive.</description>
+                <description>I got to sleep in a barrack that was unbelievably impressive, and I even got to share it with my herd.</description>
                 <baseMoodEffect>7</baseMoodEffect>
             </li>
             <li>
                 <label>wondrously impressive barrack</label>
-                <description>We slept in a barrack that was simply wondrous.</description>
+                <description>The herd got to share a barrack that was simply wondrous. I could just stay here with my herd forever.</description>
                 <baseMoodEffect>8</baseMoodEffect>
             </li>
         </stages>

--- a/Defs/Thoughts/GroupThoughts/PackThoughts.xml
+++ b/Defs/Thoughts/GroupThoughts/PackThoughts.xml
@@ -6,24 +6,24 @@
         <stages>
             <!-- should have the same number of stages as the aspect -->
             <li>
-                <label>alone</label>
-                <description>I'm the only one of my kind, I wish I had a proper pack.</description>
+                <label>no pack</label>
+                <description>I'm the only one of my kind. I feel so alone without a proper pack.</description>
                 <baseMoodEffect>-2</baseMoodEffect>
             </li>
             <li>
-                <label>lonely</label>
-                <description>There's another like me, but we're still only a small pack.</description>
+                <label>small pack</label>
+                <description>There's another like me, but we're still only a small pack. It's a bit lonely.</description>
                 <baseMoodEffect>-1</baseMoodEffect>
             </li>
             <li>
-                <label>comfortable</label>
-                <description>There's lots of my kind, strength in numbers.</description>
+                <label>decent pack</label>
+                <description>There's a decent number people in my pack. I'm glad to have them.</description>
                 <visible>true</visible>
                 <baseMoodEffect>1</baseMoodEffect>
             </li>
             <li>
-                <label>happy</label>
-                <description>There's plenty of people in my pack, this is great!</description>
+                <label>huge pack</label>
+                <description>There's plenty of people in my pack. This is great!</description>
                 <baseMoodEffect>5</baseMoodEffect>
             </li>
         </stages>
@@ -34,55 +34,55 @@
         <stages>
             <li>
                 <label>awful bedroom</label>
-                <description>I had to sleep in an awful room all by myself.</description>
+                <description>I had to sleep in an awful room, and I didn't even get to share it with my pack.</description>
                 <baseMoodEffect>-7</baseMoodEffect>
             </li>
             <li>
                 <label>dull bedroom</label>
-                <description>I had to sleep in an dull room all by myself.</description>
+                <description>I had to sleep in an dull room, and I didn't even get to share it with my pack.</description>
                 <baseMoodEffect>-5</baseMoodEffect>
             </li>
             <!-- dull -->
             <li>
                 <label>mediocre bedroom</label>
-                <description>I had to sleep in a room all by myself.</description>
+                <description>I had to sleep on my own, separated from my pack.</description>
                 <baseMoodEffect>-3</baseMoodEffect>
             
             </li>
             <!-- mediocre -->
             <li>
                 <label>decent bedroom</label>
-                <description>I had to sleep on my own</description>
+                <description>I had to sleep on my own, separated from my pack.</description>
                 <baseMoodEffect>-4</baseMoodEffect>
             </li>
             <li>
                 <label>slightly impressive bedroom</label>
-                <description>I had to sleep on my own in a slightly impressive bedroom. It was alright.</description>
+                <description>I had to sleep on my own in a slightly impressive bedroom. It was alright, but I miss my pack.</description>
                 <baseMoodEffect>-1</baseMoodEffect>
             </li>
             <li>
                 <label>impressive bedroom</label>
-                <description>I slept on my own in an impressive bedroom. It was ok.</description>
+                <description>I slept on my own in an impressive bedroom. It was fine, but I miss my pack.</description>
                 <baseMoodEffect>1</baseMoodEffect>
             </li>
             <li>
                 <label>very impressive bedroom</label>
-                <description>I slept in a very impressive bedroom on my own. It was nice but I miss my pack.</description>
+                <description>I slept in a very impressive bedroom on my own. It was nice, but it would have been better with the rest of the pack.</description>
                 <baseMoodEffect>2</baseMoodEffect>
             </li>
             <li>
                 <label>extremely impressive bedroom</label>
-                <description>I slept in an extremely impressive bedroom. It was great but I wish there were others here.</description>
+                <description>I slept in an extremely impressive bedroom. It was great, but I wish I could have shared it with my pack.</description>
                 <baseMoodEffect>3</baseMoodEffect>
             </li>
             <li>
                 <label>unbelievably impressive bedroom</label>
-                <description>I slept in an unbelievably impressive bedroom. It was marvelous but I felt something was missing</description>
+                <description>I slept in an unbelievably impressive bedroom. It was marvelous, but it just didn't feel complete without the rest of my pack.</description>
                 <baseMoodEffect>4</baseMoodEffect>
             </li>
             <li>
                 <label>wondrously impressive bedroom</label>
-                <description>I slept in a heavenly bedroom. It was astounding, but it would have been better to share it with the pack.</description>
+                <description>I slept in a heavenly bedroom. It was so astounding, I could almost forget I had to sleep away from the pack.</description>
                 <baseMoodEffect>5</baseMoodEffect>
             </li>
         </stages>
@@ -94,53 +94,53 @@
         <stages>
             <li>
                 <label>awful barrack</label>
-                <description>We had to sleep in an awful barrack, but the pack was there.</description>
+                <description>We had to sleep in an awful barrack, but at least the pack slept together.</description>
                 <baseMoodEffect>-4</baseMoodEffect>
             </li>
             <li>
                 <label>dull barrack</label>
-                <description>We had to sleep in a dull barrack. but the rest of the pack was there.</description>
+                <description>We had to sleep in a dull barrack, but at least the pack slept together.</description>
                 <baseMoodEffect>-2</baseMoodEffect>
             </li>
             <li>
                 <label>mediocre barrack</label>
-                <description>We slept in a mediocre barrack with my pack. Okay, I guess.</description>
+                <description>The pack slept together in a mediocre barrack. It beats sleeping alone.</description>
                 <baseMoodEffect>0</baseMoodEffect>
                 <visible>true</visible>
             </li>
             <li>
                 <label>decent barrack</label>
-                <description>We slept in a decent barrack with my pack. This feels nice.</description>
+                <description>The pack slept together in a decent barrack. This feels nice.</description>
                 <baseMoodEffect>2</baseMoodEffect>
             </li>
             <li>
                 <label>slightly impressive barrack</label>
-                <description>We got to sleep in a pretty nice barrack with the pack.</description>
+                <description>The pack slept together in a pretty nice barrack. This is great.</description>
                 <baseMoodEffect>3</baseMoodEffect>
             </li>
             <li>
                 <label>impressive barrack</label>
-                <description>We got to sleep in an impressive barrack. I even got to share it with the rest of the pack.</description>
+                <description>The pack slept together in an impressive barrack. We loved it.</description>
                 <baseMoodEffect>4</baseMoodEffect>
             </li>
             <li>
                 <label>very impressive barrack</label>
-                <description>We slept in a very impressive barrack with the pack. I love it.</description>
+                <description>The pack got to sleep together in a very impressive barrack. It was wonderful.</description>
                 <baseMoodEffect>5</baseMoodEffect>
             </li>
             <li>
                 <label>extremely impressive barrack</label>
-                <description>We slept in an extremely impressive barrack with the pack. It was marvelous</description>
+                <description>The pack got to sleep together in an extremely impressive barrack. It was truly marvelous.</description>
                 <baseMoodEffect>6</baseMoodEffect>
             </li>
             <li>
                 <label>unbelievably impressive barrack</label>
-                <description>The barrack we slept in was unbelievably impressive.</description>
+                <description>The pack got to share a barrack that was unbelievably impressive. There's nothing better than sleeping with my pack in a room like this.</description>
                 <baseMoodEffect>7</baseMoodEffect>
             </li>
             <li>
                 <label>wondrously impressive barrack</label>
-                <description>We slept in a barrack that was simply wondrous.</description>
+                <description>The pack got share a barrack that was simply wondrous. I could just stay here with my pack forever.</description>
                 <baseMoodEffect>8</baseMoodEffect>
             </li>
         </stages>

--- a/Defs/Thoughts/GroupThoughts/PackThoughts.xml
+++ b/Defs/Thoughts/GroupThoughts/PackThoughts.xml
@@ -145,5 +145,22 @@
             </li>
         </stages>
     </ThoughtDef>
+    
+    <ThoughtDef ParentName="SleptThoughtBase">
+        <defName>PM_PackMindedAscetic</defName>
+        
+        <stages>
+            <li>
+                <label>ascetic slept alone</label>
+                <description>I had to sleep in a room by myself, away from my pack.</description>
+                <baseMoodEffect>-4</baseMoodEffect>
+            </li>
+            <li>
+                <label>ascetic slept with pack</label>
+                <description>I was able to share a barrack with my pack. It was nice and cozy together.</description>
+                <baseMoodEffect>4</baseMoodEffect>
+            </li>
+        </stages>
+    </ThoughtDef>
 
 </Defs>

--- a/Defs/Thoughts/GroupThoughts/PackThoughts.xml
+++ b/Defs/Thoughts/GroupThoughts/PackThoughts.xml
@@ -57,7 +57,7 @@
             </li>
             <li>
                 <label>slightly impressive bedroom</label>
-                <description>I had to sleep on my own in a slightly impressive bedroom. It was alright, but I miss my pack.</description>
+                <description>I had to sleep on my own in a slightly impressive bedroom. It was alright, but I'd prefer to sleep with my pack.</description>
                 <baseMoodEffect>-1</baseMoodEffect>
             </li>
             <li>
@@ -140,7 +140,7 @@
             </li>
             <li>
                 <label>wondrously impressive barrack</label>
-                <description>The pack got share a barrack that was simply wondrous. I could just stay here with my pack forever.</description>
+                <description>The pack got to share a barrack that was simply wondrous. I could just stay here with my pack forever.</description>
                 <baseMoodEffect>8</baseMoodEffect>
             </li>
         </stages>

--- a/Defs/Thoughts/GroupThoughts/PackThoughts.xml
+++ b/Defs/Thoughts/GroupThoughts/PackThoughts.xml
@@ -46,14 +46,14 @@
             <li>
                 <label>mediocre bedroom</label>
                 <description>I had to sleep on my own, separated from my pack.</description>
-                <baseMoodEffect>-3</baseMoodEffect>
+                <baseMoodEffect>-4</baseMoodEffect>
             
             </li>
             <!-- mediocre -->
             <li>
                 <label>decent bedroom</label>
                 <description>I had to sleep on my own, separated from my pack.</description>
-                <baseMoodEffect>-4</baseMoodEffect>
+                <baseMoodEffect>-3</baseMoodEffect>
             </li>
             <li>
                 <label>slightly impressive bedroom</label>

--- a/Source/Pawnmorphs/Esoteria/HPatches/ToilsLayDownPatches.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/ToilsLayDownPatches.cs
@@ -27,28 +27,44 @@ namespace Pawnmorph.HPatches
 
             var group = actor.def.GetMorphOfRace()?.@group;
             if (group == null) return;
-            Building_Bed building_Bed = null; 
-            int? scoreStageIndex = null;
 
+            // Replace the vanilla bedroom thoughts with morph-specific thoughts
+            memories.RemoveMemoriesOfDef(ThoughtDefOf.SleptInBedroom);
+            memories.RemoveMemoriesOfDef(ThoughtDefOf.SleptInBarracks);
 
-            if (group.bedroomThoughtReplacement != null && memories.GetFirstMemoryOfDef(ThoughtDefOf.SleptInBedroom) != null)
+            // More or less duplicating the vanilla logic here.  It sucks, but some of the the bedroom levels don't leave memories (and ascetics never have bedroom thoughts)
+            // so we can't rely on there being an existing thought to tell us what to use.
+            Building_Bed building_Bed = actor.CurrentBed();
+            if (building_Bed != null && building_Bed == actor.ownership.OwnedBed && !building_Bed.ForPrisoners)
             {
-                building_Bed = actor.CurrentBed();
-                scoreStageIndex =
-                    RoomStatDefOf.Impressiveness.GetScoreStageIndex(building_Bed.GetRoom().GetStat(RoomStatDefOf.Impressiveness)); 
-                memories.RemoveMemoriesOfDef(ThoughtDefOf.SleptInBedroom);
-                var mem = ThoughtMaker.MakeThought(group.bedroomThoughtReplacement, scoreStageIndex.Value); 
-                memories.TryGainMemory(mem);
-            }
 
-            if (group.barrakThoughtReplacement != null && memories.GetFirstMemoryOfDef(ThoughtDefOf.SleptInBarracks) != null)
-            {
-                building_Bed = building_Bed ?? actor.CurrentBed(); //only do this if it wasn't done previously 
-                scoreStageIndex = scoreStageIndex ??
-                    RoomStatDefOf.Impressiveness.GetScoreStageIndex(building_Bed.GetRoom().GetStat(RoomStatDefOf.Impressiveness));
-                memories.RemoveMemoriesOfDef(ThoughtDefOf.SleptInBarracks);
-                var mem = ThoughtMaker.MakeThought(group.barrakThoughtReplacement, scoreStageIndex.Value);
-                memories.TryGainMemory(mem); 
+                RoomRoleDef roomRole = building_Bed.GetRoom(RegionType.Set_All).Role;
+
+                //Ascetics have a different thought that doesn't take room quality into account
+                if (actor.story.traits.HasTrait(TraitDefOf.Ascetic))
+                {
+                    if (roomRole == RoomRoleDefOf.Bedroom)
+                    {
+                        memories.TryGainMemory(ThoughtMaker.MakeThought(group.asceticRoomThought, 0));
+                    }
+                    else if (roomRole == RoomRoleDefOf.Barracks)
+                    {
+                        memories.TryGainMemory(ThoughtMaker.MakeThought(group.asceticRoomThought, 1));
+                    }
+                }
+                else
+                {
+                    int scoreStageIndex = RoomStatDefOf.Impressiveness.GetScoreStageIndex(building_Bed.GetRoom().GetStat(RoomStatDefOf.Impressiveness));
+                    if (roomRole == RoomRoleDefOf.Bedroom)
+                    {
+                        memories.TryGainMemory(ThoughtMaker.MakeThought(group.bedroomThoughtReplacement, scoreStageIndex));
+                    }
+                    else if (roomRole == RoomRoleDefOf.Barracks)
+                    {
+                        memories.TryGainMemory(ThoughtMaker.MakeThought(group.barrakThoughtReplacement, scoreStageIndex));
+                    }
+                }
+
             }
 
         }

--- a/Source/Pawnmorphs/Esoteria/MorphGroupDef.cs
+++ b/Source/Pawnmorphs/Esoteria/MorphGroupDef.cs
@@ -30,7 +30,12 @@ namespace Pawnmorph
         /// <summary>
         /// The bedroom thought replacement
         /// </summary>
-        [CanBeNull] public ThoughtDef bedroomThoughtReplacement; 
+        [CanBeNull] public ThoughtDef bedroomThoughtReplacement;
+        /// <summary>
+        /// The room thought for ascetics
+        /// </summary>
+        [CanBeNull] public ThoughtDef asceticRoomThought;
+
 
         /// <summary>
         /// Gets the animal races in this morph group

--- a/Source/Pawnmorphs/Esoteria/MorphUtilities.cs
+++ b/Source/Pawnmorphs/Esoteria/MorphUtilities.cs
@@ -51,7 +51,8 @@ namespace Pawnmorph
             IEnumerable<ThoughtDef> MorphGroupThoughtSelectorFunc(MorphGroupDef group)
             {
                 if (group?.barrakThoughtReplacement != null) yield return group.barrakThoughtReplacement;
-                if (group?.bedroomThoughtReplacement != null) yield return group.bedroomThoughtReplacement; 
+                if (group?.bedroomThoughtReplacement != null) yield return group.bedroomThoughtReplacement;
+                if (group?.asceticRoomThought != null) yield return group.asceticRoomThought;
             }
 
             //get all sleeping thoughts for morph groups 


### PR DESCRIPTION
Note:  This PR also includes all of #327, so review this after that one merges

This is a bugfix and feature bundled together.  When testing #327, I realized that the "dull" and "mediocre" thought levels for bedrooms weren't showing up for pack- and herd-minded morphs.  After digging through the code, I determined this was because of the way the thought patch works.  Currently, it checks for a vanilla bedroom thought and then replaces it with the modified one.  However, the vanilla bedroom thought doesn't have a level for dull or mediocre, and so no thought exists to replace.

This PR changes the patch to instead delete the vanilla thoughts and replicate the vanilla logic but using the modified thoughtdefs.  In addition, I added a new feature while I was here.  Ascetic pack-minded morphs, who would ordinarily not have bedroom thoughts at all, now have a special bedroom thought that only takes into account whether it's a bedroom or a barracks, ignoring quality.  Now ascetics can be happy to sleep with their pack just like everyone else!