### PR TITLE
Issue 465 - Tag all mutations

### DIFF
--- a/Source/Pawnmorphs/Esoteria/DebugUtils/PMDebugActions.cs
+++ b/Source/Pawnmorphs/Esoteria/DebugUtils/PMDebugActions.cs
@@ -36,6 +36,19 @@ namespace Pawnmorph.DebugUtils
         {
             var cd = Find.World.GetComponent<ChamberDatabase>();
 
+            var mutations = DefDatabase<MutationDef>.AllDefs.Distinct();
+            foreach (MutationDef mutationDef in mutations)
+            {
+                if (cd.StoredMutations.Contains(mutationDef)) continue;
+                cd.AddToDatabase(mutationDef);
+            }
+        }
+
+        [DebugAction(category = PM_CATEGORY, actionType = DebugActionType.Action)]
+        static void TagAllGenomeMutations()
+        {
+            var cd = Find.World.GetComponent<ChamberDatabase>();
+
             var mutations = DefDatabase<MutationCategoryDef>.AllDefs.Where(d => d.genomeProvider)
                                                             .SelectMany(d => d.AllMutations)
                                                             .Distinct();
@@ -44,7 +57,6 @@ namespace Pawnmorph.DebugUtils
                 if (cd.StoredMutations.Contains(mutationDef)) continue;
                 cd.AddToDatabase(mutationDef);
             }
-
         }
 
         [DebugAction(category = PM_CATEGORY, actionType = DebugActionType.Action)]


### PR DESCRIPTION
Split tag all mutations debug action into "Tag All mutations" and "Tag all genome mutations" as the original was.

**Closing issues**
closes #465