### PR TITLE
Added globalHealthMultiplier to MutationStage

### DIFF
--- a/Schemas/MutationDef.xsd
+++ b/Schemas/MutationDef.xsd
@@ -100,6 +100,7 @@
             <xs:element name="description" minOccurs="0" type="xs:string" />
             <xs:element name="painOffset" type="xs:float" minOccurs="0" />
             <xs:element name="healthOffset" type="xs:float" minOccurs="0" />
+			<xs:element name="globalHealthMultiplier" type="xs:float" minOccurs="0" />
             <xs:element name="graphics" minOccurs="0">
                 <xs:complexType>
                     <xs:sequence>

--- a/Source/Pawnmorphs/Esoteria/BodyUtilities.cs
+++ b/Source/Pawnmorphs/Esoteria/BodyUtilities.cs
@@ -148,20 +148,30 @@ namespace Pawnmorph
             if (record == null) throw new ArgumentNullException(nameof(record));
 
             MutationTracker mTracker = p.GetMutationTracker(); //use mTracker so we only check mutations, a bit faster 
-            if (mTracker == null) return record.def.hitPoints;
+            if (mTracker == null) 
+                return record.def.hitPoints;
+
             float offset = 0;
+            float maxPartHealth = record.def.GetMaxHealth(p);
             foreach (Hediff_AddedMutation mutation in mTracker.AllMutations)
             {
-                if (mutation.Part != record) continue;
                 MutationStage mStage = mutation.CurrentMutationStage;
-                if (mStage == null) continue;
+
+                if (mStage == null)
+                    continue;
+
+                if (mStage.globalHealthMultiplier != 0)
+                    offset = maxPartHealth * mStage.globalHealthMultiplier;
+
+                if (mutation.Part != record) 
+                    continue;
 
                 offset += mStage.healthOffset;
             }
 
             return
                 offset * p.HealthScale
-              + record.def.GetMaxHealth(p); //multiplying out health scale like this in case any mods patch BodyPartDef.GetMaxHealth
+              + maxPartHealth; //multiplying out health scale like this in case any mods patch BodyPartDef.GetMaxHealth
         }
 
 

--- a/Source/Pawnmorphs/Esoteria/Hediffs/MutationStage.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/MutationStage.cs
@@ -36,7 +36,12 @@ namespace Pawnmorph.Hediffs
         /// <summary>
         /// the max health offset of this particular part 
         /// </summary>
-        public float healthOffset = 0; 
+        public float healthOffset = 0;
+
+        /// <summary>
+        /// the max health modifier of this pawn's bodyparts.
+        /// </summary>
+        public float globalHealthMultiplier = 0;
 
         /// <summary>
         /// The label override


### PR DESCRIPTION
Added property on MutationStage to add a bodypart hitpoint multiplier across all body parts.
This allows to potentially moving some of the tankiness from powerful morphs into a mutation that can be added to other morphs with chamber later.
