### PR TITLE
Fixed missing ChaomorphExstension in chaothrumbo xml.

### DIFF
--- a/1.3/Defs/Chaocreatures/Chaothrumbo.xml
+++ b/1.3/Defs/Chaocreatures/Chaothrumbo.xml
@@ -13,6 +13,12 @@
 			<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
 			<ArmorRating_Heat>0.50</ArmorRating_Heat>
 		</statBases>
+		<modExtensions>
+			<li Class="Pawnmorph.DefExtensions.ChaomorphExtension">
+				<chaoType>Special</chaoType>
+				<selectionWeight>-1</selectionWeight>
+			</li>
+		</modExtensions>
 		<uiIconScale>1.75</uiIconScale>
 		<tools>
 			<li>


### PR DESCRIPTION
**Details**
Added the missing modExstension to Chaothrumbo xml to make the code see it as a proper chao-creature.

**Closing issues**
closes #387
