### PR TITLE
Performance updates

### DIFF
--- a/1.3/Defs/Interactions/AnimalNoises_GoatBleat.xml
+++ b/1.3/Defs/Interactions/AnimalNoises_GoatBleat.xml
@@ -71,9 +71,8 @@
 				<li>talkedabout->[TalkedAbout]</li>
 				<li>talkedabout->[noisedabout]</li>
 				
-				<li>noisedabout->bleated at</li>
-				<li>noisedabout->bleated to</li>
-				<li>noisedabout->baaed at</li>
+				<li>noisedabout->bleated about</li>
+				<li>noisedabout->baaed about</li>
 
 				<li>topic(p=2)->[animaltopic]</li>
 				<li>topic->[MorphTopic]</li>

--- a/Source/Pawnmorphs/Esoteria/Hediff_AddedMutation.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediff_AddedMutation.cs
@@ -16,7 +16,7 @@ namespace Pawnmorph
     /// hediff representing a mutation 
     /// </summary>
     /// <seealso cref="Verse.HediffWithComps" />
-    public class Hediff_AddedMutation : HediffWithComps, IDescriptiveHediff
+    public class Hediff_AddedMutation : Hediff_StageChanges
     {
         [NotNull]
         private readonly Dictionary<int, string> _descCache = new Dictionary<int, string>();
@@ -113,8 +113,7 @@ namespace Pawnmorph
         {
             get
             {
-                var lOverride = (CurStage as MutationStage)?.labelOverride;
-                var label = string.IsNullOrEmpty(lOverride) ? base.LabelBase : lOverride;
+                var label = base.LabelBase;
 
                 if (SeverityAdjust?.Halted == true)
                 {
@@ -132,7 +131,7 @@ namespace Pawnmorph
         /// <value>
         /// The description.
         /// </value>
-        public virtual string Description
+        public override string Description // TODO - the extra features here might be better off in Hediff_Descriptive
         {
             get
             {
@@ -260,25 +259,11 @@ namespace Pawnmorph
         }
 
         /// <summary>
-        /// called every tick 
-        /// </summary>
-        public override void Tick()
-        {
-            base.Tick();
-
-            if (_currentStageIndex != CurStageIndex)
-            {
-                _currentStageIndex = CurStageIndex;
-                OnStageChanges(); 
-            }
-        }
-
-        /// <summary>
         /// Called when the hediff stage changes.
         /// </summary>
-        protected virtual void OnStageChanges()
+        protected override void OnStageChanged(HediffStage oldStage, HediffStage newStage)
         {
-            if (CurStage is MutationStage mStage)
+            if (newStage is MutationStage mStage)
             {
                 //check for aspect skips 
                 if (mStage.SkipAspects.Any(e => e.Satisfied(pawn)))
@@ -289,9 +274,7 @@ namespace Pawnmorph
 
             }
 
-
-
-            if (CurStage is IExecutableStage exeStage)
+            if (newStage is IExecutableStage exeStage)
             {
                 exeStage.EnteredStage(this); 
             }

--- a/Source/Pawnmorphs/Esoteria/Hediffs/Hediff_MutagenicBase.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Hediff_MutagenicBase.cs
@@ -19,7 +19,7 @@ namespace Pawnmorph.Hediffs
     /// </summary>
     /// <seealso cref="Verse.Hediff" />
     /// <seealso cref="Pawnmorph.Hediffs.Hediff_Descriptive" />
-    public class Hediff_MutagenicBase : Hediff_Descriptive, IMutagenicHediff
+    public class Hediff_MutagenicBase : Hediff_StageChanges, IMutagenicHediff
     {
         // Used to track what kind of stage we're in, so we don't have to check
         // every tick
@@ -30,10 +30,7 @@ namespace Pawnmorph.Hediffs
             Transformation
         }
 
-        // Cache the stage index and stage, because CurStage/CurStageIndex both
-        // calculate it every time they're called and it can get expensive
-        private int cachedStageIndex = -1;
-        [Unsaved] private HediffStage cachedStage;
+
         [Unsaved] private StageType cachedStageType;
 
         // The number of queued up mutations to add over the next few ticks
@@ -113,7 +110,7 @@ namespace Pawnmorph.Hediffs
         {
             mutagenSensitivity = new Cached<float>(() => pawn.GetStatValue(PMStatDefOf.MutagenSensitivity));
             transformationSensitivity = new Cached<float>(() => pawn.GetStatValue(PMStatDefOf.TransformationSensitivity));
-            _painStatValue = new Cached<float>(() => pawn.GetStatValue(PMStatDefOf.PM_MutagenPainSensitivity), 1); 
+            _painStatValue = new Cached<float>(() => pawn.GetStatValue(PMStatDefOf.PM_MutagenPainSensitivity), 1);
             observerComps = new Lazy<List<ITfHediffObserverComp>>(() => comps.MakeSafe().OfType<ITfHediffObserverComp>().ToList());
         }
 
@@ -147,17 +144,6 @@ namespace Pawnmorph.Hediffs
         {
             base.Tick();
 
-            // Handle stage transitions
-            if (CurStageIndex != cachedStageIndex)
-            {
-                OnStageChanged();
-
-                // Only try to transform the pawn when entering a transformation stage
-                // NOTE: This triggers regardless of whether the stages are increasing or decreasing.
-                if (cachedStageType == StageType.Transformation && !this.IsImmune())
-                    CheckAndDoTransformation();
-            }
-
             if (pawn.IsHashIntervalTick(60))
             {
                 mutagenSensitivity.Recalculate();
@@ -184,9 +170,9 @@ namespace Pawnmorph.Hediffs
         /// </summary>
         protected virtual void CheckAndAddMutations()
         {
-            if (!(cachedStage is HediffStage_Mutation stage))
+            if (!(CurStage is HediffStage_Mutation stage))
             {
-                Log.Error($"Hediff {def.defName} tried to mutate {pawn.Name} but stage {cachedStageIndex} ({cachedStage.label}) is not a mutation stage");
+                Log.Error($"Hediff {def.defName} tried to mutate {pawn.Name} but stage {CurStageIndex} ({CurStage.label}) is not a mutation stage");
                 return;
             }
 
@@ -271,9 +257,9 @@ namespace Pawnmorph.Hediffs
         /// </summary>
         protected virtual void CheckAndDoTransformation()
         {
-            if (!(cachedStage is HediffStage_Transformation stage))
+            if (!(CurStage is HediffStage_Transformation stage))
             {
-                Log.Error($"Hediff {def.defName} tried to transform {pawn.Name} but stage {cachedStageIndex} ({cachedStage.label}) is not a transformation stage");
+                Log.Error($"Hediff {def.defName} tried to transform {pawn.Name} but stage {CurStageIndex} ({CurStage.label}) is not a transformation stage");
                 return;
             }
 
@@ -323,14 +309,9 @@ namespace Pawnmorph.Hediffs
         /// <summary>
         /// Updates the cached stage values
         /// </summary>
-        private void OnStageChanged()
+        protected override void OnStageChanged(HediffStage oldStage, HediffStage newStage)
         {
-            var oldStage = cachedStage;
-
-            cachedStageIndex = CurStageIndex;
-            cachedStage = def?.stages?[cachedStageIndex];
-
-            if (cachedStage is HediffStage_Mutation newMutStage)
+            if (newStage is HediffStage_Mutation newMutStage)
             {
                 cachedStageType = StageType.Mutation;
 
@@ -349,9 +330,14 @@ namespace Pawnmorph.Hediffs
                     ResetMutationList();
                 }
             }
-            else if (cachedStage is HediffStage_Transformation)
+            else if (newStage is HediffStage_Transformation)
             {
                 cachedStageType = StageType.Transformation;
+
+                // Only try to transform the pawn when entering a transformation stage
+                // NOTE: This triggers regardless of whether the stages are increasing or decreasing.
+                if (!this.IsImmune())
+                    CheckAndDoTransformation();
             }
             else
             {
@@ -380,7 +366,7 @@ namespace Pawnmorph.Hediffs
         /// </summary>
         protected void ResetSpreadList()
         {
-            if (cachedStage is HediffStage_Mutation mutStage)
+            if (CurStage is HediffStage_Mutation mutStage)
             {
                 var spreadList = mutStage.spreadOrder.GetSpreadList(this);
                 bodyMutationManager.ResetSpreadList(spreadList);
@@ -397,7 +383,7 @@ namespace Pawnmorph.Hediffs
         /// </summary>
         protected void ResetMutationList()
         {
-            if (cachedStage is HediffStage_Mutation mutStage)
+            if (CurStage is HediffStage_Mutation mutStage)
             {
                 var mutations = mutStage.mutationTypes.GetMutations(this);
                 bodyMutationManager.ResetMutationList(mutations);
@@ -418,7 +404,7 @@ namespace Pawnmorph.Hediffs
             set
             {
                 // Severity changes can potentially queue up mutations
-                if (cachedStage is HediffStage_Mutation mutStage)
+                if (CurStage is HediffStage_Mutation mutStage)
                 {
                     float diff = value - base.Severity;
                     int mutations = mutStage.mutationRate.GetMutationsPerSeverity(this, diff);
@@ -466,15 +452,9 @@ namespace Pawnmorph.Hediffs
         public override void ExposeData()
         {
             base.ExposeData();
-            Scribe_Values.Look(ref cachedStageIndex, nameof(cachedStageIndex), -1);
             Scribe_Values.Look(ref forceRemove, nameof(forceRemove));
             Scribe_Values.Look(ref queuedMutations, nameof(queuedMutations));
             Scribe_Deep.Look(ref bodyMutationManager, nameof(bodyMutationManager));
-
-            if (Scribe.mode == LoadSaveMode.PostLoadInit)
-            {
-                OnStageChanged();
-            }
         }
 
         /// <summary>
@@ -486,14 +466,14 @@ namespace Pawnmorph.Hediffs
             StringBuilder builder = new StringBuilder(base.DebugString());
             builder.AppendLine($"{nameof(Hediff_MutagenicBase)}:");
 
-            if (cachedStage is HediffStage_Mutation mutationStage)
+            if (CurStage is HediffStage_Mutation mutationStage)
             {
                 builder.AppendLine("  Mutation Stage");
                 builder.AppendLine("  MutagenSensitivity: " + MutagenSensitivity.ToStringPercent());
                 builder.Append(bodyMutationManager.DebugString());
                 builder.Append(mutationStage.DebugString(this));
             }
-            else if (cachedStage is HediffStage_Transformation transformationStage)
+            else if (CurStage is HediffStage_Transformation transformationStage)
             {
                 builder.AppendLine("  Transformation Stage");
                 builder.AppendLine("  TransformationSensitivity: " + TransformationSensitivity);

--- a/Source/Pawnmorphs/Esoteria/Hediffs/Hediff_StageChanges.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Hediff_StageChanges.cs
@@ -47,7 +47,7 @@ namespace Pawnmorph.Hediffs
 
                 OnStageChanged(oldStage, cachedStage);
 
-                foreach (var comp in observerComps)
+                foreach (var comp in ObserverComps)
                     comp.OnStageChanged(oldStage, cachedStage);
             }
         }

--- a/Source/Pawnmorphs/Esoteria/Hediffs/Hediff_StageChanges.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Hediff_StageChanges.cs
@@ -18,6 +18,15 @@ namespace Pawnmorph.Hediffs
         [Unsaved] private HediffStage cachedStage;
 
         private List<IStageChangeObserverComp> observerComps;
+        private IEnumerable<IStageChangeObserverComp> ObserverComps
+        {
+            get
+            {
+                if (observerComps == null)
+                    observerComps = comps.MakeSafe().OfType<IStageChangeObserverComp>().ToList();
+                return observerComps;
+            }
+        }
 
         // CurStageIndex is kind of expensive to calculate, so use the cache when possible
         public override int CurStageIndex => cachedStageIndex;
@@ -64,11 +73,10 @@ namespace Pawnmorph.Hediffs
         public override void ExposeData()
         {
             base.ExposeData();
-            Scribe_Values.Look(ref cachedStageIndex, nameof(cachedStageIndex), -1);
+            Scribe_Values.Look(ref cachedStageIndex, nameof(cachedStageIndex), base.CurStageIndex);
 
             if (Scribe.mode == LoadSaveMode.PostLoadInit)
             {
-                observerComps = comps.MakeSafe().OfType<IStageChangeObserverComp>().ToList();
                 RecacheStage(cachedStageIndex);
             }
         }

--- a/Source/Pawnmorphs/Esoteria/Hediffs/Hediff_StageChanges.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Hediff_StageChanges.cs
@@ -39,7 +39,7 @@ namespace Pawnmorph.Hediffs
         {
             base.Tick();
 
-            int stageIndex = base.CurStageIndex; // Make sure to get the actual index
+            int stageIndex = base.CurStageIndex; // Make sure to get the actual index from the base
             if (stageIndex != cachedStageIndex)
             {
                 var oldStage = cachedStage;

--- a/Source/Pawnmorphs/Esoteria/Hediffs/Hediff_StageChanges.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Hediff_StageChanges.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Pawnmorph.Utilities;
+using Verse;
+
+namespace Pawnmorph.Hediffs
+{
+    /// <summary>
+    /// An abstracty class for hediffs that need to do things on stage changes.
+    /// Also implements the IDescriptiveHediff interface
+    /// </summary>
+    public abstract class Hediff_StageChanges : Hediff_Descriptive
+    {
+        // Cache the stage index and stage, because CurStage/CurStageIndex both
+        // calculate it every time they're called and it can get expensive
+        private int cachedStageIndex = -1;
+        [Unsaved] private HediffStage cachedStage;
+
+        private List<IStageChangeObserverComp> observerComps;
+
+        // CurStageIndex is kind of expensive to calculate, so use the cache when possible
+        public override int CurStageIndex => cachedStageIndex;
+        public override HediffStage CurStage => cachedStage;
+
+        /// <summary>
+        /// Ticks this instance.
+        /// </summary>
+        public override void Tick()
+        {
+            base.Tick();
+
+            int stageIndex = base.CurStageIndex; // Make sure to get the actual index
+            if (stageIndex != cachedStageIndex)
+            {
+                var oldStage = cachedStage;
+                RecacheStage(stageIndex);
+
+                OnStageChanged(oldStage, cachedStage);
+
+                foreach (var comp in observerComps)
+                    comp.OnStageChanged(oldStage, cachedStage);
+            }
+        }
+
+        /// <summary>
+        /// Reloads the stage cache
+        /// </summary>
+        /// <param name="stageIndex">Stage index.</param>
+        private void RecacheStage(int stageIndex)
+        {
+            cachedStageIndex = stageIndex;
+            cachedStage = def?.stages?[cachedStageIndex];
+        }
+
+        /// <summary>
+        /// Called when the stage changes
+        /// </summary>
+        protected abstract void OnStageChanged(HediffStage oldStage, HediffStage newStage);
+
+        /// <summary>
+        /// Exposes data to be saved/loaded from XML upon saving the game
+        /// </summary>
+        public override void ExposeData()
+        {
+            base.ExposeData();
+            Scribe_Values.Look(ref cachedStageIndex, nameof(cachedStageIndex), -1);
+
+            if (Scribe.mode == LoadSaveMode.PostLoadInit)
+            {
+                observerComps = comps.MakeSafe().OfType<IStageChangeObserverComp>().ToList();
+                RecacheStage(cachedStageIndex);
+            }
+        }
+    }
+}

--- a/Source/Pawnmorphs/Esoteria/Hediffs/IStageChangeObserverComp.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/IStageChangeObserverComp.cs
@@ -1,0 +1,15 @@
+﻿using Verse;
+
+namespace Pawnmorph.Hediffs
+{
+    /// <summary>
+    /// Interface for hediff comps that do something on a stage change
+    /// </summary>
+    public interface IStageChangeObserverComp
+    {
+        /// <summary>
+        /// Called when the stage changes on the parent hediff
+        /// </summary>
+        void OnStageChanged(HediffStage oldStage, HediffStage newStage);
+    }
+}

--- a/Source/Pawnmorphs/Esoteria/Pawnmorph.csproj
+++ b/Source/Pawnmorphs/Esoteria/Pawnmorph.csproj
@@ -874,6 +874,8 @@
     <Compile Include="Letters\ChoiceLetter_FormerHumanJoins.cs" />
     <Compile Include="FormerHumans\FormerHumanPawnGenerator.cs" />
     <Compile Include="Thoughts\Thought_RelatedFormerHuman.cs" />
+    <Compile Include="Hediffs\Hediff_StageChanges.cs" />
+    <Compile Include="Hediffs\IStageChangeObserverComp.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Alerts\" />

--- a/Source/Pawnmorphs/Esoteria/Utilities/Cached.cs
+++ b/Source/Pawnmorphs/Esoteria/Utilities/Cached.cs
@@ -61,7 +61,6 @@ namespace Pawnmorph.Utilities
         /// </summary>
         public void Recalculate()
         {
-            _value = default;
             _cached = false; 
         }
     }


### PR DESCRIPTION
Performance updates
- Added an abstract Hediff_StageChanges and IStageChangeObserverComp to handle hediffs and hediffcomps that do things on stage changes.
- Updated Hediff_AddedMutation to inherit from Hediff_StageChanges, and Comp_MutationSeverityAdjust to implement IStageChangeObserverComp.
- Comp_MutationSeverityAdjust lets the hediff notify it of stage changes rather than checking itself (CurStageIndex is too expensive to run multiple times every tick)
- Comp_MutationSeverityAdjust no longer inherits from Comp_SeverityPerDay, and instead replicates the small amount of logic it was using to cut down on overhead (e.g. multiple redundant IsHashTick calls).
- Comp_MutationSeverityAdjust no longer adjusts tick time based on whether the pawn is spawned or not.  It turns out this an expensive check to run every tick, and was costing more time than it saved.