### PR TITLE
Add an IMutagenicHediff interface (Hediff Refactor)

### DIFF
--- a/Source/Pawnmorphs/Esoteria/Hediffs/Hediff_Descriptive.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Hediff_Descriptive.cs
@@ -1,0 +1,44 @@
+﻿using Verse;
+
+namespace Pawnmorph.Hediffs
+{
+    /// <summary>
+    /// A class for hediff with description tooltips.  Used as a base for all
+    /// Pawnmorpher hediffs, but also usable by itself if you just want to add
+    /// custom description tooltips/label overrides to a hediff.
+    /// </summary>
+    public class Hediff_Descriptive : HediffWithComps, IDescriptiveHediff
+    {
+        /// <summary>
+        /// Controls the description tooltip rendered by Pawnmorpher.
+        /// </summary>
+        /// <value>
+        /// The tooltip description.
+        /// </value>
+        public virtual string Description
+        {
+            get
+            {
+                if (CurStage is IDescriptiveStage dStage && !dStage.DescriptionOverride.NullOrEmpty())
+                    return dStage.DescriptionOverride;
+
+                return def.description;
+            }
+        }
+
+        /// <summary>
+        /// Controls the base portion of the label (the part not in parentheses)
+        /// </summary>
+        /// <value>The base label.</value>
+        public override string LabelBase
+        {
+            get
+            {
+                if (CurStage is IDescriptiveStage dStage && !dStage.LabelOverride.NullOrEmpty())
+                    return dStage.LabelOverride;
+
+                return base.LabelBase;
+            }
+        }
+    }
+}

--- a/Source/Pawnmorphs/Esoteria/Hediffs/IMutagenicHediff.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/IMutagenicHediff.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Interface for all hediffs that can possibly cause mutations
     /// </summary>
