### PR TITLE
Issue 471 - Databank power

### DIFF
--- a/Source/Pawnmorphs/Esoteria/Chambers/ChamberDatabase.cs
+++ b/Source/Pawnmorphs/Esoteria/Chambers/ChamberDatabase.cs
@@ -74,7 +74,7 @@ namespace Pawnmorph.Chambers
             get
             {
                 if (Settings.chamberDatabaseIgnoreStorageLimit) return int.MaxValue;
-                return TotalStorage - UsedStorage;
+                return TotalStorage - UsedStorage - _inactiveAmount;
             }
         }
 
@@ -139,7 +139,7 @@ namespace Pawnmorph.Chambers
         /// <value>
         ///     <c>true</c> if this instance can tag; otherwise, <c>false</c>.
         /// </value>
-        public bool CanTag => FreeStorage - _inactiveAmount > 0;
+        public bool CanTag => FreeStorage > 0;
 
 
         private PawnmorpherSettings Settings => LoadedModManager.GetMod<PawnmorpherMod>().GetSettings<PawnmorpherSettings>();


### PR DESCRIPTION
Changed inactive capacity to be subtracted from Free capacity
Databank will now immediately increase total storage without increasing free storage, which will then happen once it's powered.

**Closing issues**
closes #471

Empty database with 1 powered and 1 unpowered databank.
![billede](https://user-images.githubusercontent.com/64704191/153492607-63b189e2-7642-471b-960e-b816167771d1.png)
