### PR TITLE
MutationStage patching functionality

### DIFF
--- a/Schemas/MutationDef.xsd
+++ b/Schemas/MutationDef.xsd
@@ -53,6 +53,21 @@
                     <xs:attribute name="Inherit" type="xs:boolean" use="optional" />
                 </xs:complexType>
             </xs:element>
+            <xs:element name="patches" minOccurs="0">
+				<xs:complexType>
+				    <xs:sequence>
+						<xs:element name="li" minOccurs="1" maxOccurs="unbounded">
+							<xs:complexType>
+								<xs:all>
+								    <xs:element name="identity" type="xs:string" minOccurs="0" />
+								    <xs:element name="values" type="HediffStage" minOccurs="0" />
+								</xs:all>
+								<xs:attribute name="function" type="xs:string" use="optional" />
+							</xs:complexType>
+						</xs:element>
+				    </xs:sequence>
+				</xs:complexType>
+            </xs:element>
             <xs:element name="spawnThingOnRemoved" type="xs:string" minOccurs="0"/>
             <xs:element name="parts" minOccurs="0" type="ListOfStrings" />
             <xs:element name="categories" minOccurs="0" type="ListOfStrings" />

--- a/Schemas/MutationDef.xsd
+++ b/Schemas/MutationDef.xsd
@@ -53,13 +53,13 @@
                     <xs:attribute name="Inherit" type="xs:boolean" use="optional" />
                 </xs:complexType>
             </xs:element>
-            <xs:element name="patches" minOccurs="0">
+            <xs:element name="stagePatches" minOccurs="0">
 				<xs:complexType>
 				    <xs:sequence>
 						<xs:element name="li" minOccurs="1" maxOccurs="unbounded">
 							<xs:complexType>
 								<xs:all>
-								    <xs:element name="identity" type="xs:string" minOccurs="0" />
+								    <xs:element name="stageKey" type="xs:string" minOccurs="0" />
 								    <xs:element name="values" type="HediffStage" minOccurs="0" />
 								</xs:all>
 								<xs:attribute name="function" type="xs:string" use="optional" />
@@ -93,6 +93,7 @@
     </xs:complexType>
     <xs:complexType name="HediffStage">
         <xs:all>
+		    <xs:element name="key" minOccurs="0" type="xs:string" />
             <xs:element name="minSeverity" minOccurs="0" type="xs:float" />
             <xs:element name="label" minOccurs="0" type="xs:string" />
             <xs:element name="labelOverride" minOccurs="0" type="xs:string" />

--- a/Source/Pawnmorphs/Esoteria/Hediffs/MutationDef.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/MutationDef.cs
@@ -38,6 +38,9 @@ namespace Pawnmorph.Hediffs
         /// </summary>
         public List<MutationCategoryDef> categories = new List<MutationCategoryDef>();
 
+
+        public List<MutationStagePatch> patches = new List<MutationStagePatch>();
+
         /// <summary>
         ///     The default chance to add this mutation
         /// </summary>
@@ -296,6 +299,13 @@ namespace Pawnmorph.Hediffs
                     //Log.Message($"{defName} has implicitly defined {nameof(mutationMemory)}, this should be assigned explicitly");
                 }
             }
+
+
+            foreach (MutationStagePatch stagePatch in patches)
+            {
+                stagePatch.Apply(this);
+            }
+
 
             if (parts != null)
             {

--- a/Source/Pawnmorphs/Esoteria/Hediffs/MutationDef.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/MutationDef.cs
@@ -39,7 +39,7 @@ namespace Pawnmorph.Hediffs
         public List<MutationCategoryDef> categories = new List<MutationCategoryDef>();
 
 
-        public List<MutationStagePatch> patches = new List<MutationStagePatch>();
+        public List<MutationStagePatch> stagePatches = new List<MutationStagePatch>();
 
         /// <summary>
         ///     The default chance to add this mutation
@@ -301,7 +301,7 @@ namespace Pawnmorph.Hediffs
             }
 
 
-            foreach (MutationStagePatch stagePatch in patches)
+            foreach (MutationStagePatch stagePatch in stagePatches)
             {
                 stagePatch.Apply(this);
             }

--- a/Source/Pawnmorphs/Esoteria/Hediffs/MutationDef.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/MutationDef.cs
@@ -38,7 +38,9 @@ namespace Pawnmorph.Hediffs
         /// </summary>
         public List<MutationCategoryDef> categories = new List<MutationCategoryDef>();
 