-    public interface IMutationHediff
+    public interface IMutagenicHediff
     {
         /// <summary>
         /// Whether or not this hediff is currently blocking race checks

--- a/Source/Pawnmorphs/Esoteria/Hediffs/IMutationHediff.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/IMutationHediff.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Pawnmorph.Hediffs
+﻿namespace Pawnmorph.Hediffs
 {
     /// <summary>
     /// Interface for all hediffs that can possibly cause mutations
@@ -12,5 +10,26 @@ namespace Pawnmorph.Hediffs
         /// </summary>
         /// <value><c>true</c> if blocks race check; otherwise, <c>false</c>.</value>
         bool BlocksRaceCheck { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether there are any mutations in the current stage.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if there are any mutations in the current stage; otherwise, <c>false</c>.
+        /// </value>
+        bool CurrentStageHasMutations { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether there are any transformations in the current stage.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if there are any transformations in the current stage; otherwise, <c>false</c>.
+        /// </value>
+        bool CurrentStageHasTransformation { get; }
+
+        /// <summary>
+        /// Marks the hediff for removal
+        /// </summary>
+        void MarkForRemoval();
     }
 }

--- a/Source/Pawnmorphs/Esoteria/Hediffs/IMutationHediff.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/IMutationHediff.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Pawnmorph.Hediffs
+{
+    /// <summary>
+    /// Interface for all hediffs that can possibly cause mutations
+    /// </summary>
+    public interface IMutationHediff
+    {
+        /// <summary>
+        /// Whether or not this hediff is currently blocking race checks
+        /// </summary>
+        /// <value><c>true</c> if blocks race check; otherwise, <c>false</c>.</value>
+        bool BlocksRaceCheck { get; }
+    }
+}

--- a/Source/Pawnmorphs/Esoteria/Hediffs/TransformationBase.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/TransformationBase.cs
@@ -16,7 +16,7 @@ namespace Pawnmorph.Hediffs
     /// <summary>abstract base class for all transformation hediffs</summary>
     /// <seealso cref="Pawnmorph.IDescriptiveHediff" />
     /// <seealso cref="Verse.Hediff" />
-    public abstract class TransformationBase : HediffWithComps, IDescriptiveHediff, IMutationHediff
+    public abstract class TransformationBase : Hediff_Descriptive, IMutationHediff
     {
 
         
@@ -85,23 +85,6 @@ namespace Pawnmorph.Hediffs
         }
 
         /// <summary>
-        ///     Gets the description.
-        /// </summary>
-        /// <value>
-        ///     The description.
-        /// </value>
-        public virtual string Description
-        {
-            get
-            {
-                if (CurStage is IDescriptiveStage dStage)
-                    return string.IsNullOrEmpty(dStage.DescriptionOverride) ? def.description : dStage.DescriptionOverride;
-
-                return def.description;
-            }
-        }
-
-        /// <summary>
         /// the expected number of mutations to happen in a single day 
         /// </summary>
         public abstract float MeanMutationsPerDay { get; }
@@ -133,16 +116,10 @@ namespace Pawnmorph.Hediffs
         {
             get
             {
-                string label; 
-                if (CurStage is IDescriptiveStage dStage)
-                    label = string.IsNullOrEmpty(dStage.LabelOverride) ? base.LabelBase : dStage.LabelOverride;
-                else
-                    label = base.LabelBase;
+                string label = base.LabelBase;
 
                 if(SingleComp != null)
-                {
-                    label = $"{label}x{SingleComp.stacks}";
-                }
+                    label = $"{label} x{SingleComp.stacks}";
 
                 return label; 
 

--- a/Source/Pawnmorphs/Esoteria/Hediffs/TransformationBase.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/TransformationBase.cs
@@ -332,7 +332,15 @@ namespace Pawnmorph.Hediffs
         /// <value>
         ///   <c>true</c> if there are any mutations in the current stage; otherwise, <c>false</c>.
         /// </value>
-        public bool AnyMutationsInCurrentStage => AnyMutationsInStage(CurStage); 
+        public virtual bool CurrentStageHasMutations => AnyMutationsInStage(CurStage);
+
+        /// <summary>
+        /// Gets a value indicating whether there are any transformations in the current stage.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if there are any transformations in the current stage; otherwise, <c>false</c>.
+        /// </value>
+        public virtual bool CurrentStageHasTransformation => CurStage is FullTransformationStageBase;
 
         private void AddMutations()
         {

--- a/Source/Pawnmorphs/Esoteria/Hediffs/TransformationBase.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/TransformationBase.cs
@@ -16,7 +16,7 @@ namespace Pawnmorph.Hediffs
     /// <summary>abstract base class for all transformation hediffs</summary>
     /// <seealso cref="Pawnmorph.IDescriptiveHediff" />
     /// <seealso cref="Verse.Hediff" />
-    public abstract class TransformationBase : Hediff_Descriptive, IMutationHediff
+    public abstract class TransformationBase : Hediff_Descriptive, IMutagenicHediff
     {
 
         

--- a/Source/Pawnmorphs/Esoteria/Hediffs/TransformationBase.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/TransformationBase.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using JetBrains.Annotations;
-using Pawnmorph.DefExtensions;
 using Pawnmorph.Utilities;
 using UnityEngine;
 using Verse;
@@ -17,7 +16,7 @@ namespace Pawnmorph.Hediffs
     /// <summary>abstract base class for all transformation hediffs</summary>
     /// <seealso cref="Pawnmorph.IDescriptiveHediff" />
     /// <seealso cref="Verse.Hediff" />
-    public abstract class TransformationBase : HediffWithComps, IDescriptiveHediff
+    public abstract class TransformationBase : HediffWithComps, IDescriptiveHediff, IMutationHediff
     {
 
         

--- a/Source/Pawnmorphs/Esoteria/IngestionOutcomeDoer_CompleteTF.cs
+++ b/Source/Pawnmorphs/Esoteria/IngestionOutcomeDoer_CompleteTF.cs
@@ -42,8 +42,9 @@ namespace Pawnmorph
         {
             if (mustBeReeling)
             {
-                var tfHediff = hediff as TransformationBase;
-                if (tfHediff?.AnyMutationsInCurrentStage != false) return false; 
+                var tfHediff = hediff as IMutationHediff;
+                // TODO this should probably be changed to CurrentStageHasTransformations
+                if (tfHediff?.CurrentStageHasMutations != false) return false; 
             }
 
 

--- a/Source/Pawnmorphs/Esoteria/IngestionOutcomeDoer_CompleteTF.cs
+++ b/Source/Pawnmorphs/Esoteria/IngestionOutcomeDoer_CompleteTF.cs
@@ -42,7 +42,7 @@ namespace Pawnmorph
         {
             if (mustBeReeling)
             {
-                var tfHediff = hediff as IMutationHediff;
+                var tfHediff = hediff as IMutagenicHediff;
                 // TODO this should probably be changed to CurrentStageHasTransformations
                 if (tfHediff?.CurrentStageHasMutations != false) return false; 
             }

--- a/Source/Pawnmorphs/Esoteria/MorphUtilities.cs
+++ b/Source/Pawnmorphs/Esoteria/MorphUtilities.cs
@@ -451,7 +451,7 @@ namespace Pawnmorph
         public static MorphTransformationTypes GetTransformationType([NotNull] this HediffDef inst)
         {
             if (inst == null) throw new ArgumentNullException(nameof(inst));
-            if (!typeof(TransformationBase).IsAssignableFrom(inst.hediffClass)) return 0;
+            if (!(inst.hediffClass is IMutationHediff)) return 0;
 
             var comp = inst.CompProps<HediffCompProperties_Single>();
             return comp == null ? MorphTransformationTypes.Full : MorphTransformationTypes.Partial;

--- a/Source/Pawnmorphs/Esoteria/MorphUtilities.cs
+++ b/Source/Pawnmorphs/Esoteria/MorphUtilities.cs
@@ -451,7 +451,7 @@ namespace Pawnmorph
         public static MorphTransformationTypes GetTransformationType([NotNull] this HediffDef inst)
         {
             if (inst == null) throw new ArgumentNullException(nameof(inst));
-            if (!(inst.hediffClass is IMutationHediff)) return 0;
+            if (!(inst.hediffClass is IMutagenicHediff)) return 0;
 
             var comp = inst.CompProps<HediffCompProperties_Single>();
             return comp == null ? MorphTransformationTypes.Full : MorphTransformationTypes.Partial;

--- a/Source/Pawnmorphs/Esoteria/MutationRules/Worker_MorphHediff.cs
+++ b/Source/Pawnmorphs/Esoteria/MutationRules/Worker_MorphHediff.cs
@@ -48,7 +48,7 @@ namespace Pawnmorph.MutationRules
 
             foreach (var hediff in pawn.health.hediffSet.hediffs.MakeSafe())
             {
-                if (ConditionList.ContainsHediff(hediff) && hediff is IMutationHediff mutHediff)
+                if (ConditionList.ContainsHediff(hediff) && hediff is IMutagenicHediff mutHediff)
                 {
                     mutHediff.MarkForRemoval(); //don't directly remove them, but mark them for removal so they can be removed
                 }   

--- a/Source/Pawnmorphs/Esoteria/MutationRules/Worker_MorphHediff.cs
+++ b/Source/Pawnmorphs/Esoteria/MutationRules/Worker_MorphHediff.cs
@@ -46,11 +46,11 @@ namespace Pawnmorph.MutationRules
         {
             base.OnRuleApplied(pawn);
 
-            foreach (var hediff in pawn.health.hediffSet.hediffs.MakeSafe().OfType<TransformationBase>())
+            foreach (var hediff in pawn.health.hediffSet.hediffs.MakeSafe())
             {
-                if (ConditionList.ContainsHediff(hediff))
+                if (ConditionList.ContainsHediff(hediff) && hediff is IMutationHediff mutHediff)
                 {
-                    hediff.MarkForRemoval(); //don't directly remove them, but mark them for removal so they can be removed
+                    mutHediff.MarkForRemoval(); //don't directly remove them, but mark them for removal so they can be removed
                 }   
             }
 

--- a/Source/Pawnmorphs/Esoteria/MutationTracker.cs
+++ b/Source/Pawnmorphs/Esoteria/MutationTracker.cs
@@ -165,7 +165,7 @@ namespace Pawnmorph
             return oldRace != Pawn.def; 
         }
 
-        private bool CanRaceCheckNow => !Pawn.health.hediffSet.hediffs.OfType<TransformationBase>().Any(t => t.BlocksRaceCheck); 
+        private bool CanRaceCheckNow => !Pawn.health.hediffSet.hediffs.OfType<IMutationHediff>().Any(t => t.BlocksRaceCheck); 
 
         /// <summary>
         ///     Gets the normalized direct influence of the given morph

--- a/Source/Pawnmorphs/Esoteria/MutationTracker.cs
+++ b/Source/Pawnmorphs/Esoteria/MutationTracker.cs
@@ -165,7 +165,7 @@ namespace Pawnmorph
             return oldRace != Pawn.def; 
         }
 
-        private bool CanRaceCheckNow => !Pawn.health.hediffSet.hediffs.OfType<IMutationHediff>().Any(t => t.BlocksRaceCheck); 
+        private bool CanRaceCheckNow => !Pawn.health.hediffSet.hediffs.OfType<IMutagenicHediff>().Any(t => t.BlocksRaceCheck); 
 
         /// <summary>
         ///     Gets the normalized direct influence of the given morph

--- a/Source/Pawnmorphs/Esoteria/Pawnmorph.csproj
+++ b/Source/Pawnmorphs/Esoteria/Pawnmorph.csproj
@@ -838,6 +838,7 @@
     <Compile Include="Utilities\Collections\MultiDict.cs" />
     <Compile Include="Hediffs\Utility\HediffExtensions.cs" />
     <Compile Include="Hediffs\IMutationHediff.cs" />
+    <Compile Include="Hediffs\Hediff_Descriptive.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Alerts\" />

--- a/Source/Pawnmorphs/Esoteria/Pawnmorph.csproj
+++ b/Source/Pawnmorphs/Esoteria/Pawnmorph.csproj
@@ -837,6 +837,7 @@
     <Compile Include="Utilities\Collections\Checklist.cs" />
     <Compile Include="Utilities\Collections\MultiDict.cs" />
     <Compile Include="Hediffs\Utility\HediffExtensions.cs" />
+    <Compile Include="Hediffs\IMutationHediff.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Alerts\" />

--- a/Source/Pawnmorphs/Esoteria/Pawnmorph.csproj
+++ b/Source/Pawnmorphs/Esoteria/Pawnmorph.csproj
@@ -837,7 +837,7 @@
     <Compile Include="Utilities\Collections\Checklist.cs" />
     <Compile Include="Utilities\Collections\MultiDict.cs" />
     <Compile Include="Hediffs\Utility\HediffExtensions.cs" />
-    <Compile Include="Hediffs\IMutationHediff.cs" />
+    <Compile Include="Hediffs\IMutagenicHediff.cs" />
     <Compile Include="Hediffs\Hediff_Descriptive.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/Pawnmorphs/Esoteria/Utilities/Collections/Checklist.cs
+++ b/Source/Pawnmorphs/Esoteria/Utilities/Collections/Checklist.cs
@@ -36,21 +36,42 @@ namespace Pawnmorph.Utilities.Collections
         protected abstract LookMode LookMode { get; }
 
         /// <summary>
-        /// Gets the current entry in this checklist, or the default value if
-        /// we reached the end
+        /// Whether or not we've reached the end of the list
         /// </summary>
-        public T GetCurrentEntry()
+        /// <return>true if we have a current entry, false otherwise</return>
+        public T Entry
         {
-            if (list == null)
+            get
             {
-                Log.Error("Checklist had no parts list");
-                return default(T);
-            }
+                if (list == null)
+                {
+                    Log.Error("Checklist had no parts list");
+                    return default(T);
+                }
 
-            if (index >= list.Count)
-                return default(T);
-            return list[index];
+                if (!HasEntry)
+                    return default(T);
+                return list[index];
+            }
         }
+
+        /// <summary>
+        /// Whether we still have a current entry or we've reached the end of the list
+        /// </summary>
+        /// <value><c>true</c> if there's at least one entry left in the list; otherwise, <c>false</c>.</value>
+        public bool HasEntry => index < list.Count;
+
+        /// <summary>
+        /// The index of the current entry
+        /// </summary>
+        /// <value>The index.</value>
+        public int Index => index;
+
+        /// <summary>
+        /// The total number of entries
+        /// </summary>
+        /// <value><c>true</c> if has entry; otherwise, <c>false</c>.</value>
+        public int Count => list.Count;
 
         /// <summary>
         /// Advances the checklist to the next entry
@@ -59,7 +80,7 @@ namespace Pawnmorph.Utilities.Collections
         public bool NextEntry()
         {
             index++;
-            return index < list.Count;
+            return HasEntry;
         }
 
         /// <summary>
@@ -70,9 +91,12 @@ namespace Pawnmorph.Utilities.Collections
         /// <summary>
         /// Advances the checklist to the next entry, or resets it if we reached the end
         /// </summary>
-        public void NextEntryOrReset()
+        /// <returns>true if there was a next entry, false if the checklist reset</returns>
+        public bool NextEntryOrReset()
         {
-            if (!NextEntry()) Reset();
+            bool next = NextEntry();
+            if (!next) Reset();
+            return next;
         }
 
         /// <summary>
@@ -133,7 +157,7 @@ namespace Pawnmorph.Utilities.Collections
         /// <summary>
         /// Initializes a new checklist with the given list
         /// </summary>
-        public DefChecklist(IEnumerable<T> list) : base (list) { }
+        public DefChecklist(IEnumerable<T> list) : base(list) { }
 
         /// <summary>
         /// The look mode used to save and load the collection entries.

--- a/Source/Pawnmorphs/Esoteria/Utilities/Collections/MultiDict.cs
+++ b/Source/Pawnmorphs/Esoteria/Utilities/Collections/MultiDict.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Verse;
 
 namespace Pawnmorph.Utilities.Collections
 {
@@ -7,7 +8,7 @@ namespace Pawnmorph.Utilities.Collections
     /// A simple multi-value dictionary implementation that maps one key to multiple values
     /// Uses lists internally, so is not particularly efficient for large numbers of values on one key
     /// </summary>
-    public class MultiDict<K, V>// : IDictionary<K, IEnumerable<V>>
+    public class MultiDict<K, V>
     {
         private readonly Dictionary<K, List<V>> dict = new Dictionary<K, List<V>>();
 
@@ -16,9 +17,11 @@ namespace Pawnmorph.Utilities.Collections
         /// null collection deletes the key
         /// </summary>
         /// <param name="key">Key.</param>
-        public ICollection<V> this[K key] {
-            get => dict[key] ?? Enumerable.Empty<V>().ToList();
-            set {
+        public ICollection<V> this[K key]
+        {
+            get => dict.TryGetValue(key, Enumerable.Empty<V>().ToList());
+            set
+            {
                 var val = value?.ToList();
                 if (val != null && val.Count > 0)
                     dict[key] = val;


### PR DESCRIPTION
IMutagenicHediff should now work as a stand-in for all mutagenic hediffs, decoupling everything from TransformationBase.

Also added a Hediff_Descriptive class that implements IDescriptiveHediff, and some bugfixes/tweaks to the collection classes