### PR TITLE
Issue 445 Unselectable chaothrumbo

### DIFF
--- a/1.3/Defs/MutagenChamberNew.xml
+++ b/1.3/Defs/MutagenChamberNew.xml
@@ -77,6 +77,7 @@
                     <li>Chaoboom</li>
                     <li>Chaoboar</li>
                     <li>Chaodino</li>
+                    <li>PM_Chaothrumbo</li>
                 </alwaysAvailable>
             </li>
             <li Class="Pawnmorph.ThingComps.FillableBarDrawerProps">

--- a/Source/Pawnmorphs/Esoteria/Chambers/MutaChamber.cs
+++ b/Source/Pawnmorphs/Esoteria/Chambers/MutaChamber.cs
@@ -300,7 +300,6 @@ namespace Pawnmorph.Chambers
 
         private void SelectorComp_OnClick([NotNull] AnimalSelectorComp comp)
         {
-            Log.Message("OnClick");
             Pawn pawn = innerContainer.OfType<Pawn>().FirstOrDefault();
             if (pawn != null)
                 comp.SpeciesFilter = (x) => x.GetModExtension<ChamberAnimalTfController>()?.CanInitiateTransformation(pawn, x, this) ?? true;

--- a/Source/Pawnmorphs/Esoteria/Chambers/MutaChamber.cs
+++ b/Source/Pawnmorphs/Esoteria/Chambers/MutaChamber.cs
@@ -406,6 +406,13 @@ namespace Pawnmorph.Chambers
         /// <returns></returns>
         public override IEnumerable<Gizmo> GetGizmos()
         {
+            if (SelectorComp?.Enabled == true)
+            {
+                Pawn pawn = innerContainer.OfType<Pawn>().FirstOrDefault();
+                if (pawn != null)
+                    SelectorComp.SpeciesFilter = (x) => x.GetModExtension<ChamberAnimalTfController>()?.CanInitiateTransformation(pawn, x, this) ?? true;
+            }
+
             foreach (Gizmo gizmo in base.GetGizmos()) yield return gizmo;
 
             if (DebugSettings.godMode && (_innerState == ChamberState.Active || _innerState == ChamberState.WaitingForSpecialThing)) yield return DebugFinishGizmo;

--- a/Source/Pawnmorphs/Esoteria/Chambers/MutaChamber.cs
+++ b/Source/Pawnmorphs/Esoteria/Chambers/MutaChamber.cs
@@ -293,7 +293,17 @@ namespace Pawnmorph.Chambers
             {
 
                 if (Glower != null) Glower.Props.glowColor = _innerState == ChamberState.Active ? GlowColor : Clear;
+
+                SelectorComp.OnClick += SelectorComp_OnClick;
             }
+        }
+
+        private void SelectorComp_OnClick([NotNull] AnimalSelectorComp comp)
+        {
+            Log.Message("OnClick");
+            Pawn pawn = innerContainer.OfType<Pawn>().FirstOrDefault();
+            if (pawn != null)
+                comp.SpeciesFilter = (x) => x.GetModExtension<ChamberAnimalTfController>()?.CanInitiateTransformation(pawn, x, this) ?? true;
         }
 
 
@@ -405,13 +415,6 @@ namespace Pawnmorph.Chambers
         /// <returns></returns>
         public override IEnumerable<Gizmo> GetGizmos()
         {
-            if (SelectorComp?.Enabled == true)
-            {
-                Pawn pawn = innerContainer.OfType<Pawn>().FirstOrDefault();
-                if (pawn != null)
-                    SelectorComp.SpeciesFilter = (x) => x.GetModExtension<ChamberAnimalTfController>()?.CanInitiateTransformation(pawn, x, this) ?? true;
-            }
-
             foreach (Gizmo gizmo in base.GetGizmos()) yield return gizmo;
 
             if (DebugSettings.godMode && (_innerState == ChamberState.Active || _innerState == ChamberState.WaitingForSpecialThing)) yield return DebugFinishGizmo;

--- a/Source/Pawnmorphs/Esoteria/ThingComps/AnimalSelectorComp.cs
+++ b/Source/Pawnmorphs/Esoteria/ThingComps/AnimalSelectorComp.cs
@@ -146,7 +146,6 @@ namespace Pawnmorph.ThingComps
         private void GizmoAction()
         {
             OnClick?.Invoke(this);
-            Log.Message("Action!");
             var options = GetOptions.ToList();
             if (options.Count == 0) return; 
             Find.WindowStack.Add(new FloatMenu(options)); 

--- a/Source/Pawnmorphs/Esoteria/ThingComps/AnimalSelectorComp.cs
+++ b/Source/Pawnmorphs/Esoteria/ThingComps/AnimalSelectorComp.cs
@@ -28,7 +28,19 @@ namespace Pawnmorph.ThingComps
         /// <summary>
         /// Occurs when an animal is chosen.
         /// </summary>
-        public event AnimalChosenHandler AnimalChosen; 
+        public event AnimalChosenHandler AnimalChosen;
+
+
+        /// <summary>
+        /// Simple delegate for the <see cref="OnClick"/> event 
+        /// </summary>
+        /// <param name="comp">The <see cref="AnimalSelectorComp" /> that triggered the event.</param>
+        public delegate void OnClickHandler([NotNull] AnimalSelectorComp comp);
+
+        /// <summary>
+        /// Triggers when selector action is clicked but before anything else.
+        /// </summary>
+        public event OnClickHandler OnClick;
 
 
         private bool _enabled = true;
@@ -133,6 +145,8 @@ namespace Pawnmorph.ThingComps
 
         private void GizmoAction()
         {
+            OnClick?.Invoke(this);
+            Log.Message("Action!");
             var options = GetOptions.ToList();
             if (options.Count == 0) return; 
             Find.WindowStack.Add(new FloatMenu(options)); 

--- a/Source/Pawnmorphs/Esoteria/ThingComps/AnimalSelectorComp.cs
+++ b/Source/Pawnmorphs/Esoteria/ThingComps/AnimalSelectorComp.cs
@@ -53,6 +53,14 @@ namespace Pawnmorph.ThingComps
         public AnimalSelectorCompProperties Props => (AnimalSelectorCompProperties) props;
 
         /// <summary>
+        /// Gets or sets a filter to specify what should (true) or shouldn't (false) be selectable.
+        /// </summary>
+        /// <value>
+        /// The species filter.
+        /// </value>
+        [CanBeNull] public System.Func<PawnKindDef, bool> SpeciesFilter { get; set; } = null;
+
+        /// <summary>
         /// Gets the kind of the chosen.
         /// </summary>
         /// <value>
@@ -74,7 +82,8 @@ namespace Pawnmorph.ThingComps
                 {
                     var comp = PMComp;
 
-                    return Props.AllAnimals.Where(t => comp.TaggedAnimals.Contains(t) || Props.alwaysAvailable?.Contains(t) == true);
+                    // include if tagged or always available and filter returns true if any.
+                    return Props.AllAnimals.Where(t => (comp.TaggedAnimals.Contains(t) || Props.alwaysAvailable?.Contains(t) == true) && (SpeciesFilter == null || SpeciesFilter(t)));
                 }
 
                 return Props.AllAnimals;
@@ -138,8 +147,6 @@ namespace Pawnmorph.ThingComps
                     var tk = kind;
                     yield return new FloatMenuOption(tk.LabelCap, () => ChoseAnimal(tk));
                 }
-
-
             }
         }
 


### PR DESCRIPTION
Added Chaothrumbo as a species always available in chamber. 
Added optional filter to AnimalSelectorComp for custom filters on what should and shouldn't be selectable.
Chaothrumbo is now immediately selectable once you have an unstable genome available.

**Closing issues**
closes #445