### PR TITLE
Chao thrumbo chamber polishing

### DIFF
--- a/1.3/Defs/Chaocreatures/Chaothrumbo.xml
+++ b/1.3/Defs/Chaocreatures/Chaothrumbo.xml
@@ -177,6 +177,9 @@
 			</li>
 		</lifeStages>
 		<modExtensions>
+			<li Class="Pawnmorph.DefExtensions.AnimalSelectorOverrides">
+				<label>?????</label>
+			</li>
 			<li Class="Pawnmorph.Chambers.AnimalTfControllers.ChaoThrumbo"/>
 			<li Class="Pawnmorph.DefExtensions.FormerHumanSettings">
 				<backstory>FormerHumanChaomorph</backstory>

--- a/1.3/Defs/Things/Injectors.xml
+++ b/1.3/Defs/Things/Injectors.xml
@@ -66,6 +66,7 @@
             <li Class="Pawnmorph.Chambers.AnimalGenomeStorageCompProps">
                 <consumedOnUse>false</consumedOnUse>
                 <animal>PM_Chaothrumbo</animal>
+                <scanFailReason>This data is too corrupted to even attempt to scan.</scanFailReason>
             </li>
         </comps>
     </ThingDef>

--- a/1.3/Defs/Things/Injectors.xml
+++ b/1.3/Defs/Things/Injectors.xml
@@ -51,7 +51,7 @@
     <ThingDef ParentName="ArtifactBase">
         <defName>PM_ChaoThrumboGenome</defName>
         <label>Unstable genome</label>
-        <description>A strange and corrupted genome. Warning: Due to the extremely cryptic genome data contained within, the resulting animal may be far larger than the chambers can safely handle. Prepare accordingly.</description>
+        <description>A strange and corrupted genome. Having this interact with regular data storage would fry the system, and must be used directly in the chamber. Warning: Due to the extremely cryptic genome data contained within, the resulting animal may be far larger than the chambers can safely handle. Prepare accordingly.</description>
         <stackLimit>1</stackLimit>
         <tradeNeverStack>true</tradeNeverStack>
         <statBases>

--- a/Source/Pawnmorphs/Esoteria/Chambers/AnimalGenomeStorageComp.cs
+++ b/Source/Pawnmorphs/Esoteria/Chambers/AnimalGenomeStorageComp.cs
@@ -51,6 +51,14 @@ namespace Pawnmorph.Chambers
         {
             JobFailReason.Clear();
 
+            string scanFailReason = (props as AnimalGenomeStorageCompProps).scanFailReason;
+            if (string.IsNullOrWhiteSpace(scanFailReason) == false)
+            {
+                yield return new
+                    FloatMenuOption("CannotGenericWorkCustom".Translate(WORK_APPLY_GENOME.Translate(parent.Label)) + ": " + scanFailReason.CapitalizeFirst(), null);
+                yield break;
+            }
+
             var wComp = Find.World.GetComponent<ChamberDatabase>();
 
             if (selPawn.WorkTypeIsDisabled(WorkTypeDefOf.Research) || selPawn.WorkTagIsDisabled(WorkTags.Intellectual))
@@ -126,7 +134,12 @@ namespace Pawnmorph.Chambers
         /// <summary>
         /// if this thing is consumed on use
         /// </summary>
-        public bool consumedOnUse = true; 
+        public bool consumedOnUse = true;
+
+        /// <summary>
+        /// Special reason that block scanning if set.
+        /// </summary>
+        public string scanFailReason = null;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AnimalGenomeStorageCompProps"/> class.

--- a/Source/Pawnmorphs/Esoteria/Chambers/MutaChamber.cs
+++ b/Source/Pawnmorphs/Esoteria/Chambers/MutaChamber.cs
@@ -962,6 +962,7 @@ namespace Pawnmorph.Chambers
         {
             FillableDrawer?.Clear();
             SelectorComp.Enabled = false;
+            SelectorComp.ResetSelection();
             _innerState = ChamberState.WaitingForPawn;
             _currentUse = ChamberUse.Tf;
             _addedMutationData = null;

--- a/Source/Pawnmorphs/Esoteria/DefExtensions/AnimalSelectorOverrides.cs
+++ b/Source/Pawnmorphs/Esoteria/DefExtensions/AnimalSelectorOverrides.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Verse;
+
+namespace Pawnmorph.DefExtensions
+{
+    internal class AnimalSelectorOverrides : DefModExtension
+    {
+        public string label = null;
+    }
+}

--- a/Source/Pawnmorphs/Esoteria/Pawnmorph.csproj
+++ b/Source/Pawnmorphs/Esoteria/Pawnmorph.csproj
@@ -652,6 +652,7 @@
     <Compile Include="ThingComps\AddAspectEffectProps.cs" />
     <Compile Include="ThingComps\AlwaysMergedPawn.cs" />
     <Compile Include="ThingComps\AnimalSelectorComp.cs" />
+    <Compile Include="DefExtensions\AnimalSelectorOverrides.cs" />
     <Compile Include="ThingComps\DatabaseStorage.cs" />
     <Compile Include="ThingComps\DrawSecondChamberProperties.cs" />
     <Compile Include="ThingComps\DrawStoredPawnComp.cs" />

--- a/Source/Pawnmorphs/Esoteria/ThingComps/AnimalSelectorComp.cs
+++ b/Source/Pawnmorphs/Esoteria/ThingComps/AnimalSelectorComp.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
 using Pawnmorph.Chambers;
+using Pawnmorph.DefExtensions;
 using Pawnmorph.Utilities;
 using Verse;
 
@@ -143,6 +144,12 @@ namespace Pawnmorph.ThingComps
             }
         }
 
+        public void ResetSelection()
+        {
+            _cachedGizmo.defaultLabel = "none";
+            _cachedGizmo.icon = PMTextures.AnimalSelectorIcon;
+        }
+
         private void GizmoAction()
         {
             OnClick?.Invoke(this);
@@ -158,7 +165,14 @@ namespace Pawnmorph.ThingComps
                 foreach (PawnKindDef kind in AllAnimalsSelectable)
                 {
                     var tk = kind;
-                    yield return new FloatMenuOption(tk.LabelCap, () => ChoseAnimal(tk));
+                    string label;
+                    AnimalSelectorOverrides overrides = kind.GetModExtension<AnimalSelectorOverrides>();
+                    if (overrides != null && string.IsNullOrWhiteSpace(overrides.label) == false)
+                        label = overrides.label;
+                    else
+                        label = tk.LabelCap;
+
+                    yield return new FloatMenuOption(label, () => ChoseAnimal(tk));
                 }
             }
         }


### PR DESCRIPTION
Added a new extension to add an extendable way to modify how a PawnKind should appear in species selector.
Updated Unstable genome description.
Added selection reset method on SelectorComp.
Added special fail reason to unstable genome to allow hiding Chaothrumbo name.

![billede](https://user-images.githubusercontent.com/64704191/153490443-0e313315-69ba-45c7-b6ea-224865f74b92.png)
