### PR TITLE
Issue 462 - No reverter operation.

### DIFF
--- a/1.3/Defs/Drugs/Drugs_Reverter.xml
+++ b/1.3/Defs/Drugs/Drugs_Reverter.xml
@@ -13,10 +13,8 @@ Because reverter relies on the data stored within the mutagenic mechanites to re
 		</statBases>
 		<ingestible>
 			<outcomeDoers>
-				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediffAll">
-					<hediffDefs>
-						<li>StabiliserHigh</li>
-					</hediffDefs>
+				<li Class="Pawnmorph.IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>StabiliserHigh</hediffDef>
 					<severity>1.00</severity>
 				</li>
 				<li Class="Pawnmorph.IngestionOutcomeDoer_EsotericRevert"></li>

--- a/1.3/Defs/Recipes/Surgeries.xml
+++ b/1.3/Defs/Recipes/Surgeries.xml
@@ -8,6 +8,7 @@
         <workAmount>1000</workAmount>
         <anesthetize>false</anesthetize>
         <surgerySuccessChanceFactor>99999</surgerySuccessChanceFactor>
+        <dontShowIfAnyIngredientMissing>true</dontShowIfAnyIngredientMissing>
         <ingredients>
             <li>
                 <filter>
@@ -33,6 +34,7 @@
         <workAmount>1300</workAmount>
         <anesthetize>false</anesthetize>
         <surgerySuccessChanceFactor>99999</surgerySuccessChanceFactor>
+        <dontShowIfAnyIngredientMissing>true</dontShowIfAnyIngredientMissing>
         <ingredients>
             <li>
                 <filter>
@@ -44,9 +46,9 @@
             </li>
         </ingredients>
         <fixedIngredientFilter>
-            <thingDefs>
-                <li>PM_AdaptionCream</li>
-            </thingDefs>
+			<thingDefs>
+				<li>PM_AdaptionCream</li>
+			</thingDefs>
         </fixedIngredientFilter>
     </RecipeDef>
 </Defs>

--- a/Source/Pawnmorphs/Esoteria/Recipes/PMRecipeDefGenerator.cs
+++ b/Source/Pawnmorphs/Esoteria/Recipes/PMRecipeDefGenerator.cs
@@ -63,11 +63,9 @@ namespace Pawnmorph.Recipes
             List<ThingDef> items = new List<ThingDef>(); 
 
             items.AddRange(MorphDef.AllDefs.Select(m => m.injectorDef).Where(m => m != null && !m.IsDrug));
-            if(!PMThingDefOf.MechaniteSlurry.IsDrug)
-                items.Add(PMThingDefOf.MechaniteSlurry);
 
             //really hacky way of getting the serums but can't think of a better way 
-            var serums = DefDatabase<ThingDef>.AllDefs.Where(td => !td.IsDrug && td.ingestible?.outcomeDoers?.Any(o => o is IngestionOutcomeDoer_AddMorphTf || o is AddMorphCategoryTfHediff) == true);
+            var serums = DefDatabase<ThingDef>.AllDefs.Where(td => !td.IsDrug && td.ingestible?.outcomeDoers?.Any(o => o is IngestionOutcomeDoer_AddMorphTf || o is AddMorphCategoryTfHediff || o is IngestionOutcomeDoer_GiveHediff) == true);
 
             foreach (ThingDef thingDef in serums)
             {
@@ -93,7 +91,7 @@ namespace Pawnmorph.Recipes
                 anesthetize = false,
                 surgerySuccessChanceFactor = 99999f,
                 modContentPack = item.modContentPack,
-                workAmount = item.ingestible.baseIngestTicks,
+                workAmount = item.ingestible.baseIngestTicks,   
                 dontShowIfAnyIngredientMissing = true,
                 recipeUsers = new List<ThingDef>()
             };


### PR DESCRIPTION
Changed reverters to use IngestionOutcomeDoer_GiveHediff and included that in administer recipe generation.
Tested for duplicate administer recipes with seedpods and pills, but they are all considered Drugs and so not included.
MechaniteSlurry is still being included through GiveHediff.

Enabled hiding Halt and Adaptive cream operations if the ingredient is not available. That should make the list a lot shorter for morphs if you don't have some of them.

**Closing issues**
closes #462 