### PR TITLE
Former humans cannot pass through neutral or allied doors.

### DIFF
--- a/Source/Pawnmorphs/Esoteria/HPatches/DoorPatches.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/DoorPatches.cs
@@ -16,13 +16,15 @@ namespace Pawnmorph.HPatches
         {
             if (__result)
             {
-                if (p.Faction != __instance.Faction)
+                // Block former humans from passing through door if the pawn's faction is hostile to the door's faction.
+                if (p.Faction.HostileTo(__instance.Faction))
                 {
                     if (p.IsFormerHuman())
                     {
                         __result = false;
+                        return;
                     }
-                } 
+                }
             }
 
             return; 

--- a/Source/Pawnmorphs/Esoteria/HPatches/DoorPatches.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/DoorPatches.cs
@@ -17,7 +17,7 @@ namespace Pawnmorph.HPatches
             if (__result)
             {
                 // Block former humans from passing through door if the pawn's faction is hostile to the door's faction.
-                if (p.Faction.HostileTo(__instance.Faction))
+                if (p.Faction == null || p.Faction.HostileTo(__instance.Faction))
                 {
                     if (p.IsFormerHuman())
                     {


### PR DESCRIPTION
Changed door patch to only block pathing through doors of a hostile faction.


**Closing issues**
closes #429