### PR TITLE
Issue427 transfer hediff

### DIFF
--- a/Source/Pawnmorphs/Esoteria/BodyUtilities.cs
+++ b/Source/Pawnmorphs/Esoteria/BodyUtilities.cs
@@ -77,6 +77,18 @@ namespace Pawnmorph
             return curRecord;
         }
 
+
+
+        [CanBeNull]
+        public static BodyPartRecord GetRecord([NotNull] this BodyDef bodyDef, [NotNull] BodyPartRecord partRecord)
+        {
+            if (bodyDef == null) throw new ArgumentNullException(nameof(bodyDef));
+            if (partRecord == null) throw new ArgumentNullException(nameof(partRecord));
+
+
+            return bodyDef.GetPartsWithDef(partRecord.def).FirstOrDefault(x => x.Label == partRecord.Label);
+        }
+
         /// <summary>
         /// Gets all non missing parts of the given part defs 
         /// </summary>

--- a/Source/Pawnmorphs/Esoteria/PawnTransferUtilities.cs
+++ b/Source/Pawnmorphs/Esoteria/PawnTransferUtilities.cs
@@ -252,8 +252,6 @@ namespace Pawnmorph
             IEnumerable<Hediff> tHediffs = health1?.hediffSet?.hediffs?.Where(selector);
             foreach (Hediff hediff in tHediffs.MakeSafe())
             {
-                Log.Message($"Found hediff {hediff.def.defName}");
-
                 BodyPartRecord otherRecord;
                 if (hediff.Part == null) 
                     otherRecord = null;
@@ -261,10 +259,7 @@ namespace Pawnmorph
                     otherRecord = transferFunc(hediff.Part);
 
                 if (otherRecord == null && hediff.Part != null)
-                {
-                    Log.Message($"Failed to transfer hediff {hediff.def.defName}");
                     continue;
-                }
 
                 if (health2.hediffSet.HasHediff(hediff.def, otherRecord)) 
                     continue;

--- a/Source/Pawnmorphs/Esoteria/PawnTransferUtilities.cs
+++ b/Source/Pawnmorphs/Esoteria/PawnTransferUtilities.cs
@@ -96,8 +96,7 @@ namespace Pawnmorph
         {
             if (record == null) throw new ArgumentNullException(nameof(record));
             if (otherDef == null) throw new ArgumentNullException(nameof(otherDef));
-            PartAddress pAddr = record.GetAddress();
-            return otherDef.GetRecordAt(pAddr);
+            return otherDef.GetRecord(record);
         }
 
         /// <summary>
@@ -253,14 +252,22 @@ namespace Pawnmorph
             IEnumerable<Hediff> tHediffs = health1?.hediffSet?.hediffs?.Where(selector);
             foreach (Hediff hediff in tHediffs.MakeSafe())
             {
+                Log.Message($"Found hediff {hediff.def.defName}");
+
                 BodyPartRecord otherRecord;
-                if (hediff.Part == null) otherRecord = null;
+                if (hediff.Part == null) 
+                    otherRecord = null;
                 else
                     otherRecord = transferFunc(hediff.Part);
 
-                if (otherRecord == null && hediff.Part != null) continue;
+                if (otherRecord == null && hediff.Part != null)
+                {
+                    Log.Message($"Failed to transfer hediff {hediff.def.defName}");
+                    continue;
+                }
 
-                if (health2.hediffSet.HasHediff(hediff.def, otherRecord)) continue;
+                if (health2.hediffSet.HasHediff(hediff.def, otherRecord)) 
+                    continue;
 
                 Hediff newHediff = HediffMaker.MakeHediff(hediff.def, pawn2, otherRecord);
                 health2.AddHediff(newHediff);


### PR DESCRIPTION
Fixed issue by changing the way hediffs transfer identifies equivalent body parts for pawn <=> animal transition.
Instead of going by bodypartrecord address and matching each layer, it instead gets all body parts of identical definition (like all legs) and then matches for identical label (only 'right' leg).

This does mean however that if the target shape does not have an identical limb ("Right rear leg" vs "right leg") the hediff will still be lost in animal shape.

**Closing issues**
closes #427