-
+        /// <summary>
+        ///     The stage patches that are applied once the object has been deserialized.
+        /// </summary>
         public List<MutationStagePatch> stagePatches = new List<MutationStagePatch>();
 
         /// <summary>

--- a/Source/Pawnmorphs/Esoteria/Hediffs/MutationStage.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/MutationStage.cs
@@ -17,6 +17,12 @@ namespace Pawnmorph.Hediffs
     public class MutationStage : HediffStage, IDescriptiveStage, IExecutableStage
     {
         /// <summary>
+        /// Optional key that can be used to reference back to this specific stage.
+        /// </summary>
+        [CanBeNull]
+        public string key;
+
+        /// <summary>
         /// list of all aspect givers in this stage 
         /// </summary>
         [CanBeNull]

--- a/Source/Pawnmorphs/Esoteria/MutationStagePatch.cs
+++ b/Source/Pawnmorphs/Esoteria/MutationStagePatch.cs
@@ -78,11 +78,9 @@ namespace Pawnmorph.Hediffs
             if (string.IsNullOrWhiteSpace(this.stageKey))
                 return;
 
-            MutationStage stage = GetStage(mutation);
+            MutationStage stage = TryGetStage(mutation);
             if (stage != null)
                 mutation.stages.Remove(stage);
-            else
-                Log.Warning($"unable to find stage with key: {stageKey} in {mutation.ToString()}");
         }
 
 
@@ -95,7 +93,7 @@ namespace Pawnmorph.Hediffs
             if (values == null)
                 return;
 
-            MutationStage stage = GetStage(mutation);
+            MutationStage stage = TryGetStage(mutation);
             if (stage != null)
             {
                 // Get public instance fields that can be set.
@@ -121,7 +119,10 @@ namespace Pawnmorph.Hediffs
             }
         }
 
