### PR TITLE
Part picker polish

### DIFF
--- a/Source/Pawnmorphs/Esoteria/User Interface/Dialog_PartPicker.cs
+++ b/Source/Pawnmorphs/Esoteria/User Interface/Dialog_PartPicker.cs
@@ -519,7 +519,7 @@ namespace Pawnmorph.User_Interface
                     mutations = pawnCurrentMutations.Where(m => parts.Contains(m.Part) && m.Def.RemoveComp.layer == MutationLayer.Core).ToList();
                     layer = MutationLayer.Core;
                 }
-                buttonLabel = $"{(mutations.NullOrEmpty() ? NO_MUTATIONS_LOC_STRING.Translate().ToString() : string.Join(", ", mutations.Select(m => $"{m.Def.LabelCap} ({m.Def.classInfluence.label.CapitalizeFirst()})").Distinct()))}";
+                buttonLabel = $"{(mutations.NullOrEmpty() ? NO_MUTATIONS_LOC_STRING.Translate().ToString() : string.Join(", ", mutations.Select(m => $"{m.Def.LabelCap}").Distinct()))}";
                 DrawPartButtons(ref curY, partListViewRect, mutations, parts, layer, buttonLabel);
             }
         }
@@ -534,7 +534,6 @@ namespace Pawnmorph.User_Interface
             // Draw the main mutation selection button. It should take up the whole width if there are no details, otherwise it will leave a space for the edit button.
             float partButtonWidth = partListViewRect.width - (hasDetails == false ? 0 : editButtonWidth);
             Rect partButtonRect = new Rect(partListViewRect.x, curY, partButtonWidth, Text.CalcHeight(label, partButtonWidth - BUTTON_HORIZONTAL_PADDING));
-
             if (Widgets.ButtonText(partButtonRect, label))
             {
                 List<FloatMenuOption> options = new List<FloatMenuOption>();

--- a/Source/Pawnmorphs/Esoteria/User Interface/Dialog_PartPicker.cs
+++ b/Source/Pawnmorphs/Esoteria/User Interface/Dialog_PartPicker.cs
@@ -527,9 +527,14 @@ namespace Pawnmorph.User_Interface
 
         private void DrawPartButtons(ref float curY, Rect partListViewRect, List<Hediff_AddedMutation> mutations, List<BodyPartRecord> parts, MutationLayer layer, string label)
         {
-            // Draw the main mutation selection button. It should take up the whole width if there are no mutations, otherwise it will leave a space for the edit button.
-            float partButtonWidth = partListViewRect.width - (mutations.NullOrEmpty() ? 0 : editButtonWidth);
+            bool hasDetails = false;
+            if (mutations.Count > 0 && mutations.Any(x => x.SeverityAdjust != null))
+                hasDetails = true;
+
+            // Draw the main mutation selection button. It should take up the whole width if there are no details, otherwise it will leave a space for the edit button.
+            float partButtonWidth = partListViewRect.width - (hasDetails == false ? 0 : editButtonWidth);
             Rect partButtonRect = new Rect(partListViewRect.x, curY, partButtonWidth, Text.CalcHeight(label, partButtonWidth - BUTTON_HORIZONTAL_PADDING));
+
             if (Widgets.ButtonText(partButtonRect, label))
             {
                 List<FloatMenuOption> options = new List<FloatMenuOption>();
@@ -575,7 +580,7 @@ namespace Pawnmorph.User_Interface
             curY += partButtonRect.height;
 
             // If there are actually mutations, draw the edit button.
-            if (!mutations.NullOrEmpty())
+            if (hasDetails)
             {
                 Rect editButtonRect = new Rect(partButtonWidth, partButtonRect.y, editButtonWidth, partButtonRect.height);
                 if (Widgets.ButtonText(editButtonRect, editButtonText))
@@ -585,7 +590,7 @@ namespace Pawnmorph.User_Interface
             }
 
             // If the currently selected part and layer match up with the part to give details for, draw the edit area below the buttons.
-            if (detailPart.Item1 == parts.FirstOrDefault() && detailPart.Item2 == layer)
+            if (hasDetails && detailPart.Item1 == parts.FirstOrDefault() && detailPart.Item2 == layer)
             {
                 foreach (MutationDef mutationDef in mutations.Select(m => m.Def).Distinct())
                 {

--- a/Source/Pawnmorphs/Esoteria/User Interface/Dialog_PartPicker.cs
+++ b/Source/Pawnmorphs/Esoteria/User Interface/Dialog_PartPicker.cs
@@ -810,7 +810,6 @@ namespace Pawnmorph.User_Interface
             foreach (Material mat in graphics.MatsBodyBaseAt(previewRot))
             {
                 Material damagedMat = graphics.flasher.GetDamagedMat(mat);
-                damagedMat.color = pawn.GetHighestInfluence()?.GetSkinColorOverride(pawn) ?? damagedMat.color;
                 GenDraw.DrawMeshNowOrLater(bodyMesh, bodyOffset, quaternion, damagedMat, false);
                 bodyOffset.y += 0.00390625f;
                 if (!toggleClothesEnabled)


### PR DESCRIPTION
QoL changes and fixes for PartPicker
1. Skin now changes color to the skin override of morph species most associated with currently selected mutations.
2. Removed random texture in background. (Presumably corner of map itself, fixed by moving entire preview rendering to -10x)
3. Hidden detail button if the mutation has no severity prop.
4. Removed species text from selected mutations to prevent text clipping on buttons.
5. Fixed head mutations not being aligned to head.
6. Fixed mutation details not showing correct mutation stage on changing severity.

Still need to figure out how to handle hair.