### PR TITLE
Issue438 - Incorrect reverted age

### DIFF
--- a/Source/Pawnmorphs/Esoteria/PawnTransferUtilities.cs
+++ b/Source/Pawnmorphs/Esoteria/PawnTransferUtilities.cs
@@ -402,25 +402,32 @@ namespace Pawnmorph
         public static void TransferRelations([NotNull] Pawn pawn1, [NotNull] Pawn pawn2,
                                              Predicate<PawnRelationDef> predicate = null)
         {
-            if (pawn1.relations == null) return;
+            if (pawn1.relations == null) 
+                return;
+
             List<DirectPawnRelation> enumerator = pawn1.relations.DirectRelations.MakeSafe().ToList();
             predicate = predicate ?? (r => true); //if no filter is set, have it pass everything 
+
             foreach (DirectPawnRelation directPawnRelation in enumerator.Where(d => predicate(d.def)))
             {
-                if (directPawnRelation.def.implied) continue;
-                pawn1.relations?.RemoveDirectRelation(directPawnRelation); //make sure we remove the relations first 
+                if (directPawnRelation.def == null || directPawnRelation.def.implied) 
+                    continue;
+
+                pawn1.relations.RemoveDirectRelation(directPawnRelation); //make sure we remove the relations first 
                 pawn2.relations?.AddDirectRelation(directPawnRelation.def,
                                                    directPawnRelation.otherPawn); //TODO restrict these to special relationships? 
             }
 
-            foreach (Pawn pRelatedPawns in pawn1.relations.PotentiallyRelatedPawns.ToList()
-            ) //make copies so we don't  invalidate the enumerator mid way through 
-            foreach (PawnRelationDef pawnRelationDef in pRelatedPawns.GetRelations(pawn1).Where(d => predicate(d)).ToList())
-            {
-                if (pawnRelationDef.implied) continue;
-                pRelatedPawns.relations.RemoveDirectRelation(pawnRelationDef, pawn1);
-                pRelatedPawns.relations.AddDirectRelation(pawnRelationDef, pawn2);
-            }
+            //make copies so we don't  invalidate the enumerator mid way through 
+            foreach (Pawn pRelatedPawns in pawn1.relations.PotentiallyRelatedPawns.MakeSafe().ToList())
+                foreach (PawnRelationDef pawnRelationDef in pRelatedPawns.GetRelations(pawn1).Where(d => predicate(d)).ToList())
+                {
+                    if (pawnRelationDef.implied) 
+                        continue;
+
+                    pRelatedPawns.relations.RemoveDirectRelation(pawnRelationDef, pawn1);
+                    pRelatedPawns.relations.AddDirectRelation(pawnRelationDef, pawn2);
+                }
         }
 
         /// <summary>

--- a/Source/Pawnmorphs/Esoteria/TfSys/MergeMutagen.cs
+++ b/Source/Pawnmorphs/Esoteria/TfSys/MergeMutagen.cs
@@ -173,6 +173,17 @@ namespace Pawnmorph.TfSys
             PawnRelationDef mergeMateEx = DefDatabase<PawnRelationDef>.GetNamed("ExMerged"); //TODO put these in a DefOf 
 
 
+
+            foreach (Pawn originalPawn in transformedPawn.originals)
+            {
+                float currentConvertedAge = TransformerUtility.ConvertAge(transformedPawn.meld, originalPawn.RaceProps);
+                float originalAge = originalPawn.ageTracker.AgeBiologicalYearsFloat;
+
+                long agedTicksDelta = (long)(currentConvertedAge - originalAge) * 3600000L; // 3600000f ticks per year.
+                originalPawn.ageTracker.AgeBiologicalTicks += agedTicksDelta;
+            }
+
+
             var firstO = (Pawn) GenSpawn.Spawn(transformedPawn.originals[0], meld.PositionHeld, meld.MapHeld);
             var secondO = (Pawn) GenSpawn.Spawn(transformedPawn.originals[1], meld.PositionHeld, meld.MapHeld);
 

--- a/Source/Pawnmorphs/Esoteria/TfSys/SimpleMechaniteMutagen.cs
+++ b/Source/Pawnmorphs/Esoteria/TfSys/SimpleMechaniteMutagen.cs
@@ -311,6 +311,11 @@ namespace Pawnmorph.TfSys
             if (animal == null) return false; 
             var rFaction = transformedPawn.FactionResponsible;
 
+            float currentConvertedAge = TransformerUtility.ConvertAge(transformedPawn.animal, transformedPawn.original.RaceProps);
+            float originalAge = transformedPawn.original.ageTracker.AgeBiologicalYearsFloat;
+
+            long agedTicksDelta = (long)(currentConvertedAge - originalAge) * 3600000L; // 3600000f ticks per year.
+            transformedPawn.original.ageTracker.AgeBiologicalTicks += agedTicksDelta;
 
             var spawned = (Pawn) GenSpawn.Spawn(transformedPawn.original, animal.PositionHeld, animal.MapHeld);
 


### PR DESCRIPTION
Calculates how much the pawn aged relative to life-span while transformed and adds that on reversion.

Also fixed rare issue with reversion where a relationship might not have a def, encountered while testing.

**Closing issues**
closes #438 