-        private MutationStage GetStage(MutationDef mutation)
+        /// <summary>
+        /// Attempts to find and return the stage with identical key from the provided <see cref="MutationDef"/>. Logs a warning and returns null if not found.
+        /// </summary>
+        private MutationStage TryGetStage(MutationDef mutation)
         {
             MutationStage stage = mutation.stages.FirstOrDefault(x => ((MutationStage)x).key == stageKey) as MutationStage;
             if (stage == null)

--- a/Source/Pawnmorphs/Esoteria/MutationStagePatch.cs
+++ b/Source/Pawnmorphs/Esoteria/MutationStagePatch.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Verse;
+
+namespace Pawnmorph.Hediffs
+{
+    public class MutationStagePatch
+    {
+        string identity;
+        string function = "modify";
+        MutationStage values = null;
+
+        public void Apply(MutationDef mutation)
+        {
+            if (values == null)
+                return;
+
+            switch (function)
+            {
+                case "add":
+                    Add(mutation);
+                    break;
+
+                case "modify":
+                    Modify(mutation);
+                    break;
+
+                case "remove":
+                    Remove(mutation);
+                    break;
+            }
+
+        }
+
+        private void Add(MutationDef mutation)
+        {
+            mutation.stages.Add(values);
+        }
+
+        private void Remove(MutationDef mutation)
+        {
+            MutationStage stage = mutation.stages.FirstOrDefault(x => (x.overrideLabel ?? x.label) == identity) as MutationStage;
+            if (stage != null)
+                mutation.stages.Remove(stage);
+        }
+
+
+
+        private void Modify(MutationDef mutation)
+        {
+            MutationStage stage = mutation.stages.FirstOrDefault(x => (x.overrideLabel ?? x.label) == identity) as MutationStage;
+            if (stage != null)
+            {
+                if (values.graphics != null)
+                    stage.graphics = values.graphics;
+
+                if (values.capMods != null)
+                    stage.capMods = values.capMods;
+
+                if (values.description != null)
+                    stage.description = values.description;
+
+                if (values.minSeverity > 0)
+                    stage.minSeverity = values.minSeverity;
+
+
+                if (values.healthOffset > 0)
+                    stage.healthOffset = values.healthOffset;
+
+                if (values.labelOverride != null)
+                    stage.labelOverride = values.labelOverride;
+
+                if (values.stopChance > 0)
+                    stage.stopChance = values.stopChance;
+            }
+        }
+    }
+}

--- a/Source/Pawnmorphs/Esoteria/MutationStagePatch.cs
+++ b/Source/Pawnmorphs/Esoteria/MutationStagePatch.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using JetBrains.Annotations;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -7,17 +8,35 @@ using Verse;
 
 namespace Pawnmorph.Hediffs
 {
+    /// <summary>
+    /// Mutation stage patch that can be included in a <see cref="MutationDef" /> to allow modifying mutation stages in derived xml files with shared stages.
+    /// </summary>
     public class MutationStagePatch
     {
-        string identity;
+        /// <summary>
+        /// Identity of the stage to affect when using modify or remove function.
+        /// </summary>
+        [CanBeNull]
+        string identity = null;
+
+        /// <summary>
+        /// The patch behavior. Can be either "add", "modify" or "remove".
+        /// </summary>
+        [NotNull]
         string function = "modify";
+
+        /// <summary>
+        /// The mutation stage containing the values to use to either update an existing stage or append and entirely new stage.
+        /// </summary>
+        [CanBeNull]
         MutationStage values = null;
 
+        /// <summary>
+        /// Applies the specified stage patch.
+        /// </summary>
+        /// <param name="mutation">The mutation.</param>
         public void Apply(MutationDef mutation)
         {
-            if (values == null)
-                return;
-
             switch (function)
             {
                 case "add":
@@ -31,17 +50,27 @@ namespace Pawnmorph.Hediffs
                 case "remove":
                     Remove(mutation);
                     break;
+
+                default:
+                    Log.Warning($"Invalid mutation stage patch function: {function} in {mutation.ToString()}");
+                    break;
             }
 
         }
 
         private void Add(MutationDef mutation)
         {
+            if (values == null)
+                return;
+
             mutation.stages.Add(values);
         }
 
         private void Remove(MutationDef mutation)
         {
+            if (String.IsNullOrWhiteSpace(identity))
+                return;
+
             MutationStage stage = mutation.stages.FirstOrDefault(x => (x.overrideLabel ?? x.label) == identity) as MutationStage;
             if (stage != null)
                 mutation.stages.Remove(stage);
@@ -51,31 +80,37 @@ namespace Pawnmorph.Hediffs
 
         private void Modify(MutationDef mutation)
         {
+            if (String.IsNullOrWhiteSpace(identity))
+                return;
+
+            if (values == null)
+                return;
+
             MutationStage stage = mutation.stages.FirstOrDefault(x => (x.overrideLabel ?? x.label) == identity) as MutationStage;
             if (stage != null)
             {
-                if (values.graphics != null)
-                    stage.graphics = values.graphics;
+                // Get public instance fields that can be set.
+                System.Reflection.FieldInfo[] members = typeof(MutationStage).GetFields(System.Reflection.BindingFlags.Public | 
+                                                                                        System.Reflection.BindingFlags.Instance);
 
-                if (values.capMods != null)
-                    stage.capMods = values.capMods;
+                MutationStage defaultValues = new MutationStage();
+                foreach (System.Reflection.FieldInfo member in members)
+                {
+                    object newValue = member.GetValue(values);
 
-                if (values.description != null)
-                    stage.description = values.description;
+                    if (newValue != null)
+                    {
+                        // get default value
+                        object defaultValue = member.GetValue(defaultValues);
 
-                if (values.minSeverity > 0)
-                    stage.minSeverity = values.minSeverity;
+                        if (newValue.Equals(defaultValue))
+                            continue;
 
-
-                if (values.healthOffset > 0)
-                    stage.healthOffset = values.healthOffset;
-
-                if (values.labelOverride != null)
-                    stage.labelOverride = values.labelOverride;
-
-                if (values.stopChance > 0)
-                    stage.stopChance = values.stopChance;
+                        member.SetValue(stage, newValue);
+                    }
+                }
             }
         }
+
     }
 }

--- a/Source/Pawnmorphs/Esoteria/Pawnmorph.csproj
+++ b/Source/Pawnmorphs/Esoteria/Pawnmorph.csproj
@@ -574,6 +574,7 @@
     <Compile Include="MutationRules\Worker_MorphHediff.cs" />
     <Compile Include="MutationRuleUtilities.cs" />
     <Compile Include="MutationSite.cs" />
+    <Compile Include="MutationStagePatch.cs" />
     <Compile Include="Need_Control.cs" />
     <Compile Include="PartAddress.cs" />
     <Compile Include="PatchOperations\DebugAdd.cs" />


### PR DESCRIPTION
This will allow modifying mutation stages after a mutation has been compiled and objectified into the game. 
Which makes it possible to share stages between multiple derived mutation definitions with only small changes on each like graphics.

I tried to make key on MutationStage an attribute but then it didn't get deserialized properly, so I had to make it an optional element.