### PR TITLE
Fix for cowmorphs not being attacked by manhunter

### DIFF
--- a/Source/Pawnmorphs/Esoteria/PawnmorphPatches.cs
+++ b/Source/Pawnmorphs/Esoteria/PawnmorphPatches.cs
@@ -264,9 +264,6 @@ namespace Pawnmorph
             //incidents 
             PatchIncidents(methodsToPatch);
 
-            methodsToPatch.Add(typeof(Pawn).GetMethod(nameof(Pawn.ThreatDisabledBecauseNonAggressiveRoamer), instanceFlags));
-
-
             //interaction patch 
             methodsToPatch.Add(typeof(InteractionUtility).GetMethod(nameof(InteractionUtility.CanReceiveRandomInteraction), STATIC_FLAGS));
             methodsToPatch.Add(typeof(InteractionUtility).GetMethod(nameof(InteractionUtility.CanInitiateRandomInteraction), STATIC_FLAGS));
@@ -296,7 +293,8 @@ namespace Pawnmorph
             //roamer patches 
             methodsToPatch.Add(typeof(MentalStateWorker_Roaming).GetMethod(nameof(MentalStateWorker_Roaming.CanRoamNow), staticFlags));
             methodsToPatch.Add(typeof(MentalState_Manhunter).GetMethod(nameof(MentalState_Manhunter.ForceHostileTo), INSTANCE_FLAGS, null, new[] { typeof(Thing) }, null));
-
+            methodsToPatch.Add(typeof(Pawn).GetMethod(nameof(Pawn.ThreatDisabledBecauseNonAggressiveRoamer), instanceFlags));
+            
             //now patch them 
             foreach (var methodInfo in methodsToPatch)
             {

--- a/Source/Pawnmorphs/Esoteria/PawnmorphPatches.cs
+++ b/Source/Pawnmorphs/Esoteria/PawnmorphPatches.cs
@@ -264,6 +264,8 @@ namespace Pawnmorph
             //incidents 
             PatchIncidents(methodsToPatch);
 
+            methodsToPatch.Add(typeof(Pawn).GetMethod(nameof(Pawn.ThreatDisabledBecauseNonAggressiveRoamer), instanceFlags));
+
 
             //interaction patch 
             methodsToPatch.Add(typeof(InteractionUtility).GetMethod(nameof(InteractionUtility.CanReceiveRandomInteraction), STATIC_FLAGS));
@@ -292,9 +294,8 @@ namespace Pawnmorph
             methodsToPatch.Add(typeof(SocialProperness).GetMethod(nameof(SocialProperness.IsSociallyProper), new Type[] { typeof(Thing), typeof(Pawn), typeof(bool), typeof(bool) }));
 
             //roamer patches 
-            methodsToPatch.Add(typeof(MentalStateWorker_Roaming).GetMethod(nameof(MentalStateWorker_Roaming.CanRoamNow),
-                                                                           staticFlags));
-
+            methodsToPatch.Add(typeof(MentalStateWorker_Roaming).GetMethod(nameof(MentalStateWorker_Roaming.CanRoamNow), staticFlags));
+            methodsToPatch.Add(typeof(MentalState_Manhunter).GetMethod(nameof(MentalState_Manhunter.ForceHostileTo), INSTANCE_FLAGS, null, new[] { typeof(Thing) }, null));
 
             //now patch them 
             foreach (var methodInfo in methodsToPatch)


### PR DESCRIPTION
**Details**
Added missing patches to allow the manhunter targeting to see roaming morphs as threats and vice versa.

**Closing issues**
closes #380
