### PR TITLE
Potential fix for random mutation bias

### DIFF
--- a/Source/Pawnmorphs/Esoteria/Hediffs/Hediff_MutagenicBase.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Hediff_MutagenicBase.cs
@@ -300,6 +300,26 @@ namespace Pawnmorph.Hediffs
                 if (!bodyMutationManager.HasMutations())
                     continue;
 
+                if (this.CurStage is HediffStage_Mutation mutationStage)
+                {
+                    // If completely random provide a small chance to skip a limb
+                    if (mutationStage.mutationTypes is MutTypes_All)
+                    {
+                        // Only provide a chance to completely skip if there is 25% or less chance to get identical mutations.
+                        if (bodyMutationManager.AvailableMutations <= 4)
+                        {
+                            float skipChance = 1F / (bodyMutationManager.AvailableMutations + 1);
+                            if (Rand.Chance(skipChance))
+                            {
+    #if DEBUG
+                                Log.Message($"Skipped mutating limb {bodyMutationManager.BodyPart.Label} for {pawn.Name} - {bodyMutationManager.AvailableMutations} mutations available. ({skipChance*100}% chance)");
+    #endif
+                                continue;
+                            }
+                        }
+                    }
+                }
+
                 // Check all mutations in order until we add one
                 do
                 {
@@ -483,6 +503,7 @@ namespace Pawnmorph.Hediffs
                 var spreadList = mutStage.spreadOrder?.GetSpreadList(this);
                 if(spreadList == null)
                     return;
+
                 bodyMutationManager.ResetSpreadList(spreadList);
 
                 // Let the observers know we've reset our spreading

--- a/Source/Pawnmorphs/Esoteria/Hediffs/Utility/BodyMutationManager.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Utility/BodyMutationManager.cs
@@ -28,6 +28,13 @@ namespace Pawnmorph.Hediffs.Utility
         [Unsaved]
         private readonly List<MutationEntry> wholeBodyMutationCache = new List<MutationEntry>();
 
+        /// <summary>
+        /// Gets the total number of mutations available for the current limb.
+        /// </summary>
+        /// <value>
+        /// The remaining mutations.
+        /// </value>
+        public int AvailableMutations => bodyPartMutationList.Count;
 
         /// <summary>
         /// Gets the current body part.

--- a/Source/Pawnmorphs/Esoteria/Hediffs/Utility/BodyMutationManager.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Utility/BodyMutationManager.cs
@@ -32,7 +32,7 @@ namespace Pawnmorph.Hediffs.Utility
         /// Gets the total number of mutations available for the current limb.
         /// </summary>
         /// <value>
-        /// The remaining mutations.
+        /// The number of available mutations.
         /// </value>
         public int AvailableMutations => bodyPartMutationList.Count;
 


### PR DESCRIPTION
A proposed solution for the mutation bias described in issue #371.

By adding an increasing chance of completely skipping a body part with fewer available mutations.
The current percentage equates to just having an additional mutation option of "none".

This means that you are not guaranteed to mutate every single body part, and you are not guaranteed to get a production mutation with a completely random mutation source.

This is only wanted for complete random because that allows every mutation on every body part. For any targeted or limited mutation source, you will have much fewer available mutations and with a specific injector, you only have single choices available.

Right now I check if it is MutTypes_All, but it might be more correct to have it as an exposed option in XML defs as an "allowSkip" or similar.

**Closing issues**
closes #371