### PR TITLE
Issue 467 - Warning on eating grass.

### DIFF
--- a/Source/Pawnmorphs/Esoteria/HPatches/ForbidUtilityPatch.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/ForbidUtilityPatch.cs
@@ -1,0 +1,23 @@
+﻿using HarmonyLib;
+using RimWorld;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Verse;
+
+namespace Pawnmorph.HPatches
+{
+    [HarmonyPatch(typeof(ForbidUtility))]
+    internal class ForbidUtilityPatch
+    {
+        [HarmonyPatch(nameof(ForbidUtility.SetForbidden)), HarmonyPrefix]
+        static void SetForbidden(Thing t, ref bool value, ref bool warnOnFail)
+        {
+            warnOnFail = false;
+        }
+
+
+    }
+}

--- a/Source/Pawnmorphs/Esoteria/Pawnmorph.csproj
+++ b/Source/Pawnmorphs/Esoteria/Pawnmorph.csproj
@@ -470,6 +470,7 @@
     <Compile Include="HPatches\DrugPolicyPatches.cs" />
     <Compile Include="HPatches\DrupPolicyPatches.cs" />
     <Compile Include="HPatches\FoodUtilityPatches.cs" />
+    <Compile Include="HPatches\ForbidUtilityPatch.cs" />
     <Compile Include="HPatches\GatherableBodyResourcePatch.cs" />
     <Compile Include="HPatches\GiddyUpPatch.cs" />
     <Compile Include="HPatches\HediffDefPatches.cs" />


### PR DESCRIPTION
Added harmony patch to silence log warning happening every time a pawn tries to eat grass when the game then tries to forbid the grass.
It isn't a _good_ solution, but I can't think of any better approach since this is as far as I can tell all internal.

**Closing issues**
closes #467
