### PR TITLE
Refactoring morph balance - Ratite

### DIFF
--- a/1.3/Defs/Morphs/Animal/Animal_Parts.xml
+++ b/1.3/Defs/Morphs/Animal/Animal_Parts.xml
@@ -13,15 +13,13 @@
 				<graphics>
 					<Muzzle>Parts/None/None</Muzzle>
 				</graphics>
+				<minSeverity>0</minSeverity>
 			</li>
 			<li Class="Pawnmorph.Hediffs.MutationStage">
 				<label>pressing out</label>
 				<key>pressing</key>
 				<description>[PAWN_nameDef]'s face seems to be swelling, the nose and jaw pressing out and looking decidedly more like an animal's.</description>
-				<graphics>
-					<Muzzle>Parts/Partials/PartialMuzzle/TinySnout</Muzzle>
-				</graphics>
-					<capMods>
+				<capMods>
 					<li>
 						<capacity>Talking</capacity>
 						<offset>-0.05</offset>
@@ -37,9 +35,6 @@
 				<label>growing</label>
 				<key>growing</key>
 				<description>[PAWN_nameDef]'s face continue to change, looking closer and closer to an animal.</description>
-				<graphics>
-					<Muzzle>Parts/Partials/PartialMuzzle/PartialMuzzle</Muzzle>
-				</graphics>
 				<capMods>
 					<li>
 						<capacity>Talking</capacity>

--- a/1.3/Defs/Morphs/Animal/Avian/Avian_Parts.xml
+++ b/1.3/Defs/Morphs/Animal/Avian/Avian_Parts.xml
@@ -1,10 +1,19 @@
 <Defs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../Schemas/MutationDef.xsd">
 	<Pawnmorph.Hediffs.MutationDef Name ="AvianJawPart" ParentName="AnimalJawPart" Abstract="true">
+		<categories>
+			<li>Avian</li>
+		</categories>
 	</Pawnmorph.Hediffs.MutationDef>
 
-	<Pawnmorph.Hediffs.MutationDef Name ="AvianEarPart" ParentName="AnimalEarPart" Abstract="true">
+	<Pawnmorph.Hediffs.MutationDef Name ="AvianEarPart" ParentName="PM_Earhole" Abstract="true">
+		<categories>
+			<li>Avian</li>
+		</categories>
 	</Pawnmorph.Hediffs.MutationDef>
 
 	<Pawnmorph.Hediffs.MutationDef Name ="AvianTailPart" ParentName="AnimalTailPart" Abstract="true">
+		<categories>
+			<li>Avian</li>
+		</categories>
 	</Pawnmorph.Hediffs.MutationDef>
 </Defs>

--- a/1.3/Defs/Morphs/Animal/Avian/Avian_Parts.xml
+++ b/1.3/Defs/Morphs/Animal/Avian/Avian_Parts.xml
@@ -1,19 +1,10 @@
 <Defs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../Schemas/MutationDef.xsd">
 	<Pawnmorph.Hediffs.MutationDef Name ="AvianJawPart" ParentName="AnimalJawPart" Abstract="true">
-		<categories>
-			<li>Avian</li>
-		</categories>
 	</Pawnmorph.Hediffs.MutationDef>
 
 	<Pawnmorph.Hediffs.MutationDef Name ="AvianEarPart" ParentName="PM_Earhole" Abstract="true">
-		<categories>
-			<li>Avian</li>
-		</categories>
 	</Pawnmorph.Hediffs.MutationDef>
 
 	<Pawnmorph.Hediffs.MutationDef Name ="AvianTailPart" ParentName="AnimalTailPart" Abstract="true">
-		<categories>
-			<li>Avian</li>
-		</categories>
 	</Pawnmorph.Hediffs.MutationDef>
 </Defs>

--- a/1.3/Defs/Morphs/Animal/Avian/Ratite/Cassowary/Cassowary_Parts.xml
+++ b/1.3/Defs/Morphs/Animal/Avian/Ratite/Cassowary/Cassowary_Parts.xml
@@ -13,36 +13,12 @@
 				<stageKey>adapting</stageKey>
 				<values>
 					<description>A beak graces [PAWN_nameDef]'s face, like that of a cassowary. A large ornament extends from the top of their beak to their head.</description>
-					<capMods>
-						<li>
-							<capacity>Talking</capacity>
-							<offset>-0.1</offset>
-						</li>
-						<li>
-							<capacity>Sight</capacity>
-							<offset>-0.20</offset>
-						</li>
-					</capMods>
-					<statOffsets>
-						<ArmorRating_Sharp>0.05</ArmorRating_Sharp>
-						<ArmorRating_Blunt>0.1</ArmorRating_Blunt>
-					</statOffsets>
 				</values>
 			</li>
 			<li function="modify">
 				<stageKey>adapted</stageKey>
 				<values>
 					<description>A beak graces [PAWN_nameDef]'s face, like that of a cassowary. A large ornament extends from the top of their beak to their head. [PAWN_nameDef] adapted to move their head around like a bird so the ornament doesn't block their vision.</description>
-					<capMods>
-						<li>
-							<capacity>Talking</capacity>
-							<offset>-0.1</offset>
-						</li>
-					</capMods>
-					<statOffsets>
-						<ArmorRating_Sharp>0.05</ArmorRating_Sharp>
-						<ArmorRating_Blunt>0.1</ArmorRating_Blunt>
-					</statOffsets>
 				</values>
 			</li>
 		</stagePatches>

--- a/1.3/Defs/Morphs/Animal/Avian/Ratite/Cassowary/Cassowary_Parts.xml
+++ b/1.3/Defs/Morphs/Animal/Avian/Ratite/Cassowary/Cassowary_Parts.xml
@@ -12,10 +12,6 @@
 			<li function="modify">
 				<stageKey>adapting</stageKey>
 				<values>
-					<!-- <graphics>
-						<Muzzle>Parts/Cassowary/Cassowary_Jaw</Muzzle>
-						<BirdJawOrnament>Parts/Cassowary/Cassowary_Ornament</BirdJawOrnament>
-					</graphics> -->
 					<description>A beak graces [PAWN_nameDef]'s face, like that of a cassowary. A large ornament extends from the top of their beak to their head.</description>
 					<capMods>
 						<li>
@@ -36,10 +32,6 @@
 			<li function="modify">
 				<stageKey>adapted</stageKey>
 				<values>
-					<!-- <graphics>
-						<Muzzle>Parts/Cassowary/Cassowary_Jaw</Muzzle>
-						<BirdJawOrnament>Parts/Cassowary/Cassowary_Ornament</BirdJawOrnament>
-					</graphics> -->
 					<description>A beak graces [PAWN_nameDef]'s face, like that of a cassowary. A large ornament extends from the top of their beak to their head. [PAWN_nameDef] adapted to move their head around like a bird so the ornament doesn't block their vision.</description>
 					<capMods>
 						<li>

--- a/1.3/Defs/Morphs/Animal/Avian/Ratite/Cassowary/Cassowary_Parts.xml
+++ b/1.3/Defs/Morphs/Animal/Avian/Ratite/Cassowary/Cassowary_Parts.xml
@@ -1,161 +1,79 @@
 <Defs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../Schemas/MutationDef.xsd">
-	<Pawnmorph.Hediffs.MutationDef Name="CassowaryPart" ParentName="PawnmorphPart" Abstract="true">
-		<classInfluence>CassowaryMorph</classInfluence>
-	</Pawnmorph.Hediffs.MutationDef>
-	<Pawnmorph.Hediffs.MutationDef ParentName="CassowaryPart">
+	<Pawnmorph.Hediffs.MutationDef ParentName="RatiteJawPart">
 		<defName>EtherCassowaryBeak</defName>
+		<classInfluence>CassowaryMorph</classInfluence>
 		<label>cassowary beak</label>
 		<description>The sharp beak of a cassowary.</description>
-		<parts>
-			<li>Jaw</li>
-		</parts>
-		<stages>
-			<li Class="Pawnmorph.Hediffs.MutationStage">
-				<labelOverride>pressing out</labelOverride>
-				<description>[PAWN_nameDef]'s teeth are merging into a keratinous beak, the nose and jaw pressing out and looking decidedly more avian.</description>
-				<minSeverity>0</minSeverity>
-				<capMods>
-					<li>
-						<capacity>Talking</capacity>
-						<offset>-0.1</offset>
-					</li>
-					<li>
-						<capacity>Eating</capacity>
-						<offset>0.1</offset>
-					</li>
-				</capMods>
+		<graphics>
+			<Muzzle>Parts/Cassowary/Cassowary_Jaw</Muzzle>
+			<BirdJawOrnament>Parts/Cassowary/Cassowary_Ornament</BirdJawOrnament>
+		</graphics>
+		<stagePatches>
+			<li function="modify">
+				<stageKey>adapting</stageKey>
+				<values>
+					<!-- <graphics>
+						<Muzzle>Parts/Cassowary/Cassowary_Jaw</Muzzle>
+						<BirdJawOrnament>Parts/Cassowary/Cassowary_Ornament</BirdJawOrnament>
+					</graphics> -->
+					<description>A beak graces [PAWN_nameDef]'s face, like that of a cassowary. A large ornament extends from the top of their beak to their head.</description>
+					<capMods>
+						<li>
+							<capacity>Talking</capacity>
+							<offset>-0.1</offset>
+						</li>
+						<li>
+							<capacity>Sight</capacity>
+							<offset>-0.20</offset>
+						</li>
+					</capMods>
+					<statOffsets>
+						<ArmorRating_Sharp>0.05</ArmorRating_Sharp>
+						<ArmorRating_Blunt>0.1</ArmorRating_Blunt>
+					</statOffsets>
+				</values>
 			</li>
-			<li Class="Pawnmorph.Hediffs.MutationStage">
-				<minSeverity>0.5</minSeverity>
-				<description>A beak graces [PAWN_nameDef]'s face, like that of a cassowary. A large ornament extends from the top of their beak to their head.</description>
-				<capMods>
-					<li>
-						<capacity>Talking</capacity>
-						<offset>-0.1</offset>
-					</li>
-					<li>
-						<capacity>Sight</capacity>
-						<offset>-0.20</offset>
-					</li>
-				</capMods>
-				<statOffsets>
-					<ArmorRating_Sharp>0.05</ArmorRating_Sharp>
-					<ArmorRating_Blunt>0.1</ArmorRating_Blunt>
-				</statOffsets>
+			<li function="modify">
+				<stageKey>adapted</stageKey>
+				<values>
+					<!-- <graphics>
+						<Muzzle>Parts/Cassowary/Cassowary_Jaw</Muzzle>
+						<BirdJawOrnament>Parts/Cassowary/Cassowary_Ornament</BirdJawOrnament>
+					</graphics> -->
+					<description>A beak graces [PAWN_nameDef]'s face, like that of a cassowary. A large ornament extends from the top of their beak to their head. [PAWN_nameDef] adapted to move their head around like a bird so the ornament doesn't block their vision.</description>
+					<capMods>
+						<li>
+							<capacity>Talking</capacity>
+							<offset>-0.1</offset>
+						</li>
+					</capMods>
+					<statOffsets>
+						<ArmorRating_Sharp>0.05</ArmorRating_Sharp>
+						<ArmorRating_Blunt>0.1</ArmorRating_Blunt>
+					</statOffsets>
+				</values>
 			</li>
-			<li Class="Pawnmorph.Hediffs.MutationStage">
-				<minSeverity>1</minSeverity>
-				<description>A beak graces [PAWN_nameDef]'s face, like that of a cassowary. A large ornament extends from the top of their beak to their head. [PAWN_nameDef] adapted to move their head around like a bird so the ornament doesn't block their vision.</description>
-				<label>adapted</label>
-				<capMods>
-					<li>
-						<capacity>Talking</capacity>
-						<offset>-0.1</offset>
-					</li>
-				</capMods>
-				<statOffsets>
-					<ArmorRating_Sharp>0.05</ArmorRating_Sharp>
-					<ArmorRating_Blunt>0.1</ArmorRating_Blunt>
-				</statOffsets>
-			</li>
-		</stages>
-		<comps>
-			<li Class="HediffCompProperties_VerbGiver">
-				<tools>
-					<li>
-						<label>beak</label>
-						<labelUsedInLogging>False</labelUsedInLogging>
-						<capacities>
-							<li>Bite</li>
-						</capacities>
-						<power>15.0</power>
-						<cooldownTime>1.5</cooldownTime>
-						<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-					</li>
-				</tools>
-			</li>
-			<li Class="Pawnmorph.Hediffs.CompProperties_MutationSeverityAdjust">
-				<severityPerDay>0.25</severityPerDay>
-			</li>
-		</comps>
+		</stagePatches>
 	</Pawnmorph.Hediffs.MutationDef>
-	<Pawnmorph.Hediffs.MutationDef ParentName="CassowaryPart">
+
+	<Pawnmorph.Hediffs.MutationDef ParentName="RatiteTailPart">
 		<defName>EtherCassowaryTailfeathers</defName>
+		<classInfluence>CassowaryMorph</classInfluence>
 		<description>A cascade of coarse feathers sprout from [PAWN_nameDef]'s tail.</description>
 		<label>cassowary tailfeathers</label>
-		<parts>
-			<li>Tail</li>
-			<li>MorphTail</li>
-		</parts>
-		<stages>
-			<li Class="Pawnmorph.Hediffs.MutationStage">
-				<statOffsets>
-					<ComfyTemperatureMin>-2</ComfyTemperatureMin>
-				</statOffsets>
-			</li>
-		</stages>
+		<graphics>
+			<Tail>Parts/Cassowary/Cassowary_Tail</Tail>
+		</graphics>
 	</Pawnmorph.Hediffs.MutationDef>
-	<Pawnmorph.Hediffs.MutationDef ParentName="CassowaryPart">
+
+	<Pawnmorph.Hediffs.MutationDef ParentName="RatiteEarPart">
+		<defName>EtherCassowaryEar</defName>
+		<classInfluence>CassowaryMorph</classInfluence>
+	</Pawnmorph.Hediffs.MutationDef>
+
+	<Pawnmorph.Hediffs.MutationDef ParentName="RatiteFootPart">
 		<defName>EtherCassowaryFoot</defName>
-		<label>clawed ratite</label>
+		<classInfluence>CassowaryMorph</classInfluence>
 		<description>A scary cassowary foot.</description>
-		<parts>
-			<li>Foot</li>
-		</parts>
-		<mutationTale>FeetBecomeTalons</mutationTale>
-		<mutationMemory>AvianFootMemory</mutationMemory>
-		<categories>
-			<li>Major</li>
-		</categories>
-		<stages>
-			<li Class="Pawnmorph.Hediffs.MutationStage">
-				<labelOverride>scaly</labelOverride>
-				<description>[PAWN_nameDef]'s foot appears to have broken out into hives, but doesn't seem to itch.</description>
-				<stopChance>0.3</stopChance>
-				<partEfficiencyOffset>-0.05</partEfficiencyOffset>
-			</li>
-			<li Class="Pawnmorph.Hediffs.MutationStage">
-				<minSeverity>0.5</minSeverity>
-				<labelOverride>toe-foot</labelOverride>
-				<description>[PAWN_nameDef]'s toes have become long, thick and scaly.</description>
-				<stopChance>0.3</stopChance>
-				<partEfficiencyOffset>-0.15</partEfficiencyOffset>
-			</li>
-			<li Class="Pawnmorph.Hediffs.MutationStage">
-				<minSeverity>1.0</minSeverity>
-				<description>[PAWN_nameDef]'s toes stretch out into long sharp talons that wouldn't be out of place on a dinosaur.</description>
-				<partEfficiencyOffset>-0.1</partEfficiencyOffset>
-				<statOffsets>
-					<MeleeDodgeChance>5</MeleeDodgeChance>
-				</statOffsets>
-			</li>
-			<li Class="Pawnmorph.Hediffs.MutationStage">
-				<minSeverity>1.5</minSeverity>
-				<label>paragon</label>
-				<description>[PAWN_nameDef]'s toes stretch out into long sharp talons that wouldn't be out of place on a dinosaur. The large talons somehow don't get in the way of movement.</description>
-				<statOffsets>
-					<MeleeDodgeChance>5</MeleeDodgeChance>
-				</statOffsets>
-			</li>
-		</stages>
-		<comps>
-			<li Class="HediffCompProperties_VerbGiver">
-				<tools>
-					<li>
-						<label>talons</label>
-						<labelUsedInLogging>False</labelUsedInLogging>
-						<capacities>
-							<li>Scratch</li>
-						</capacities>
-						<power>15.0</power>
-						<cooldownTime>1.5</cooldownTime>
-						<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-					</li>
-				</tools>
-			</li>
-			<li Class="Pawnmorph.Hediffs.CompProperties_MutationSeverityAdjust">
-				<severityPerDay>0.15</severityPerDay>
-			</li>
-		</comps>
 	</Pawnmorph.Hediffs.MutationDef>
 </Defs>

--- a/1.3/Defs/Morphs/Animal/Avian/Ratite/Emu/Emu_Parts.xml
+++ b/1.3/Defs/Morphs/Animal/Avian/Ratite/Emu/Emu_Parts.xml
@@ -1,90 +1,68 @@
 <Defs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../Schemas/MutationDef.xsd">
-	<Pawnmorph.Hediffs.MutationDef Name="EmuPart" ParentName="PawnmorphPart" Abstract="true">
-		<classInfluence>EmuMorph</classInfluence>
-	</Pawnmorph.Hediffs.MutationDef>
-	<Pawnmorph.Hediffs.MutationDef ParentName="EmuPart">
+	<Pawnmorph.Hediffs.MutationDef ParentName="RatiteJawPart">
 		<defName>EtherEmuBeak</defName>
+		<classInfluence>EmuMorph</classInfluence>
 		<label>emu beak</label>
 		<description>The pointy beak of an emu.</description>
-		<parts>
-			<li>Jaw</li>
-		</parts>
-		<stages>
-			<li Class="Pawnmorph.Hediffs.MutationStage">
-				<labelOverride>pressing out</labelOverride>
-				<description>[PAWN_nameDef]'s teeth are merging into a keratinous beak, the nose and jaw pressing out and looking decidedly more avian.</description>
-				<minSeverity>0</minSeverity>
-				<capMods>
-					<li>
-						<capacity>Talking</capacity>
-						<offset>-0.1</offset>
-					</li>
-					<li>
-						<capacity>Eating</capacity>
-						<offset>0.1</offset>
-					</li>
-				</capMods>
+		<graphics>
+			<Muzzle>Parts/Emu/Emu_Jaw</Muzzle>
+		</graphics>
+		<stagePatches>
+			<li function="modify">
+				<stageKey>adapting</stageKey>
+				<values>
+					<!-- <graphics>
+						<Muzzle>Parts/Emu/Emu_Jaw</Muzzle>
+					</graphics> -->
+					<description>A beak graces [PAWN_nameDef]'s face, like that of an emu.</description>
+					<capMods>
+						<li>
+							<capacity>Talking</capacity>
+							<offset>-0.50</offset>
+						</li>
+						<li>
+							<capacity>Eating</capacity>
+							<offset>-0.10</offset>
+						</li>
+					</capMods>
+				</values>
 			</li>
-			<li Class="Pawnmorph.Hediffs.MutationStage">
-				<minSeverity>0.5</minSeverity>
-				<description>A beak graces [PAWN_nameDef]'s face, like that of an emu.</description>
-				<capMods>
-					<li>
-						<capacity>Talking</capacity>
-						<offset>-0.50</offset>
-					</li>
-					<li>
-						<capacity>Eating</capacity>
-						<offset>-0.10</offset>
-					</li>
-				</capMods>
+			<li function="modify">
+				<stageKey>adapted</stageKey>
+				<values>
+					<!-- <graphics>
+						<Muzzle>Parts/Emu/Emu_Jaw</Muzzle>
+					</graphics> -->
+					<description>A beak graces [PAWN_nameDef]'s face, like that of an emu. Adaptation has made it less frustrating to talk and eat.</description>
+					<capMods>
+						<li>
+							<capacity>Talking</capacity>
+							<offset>-0.1</offset>
+						</li>
+					</capMods>
+				</values>
 			</li>
-			<li Class="Pawnmorph.Hediffs.MutationStage">
-				<minSeverity>1</minSeverity>
-				<description>A beak graces [PAWN_nameDef]'s face, like that of an emu. Adaptation has made it less frustrating to talk and eat.</description>
-				<label>adapted</label>
-				<capMods>
-					<li>
-						<capacity>Talking</capacity>
-						<offset>-0.1</offset>
-					</li>
-				</capMods>
-			</li>
-		</stages>
-		<comps>
-			<li Class="HediffCompProperties_VerbGiver">
-				<tools>
-					<li>
-						<label>beak</label>
-						<labelUsedInLogging>False</labelUsedInLogging>
-						<capacities>
-							<li>Bite</li>
-						</capacities>
-						<power>10.0</power>
-						<cooldownTime>1.5</cooldownTime>
-						<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-					</li>
-				</tools>
-			</li>
-			<li Class="Pawnmorph.Hediffs.CompProperties_MutationSeverityAdjust">
-				<severityPerDay>0.25</severityPerDay>
-			</li>
-		</comps>
+		</stagePatches>
 	</Pawnmorph.Hediffs.MutationDef>
-	<Pawnmorph.Hediffs.MutationDef ParentName="EmuPart">
+
+	<Pawnmorph.Hediffs.MutationDef ParentName="RatiteTailPart">
 		<defName>EtherEmuTailfeathers</defName>
+		<classInfluence>EmuMorph</classInfluence>
 		<description>A plume of coarse feathers sprout from a bird tail above [PAWN_nameDef]'s butt.</description>
 		<label>emu tailfeathers</label>
-		<parts>
-			<li>Tail</li>
-			<li>MorphTail</li>
-		</parts>
-		<stages>
-			<li Class="Pawnmorph.Hediffs.MutationStage">
-				<statOffsets>
-					<ComfyTemperatureMin>-2</ComfyTemperatureMin>
-				</statOffsets>
-			</li>
-		</stages>
+		<graphics>
+			<Tail>Parts/Emu/Emu_Tail</Tail>
+		</graphics>
+	</Pawnmorph.Hediffs.MutationDef>
+
+	<Pawnmorph.Hediffs.MutationDef ParentName="RatiteEarPart">
+		<defName>EtherEmuEar</defName>
+		<classInfluence>EmuMorph</classInfluence>
+	</Pawnmorph.Hediffs.MutationDef>
+
+	<Pawnmorph.Hediffs.MutationDef ParentName="RatiteFootPart">
+		<defName>EtherEmuFoot</defName>
+		<classInfluence>EmuMorph</classInfluence>
+		<description>A scary emu foot.</description>
 	</Pawnmorph.Hediffs.MutationDef>
 </Defs>

--- a/1.3/Defs/Morphs/Animal/Avian/Ratite/Emu/Emu_Parts.xml
+++ b/1.3/Defs/Morphs/Animal/Avian/Ratite/Emu/Emu_Parts.xml
@@ -11,9 +11,6 @@
 			<li function="modify">
 				<stageKey>adapting</stageKey>
 				<values>
-					<!-- <graphics>
-						<Muzzle>Parts/Emu/Emu_Jaw</Muzzle>
-					</graphics> -->
 					<description>A beak graces [PAWN_nameDef]'s face, like that of an emu.</description>
 					<capMods>
 						<li>
@@ -30,9 +27,6 @@
 			<li function="modify">
 				<stageKey>adapted</stageKey>
 				<values>
-					<!-- <graphics>
-						<Muzzle>Parts/Emu/Emu_Jaw</Muzzle>
-					</graphics> -->
 					<description>A beak graces [PAWN_nameDef]'s face, like that of an emu. Adaptation has made it less frustrating to talk and eat.</description>
 					<capMods>
 						<li>

--- a/1.3/Defs/Morphs/Animal/Avian/Ratite/Emu/Emu_Parts.xml
+++ b/1.3/Defs/Morphs/Animal/Avian/Ratite/Emu/Emu_Parts.xml
@@ -12,28 +12,12 @@
 				<stageKey>adapting</stageKey>
 				<values>
 					<description>A beak graces [PAWN_nameDef]'s face, like that of an emu.</description>
-					<capMods>
-						<li>
-							<capacity>Talking</capacity>
-							<offset>-0.50</offset>
-						</li>
-						<li>
-							<capacity>Eating</capacity>
-							<offset>-0.10</offset>
-						</li>
-					</capMods>
 				</values>
 			</li>
 			<li function="modify">
 				<stageKey>adapted</stageKey>
 				<values>
 					<description>A beak graces [PAWN_nameDef]'s face, like that of an emu. Adaptation has made it less frustrating to talk and eat.</description>
-					<capMods>
-						<li>
-							<capacity>Talking</capacity>
-							<offset>-0.1</offset>
-						</li>
-					</capMods>
 				</values>
 			</li>
 		</stagePatches>

--- a/1.3/Defs/Morphs/Animal/Avian/Ratite/Ostrich/Ostrich_Parts.xml
+++ b/1.3/Defs/Morphs/Animal/Avian/Ratite/Ostrich/Ostrich_Parts.xml
@@ -1,90 +1,69 @@
 <Defs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../Schemas/MutationDef.xsd">
-	<Pawnmorph.Hediffs.MutationDef Name="OstrichPart" ParentName="PawnmorphPart" Abstract="true">
-		<classInfluence>OstrichMorph</classInfluence>
-	</Pawnmorph.Hediffs.MutationDef>
-	<Pawnmorph.Hediffs.MutationDef ParentName="OstrichPart">
+	<Pawnmorph.Hediffs.MutationDef ParentName="RatiteJawPart">
 		<defName>EtherOstrichBeak</defName>
+		<classInfluence>OstrichMorph</classInfluence>
 		<label>ostrich beak</label>
 		<description>The pointy beak of an ostrich.</description>
-		<parts>
-			<li>Jaw</li>
-		</parts>
-		<stages>
-			<li Class="Pawnmorph.Hediffs.MutationStage">
-				<labelOverride>pressing out</labelOverride>
-				<description>[PAWN_nameDef]'s teeth are merging into a keratinous beak, the nose and jaw pressing out and looking decidedly more avian.</description>
-				<minSeverity>0</minSeverity>
-				<capMods>
-					<li>
-						<capacity>Talking</capacity>
-						<offset>-0.1</offset>
-					</li>
-					<li>
-						<capacity>Eating</capacity>
-						<offset>0.1</offset>
-					</li>
-				</capMods>
+		<graphics>
+			<Muzzle>Parts/Ostrich/Ostrich_Jaw</Muzzle>
+		</graphics>
+		<stagePatches>
+			<li function="modify">
+				<stageKey>adapting</stageKey>
+				<values>
+					<!-- <graphics>
+						<Muzzle>Parts/Ostrich/Ostrich_Jaw</Muzzle>
+					</graphics> -->
+					<description>A beak graces [PAWN_nameDef]'s face, like that of an ostrich.</description>
+					<capMods>
+						<li>
+							<capacity>Talking</capacity>
+							<offset>-0.50</offset>
+						</li>
+						<li>
+							<capacity>Eating</capacity>
+							<offset>-0.10</offset>
+						</li>
+					</capMods>
+				</values>
 			</li>
-			<li Class="Pawnmorph.Hediffs.MutationStage">
-				<minSeverity>0.5</minSeverity>
-				<description>A beak graces [PAWN_nameDef]'s face, like that of an ostrich.</description>
-				<capMods>
-					<li>
-						<capacity>Talking</capacity>
-						<offset>-0.50</offset>
-					</li>
-					<li>
-						<capacity>Eating</capacity>
-						<offset>-0.10</offset>
-					</li>
-				</capMods>
+			<li function="modify">
+				<stageKey>adapted</stageKey>
+				<values>
+					<!-- <graphics>
+						<Muzzle>Parts/Ostrich/Ostrich_Jaw</Muzzle>
+					</graphics> -->
+					<description>A beak graces [PAWN_nameDef]'s face, like that of an ostrich. Adaptation has made it less frustrating to talk and eat.</description>
+					<label>adapted</label>
+					<capMods>
+						<li>
+							<capacity>Talking</capacity>
+							<offset>-0.1</offset>
+						</li>
+					</capMods>
+				</values>
 			</li>
-			<li Class="Pawnmorph.Hediffs.MutationStage">
-				<minSeverity>1</minSeverity>
-				<description>A beak graces [PAWN_nameDef]'s face, like that of an ostrich. Adaptation has made it less frustrating to talk and eat.</description>
-				<label>adapted</label>
-				<capMods>
-					<li>
-						<capacity>Talking</capacity>
-						<offset>-0.1</offset>
-					</li>
-				</capMods>
-			</li>
-		</stages>
-		<comps>
-			<li Class="HediffCompProperties_VerbGiver">
-				<tools>
-					<li>
-						<label>beak</label>
-						<labelUsedInLogging>False</labelUsedInLogging>
-						<capacities>
-							<li>Bite</li>
-						</capacities>
-						<power>10.0</power>
-						<cooldownTime>1.5</cooldownTime>
-						<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
-					</li>
-				</tools>
-			</li>
-			<li Class="Pawnmorph.Hediffs.CompProperties_MutationSeverityAdjust">
-				<severityPerDay>0.25</severityPerDay>
-			</li>
-		</comps>
+		</stagePatches>
 	</Pawnmorph.Hediffs.MutationDef>
-	<Pawnmorph.Hediffs.MutationDef ParentName="OstrichPart">
+
+	<Pawnmorph.Hediffs.MutationDef ParentName="RatiteTailPart">
 		<defName>EtherOstrichTailfeathers</defName>
+		<classInfluence>OstrichMorph</classInfluence>
 		<description>A plume of coarse feathers sprout from a bird tail above [PAWN_nameDef]'s butt.</description>
 		<label>ostrich tailfeathers</label>
-		<parts>
-			<li>Tail</li>
-			<li>MorphTail</li>
-		</parts>
-		<stages>
-			<li Class="Pawnmorph.Hediffs.MutationStage">
-				<statOffsets>
-					<ComfyTemperatureMin>-2</ComfyTemperatureMin>
-				</statOffsets>
-			</li>
-		</stages>
+		<graphics>
+			<Tail>Parts/Ostrich/Ostrich_Tail</Tail>
+		</graphics>
+	</Pawnmorph.Hediffs.MutationDef>
+
+	<Pawnmorph.Hediffs.MutationDef ParentName="RatiteEarPart">
+		<defName>EtherOstrichEar</defName>
+		<classInfluence>OstrichMorph</classInfluence>
+	</Pawnmorph.Hediffs.MutationDef>
+
+	<Pawnmorph.Hediffs.MutationDef ParentName="RatiteFootPart">
+		<defName>EtherOstrichFoot</defName>
+		<classInfluence>OstrichMorph</classInfluence>
+		<description>A scary ostrich foot.</description>
 	</Pawnmorph.Hediffs.MutationDef>
 </Defs>

--- a/1.3/Defs/Morphs/Animal/Avian/Ratite/Ostrich/Ostrich_Parts.xml
+++ b/1.3/Defs/Morphs/Animal/Avian/Ratite/Ostrich/Ostrich_Parts.xml
@@ -11,9 +11,6 @@
 			<li function="modify">
 				<stageKey>adapting</stageKey>
 				<values>
-					<!-- <graphics>
-						<Muzzle>Parts/Ostrich/Ostrich_Jaw</Muzzle>
-					</graphics> -->
 					<description>A beak graces [PAWN_nameDef]'s face, like that of an ostrich.</description>
 					<capMods>
 						<li>
@@ -30,9 +27,6 @@
 			<li function="modify">
 				<stageKey>adapted</stageKey>
 				<values>
-					<!-- <graphics>
-						<Muzzle>Parts/Ostrich/Ostrich_Jaw</Muzzle>
-					</graphics> -->
 					<description>A beak graces [PAWN_nameDef]'s face, like that of an ostrich. Adaptation has made it less frustrating to talk and eat.</description>
 					<label>adapted</label>
 					<capMods>

--- a/1.3/Defs/Morphs/Animal/Avian/Ratite/Ostrich/Ostrich_Parts.xml
+++ b/1.3/Defs/Morphs/Animal/Avian/Ratite/Ostrich/Ostrich_Parts.xml
@@ -12,29 +12,12 @@
 				<stageKey>adapting</stageKey>
 				<values>
 					<description>A beak graces [PAWN_nameDef]'s face, like that of an ostrich.</description>
-					<capMods>
-						<li>
-							<capacity>Talking</capacity>
-							<offset>-0.50</offset>
-						</li>
-						<li>
-							<capacity>Eating</capacity>
-							<offset>-0.10</offset>
-						</li>
-					</capMods>
 				</values>
 			</li>
 			<li function="modify">
 				<stageKey>adapted</stageKey>
 				<values>
 					<description>A beak graces [PAWN_nameDef]'s face, like that of an ostrich. Adaptation has made it less frustrating to talk and eat.</description>
-					<label>adapted</label>
-					<capMods>
-						<li>
-							<capacity>Talking</capacity>
-							<offset>-0.1</offset>
-						</li>
-					</capMods>
 				</values>
 			</li>
 		</stagePatches>

--- a/1.3/Defs/Morphs/Animal/Avian/Ratite/Ratite_Parts.xml
+++ b/1.3/Defs/Morphs/Animal/Avian/Ratite/Ratite_Parts.xml
@@ -8,6 +8,15 @@
 				<stageKey>pressing</stageKey>
 				<values>
 					<graphics>
+						<Muzzle>Parts/None/None</Muzzle>
+					</graphics>
+					<description>[PAWN_nameDef]'s teeth are merging into a keratinous beak, the nose and jaw pressing out and looking decidedly more avian.</description>
+				</values>
+			</li>
+			<li function="modify">
+				<stageKey>growing</stageKey>
+				<values>
+					<graphics>
 						<Muzzle>Parts/Partials/PartialMuzzle/PartialBeak</Muzzle>
 					</graphics>
 					<description>[PAWN_nameDef]'s teeth are merging into a keratinous beak, the nose and jaw pressing out and looking decidedly more avian.</description>
@@ -59,7 +68,7 @@
 	</Pawnmorph.Hediffs.MutationDef>
 
 	<!-- Moved from inside cassowary to here. -->
-	<Pawnmorph.Hediffs.MutationDef Name ="RatiteFootPart" ParentName="PawnmorphPart">
+	<Pawnmorph.Hediffs.MutationDef Name ="RatiteFootPart" ParentName="PawnmorphPart" abstract="true">
 		<defName>EtherRatiteFoot</defName>
 		<description>A deadly bird foot.</description>
 		<label>clawed ratite</label>

--- a/1.3/Defs/Morphs/Animal/Avian/Ratite/Ratite_Parts.xml
+++ b/1.3/Defs/Morphs/Animal/Avian/Ratite/Ratite_Parts.xml
@@ -1,10 +1,125 @@
 <Defs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../Schemas/MutationDef.xsd">
 	<Pawnmorph.Hediffs.MutationDef Name ="RatiteJawPart" ParentName="AvianJawPart" Abstract="true">
+		<defName>EtherRatiteBeak</defName>
+		<description>A beak</description>
+		<mutationMemory>EtherBeak</mutationMemory>
+		<stagePatches>
+			<li function="modify">
+				<stageKey>pressing</stageKey>
+				<values>
+					<graphics>
+						<Muzzle>Parts/Partials/PartialMuzzle/PartialBeak</Muzzle>
+					</graphics>
+					<description>[PAWN_nameDef]'s teeth are merging into a keratinous beak, the nose and jaw pressing out and looking decidedly more avian.</description>
+				</values>
+			</li>
+		</stagePatches>
+		<comps>
+			<li Class="HediffCompProperties_VerbGiver">
+				<tools>
+					<li>
+						<label>teeth</label>
+						<labelUsedInLogging>False</labelUsedInLogging>
+						<capacities>
+							<li>Bite</li>
+						</capacities>
+						<power>20.0</power>
+						<cooldownTime>1.5</cooldownTime>
+						<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+					</li>
+				</tools>
+			</li>
+		</comps>
 	</Pawnmorph.Hediffs.MutationDef>
 
 	<Pawnmorph.Hediffs.MutationDef Name ="RatiteEarPart" ParentName="AvianEarPart" Abstract="true">
+		<!-- TODO -->
+		<defName>EtherRatiteEar</defName>
+		<description>An ear hole.</description>
 	</Pawnmorph.Hediffs.MutationDef>
 
 	<Pawnmorph.Hediffs.MutationDef Name ="RatiteTailPart" ParentName="AvianTailPart" Abstract="true">
+		<defName>EtherRatiteTailfeathers</defName>
+		<description>A plume of coarse feathers sprout from a bird tail above [PAWN_nameDef]'s butt.</description>
+		<label>Tailfeathers</label>
+		<parts>
+			<li>Tail</li>
+			<li>MorphTail</li>
+		</parts>
+		<stagePatches>
+			<li function="modify">
+				<stageKey>grown</stageKey>
+				<values>
+					<statOffsets>
+						<ComfyTemperatureMin>-2</ComfyTemperatureMin>
+					</statOffsets>
+				</values>
+			</li>
+		</stagePatches>
+	</Pawnmorph.Hediffs.MutationDef>
+
+	<!-- Moved from inside cassowary to here. -->
+	<Pawnmorph.Hediffs.MutationDef Name ="RatiteFootPart" ParentName="PawnmorphPart">
+		<defName>EtherRatiteFoot</defName>
+		<description>A deadly bird foot.</description>
+		<label>clawed ratite</label>
+		<parts>
+			<li>Foot</li>
+		</parts>
+		<mutationTale>FeetBecomeTalons</mutationTale>
+		<mutationMemory>AvianFootMemory</mutationMemory>
+		<categories>
+			<li>Major</li>
+		</categories>
+		<stages>
+			<li Class="Pawnmorph.Hediffs.MutationStage">
+				<labelOverride>scaly</labelOverride>
+				<description>[PAWN_nameDef]'s foot appears to have broken out into hives, but doesn't seem to itch.</description>
+				<stopChance>0.3</stopChance>
+				<partEfficiencyOffset>-0.05</partEfficiencyOffset>
+			</li>
+			<li Class="Pawnmorph.Hediffs.MutationStage">
+				<minSeverity>0.5</minSeverity>
+				<labelOverride>toe-foot</labelOverride>
+				<description>[PAWN_nameDef]'s toes have become long, thick and scaly.</description>
+				<stopChance>0.3</stopChance>
+				<partEfficiencyOffset>-0.15</partEfficiencyOffset>
+			</li>
+			<li Class="Pawnmorph.Hediffs.MutationStage">
+				<minSeverity>1.0</minSeverity>
+				<description>[PAWN_nameDef]'s toes stretch out into long sharp talons that wouldn't be out of place on a dinosaur.</description>
+				<partEfficiencyOffset>-0.1</partEfficiencyOffset>
+				<statOffsets>
+					<MeleeDodgeChance>5</MeleeDodgeChance>
+				</statOffsets>
+			</li>
+			<li Class="Pawnmorph.Hediffs.MutationStage">
+				<minSeverity>1.5</minSeverity>
+				<label>paragon</label>
+				<description>[PAWN_nameDef]'s toes stretch out into long sharp talons that wouldn't be out of place on a dinosaur. The large talons somehow don't get in the way of movement.</description>
+				<statOffsets>
+					<MeleeDodgeChance>5</MeleeDodgeChance>
+				</statOffsets>
+			</li>
+		</stages>
+		<comps>
+			<li Class="HediffCompProperties_VerbGiver">
+				<tools>
+					<li>
+						<label>talons</label>
+						<labelUsedInLogging>False</labelUsedInLogging>
+						<capacities>
+							<li>Scratch</li>
+						</capacities>
+						<power>15.0</power>
+						<cooldownTime>1.5</cooldownTime>
+						<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+					</li>
+				</tools>
+			</li>
+			<li Class="Pawnmorph.Hediffs.CompProperties_MutationSeverityAdjust">
+				<severityPerDay>0.15</severityPerDay>
+			</li>
+		</comps>
 	</Pawnmorph.Hediffs.MutationDef>
 </Defs>

--- a/1.3/Defs/Mutations/AbstractMutations.xml
+++ b/1.3/Defs/Mutations/AbstractMutations.xml
@@ -57,23 +57,24 @@
 				<label>initial</label>
 				<key>initial</key>
 				<description>[PAWN_nameDef]'s ears feel itchy, but nothing suspicious for now.</description>
+                <minSeverity>0</minSeverity>
 			</li>
             <li Class="Pawnmorph.Hediffs.MutationStage">
                 <label>shrinking</label>
 				<key>initial</key>
-                <painOffset>0.1</painOffset>
                 <description>[PAWN_nameDef]'s ears are shrinking.</description>
+                <minSeverity>0.1</minSeverity>
             </li>
             <li Class="Pawnmorph.Hediffs.MutationStage">
                 <label>flat</label>
 				<key>flat</key>
-                <minSeverity>0.5</minSeverity>
                 <description>[PAWN_nameDef] no longer has any visible ears.</description>
+                <minSeverity>0.5</minSeverity>
             </li>
             <li Class="Pawnmorph.Hediffs.MutationStage">
 				<key>adapting</key>
-                <minSeverity>1</minSeverity>
                 <description>[PAWN_nameDef] now has ear holes.</description>
+                <minSeverity>1</minSeverity>
             </li>
         </stages>
 		<comps>

--- a/1.3/Defs/Mutations/AbstractMutations.xml
+++ b/1.3/Defs/Mutations/AbstractMutations.xml
@@ -42,4 +42,48 @@
             </li>
         </comps>
     </Pawnmorph.Hediffs.MutationDef>
+
+    <Pawnmorph.Hediffs.MutationDef ParentName="PawnmorphPart" Name="PM_Earhole" Abstract="true">
+        <label>Ear hole</label>
+        <description>[PAWN_nameDef]'s chest has bulked up significantly, making it not only stronger but more resistant to damage</description>
+        <stages>
+            <li Class="Pawnmorph.Hediffs.MutationStage">
+                <labelOverride>growing</labelOverride>
+                <painOffset>0.1</painOffset>
+            </li>
+            <li Class="Pawnmorph.Hediffs.MutationStage">
+                <labelOverride>growing</labelOverride>
+                <painOffset>0.1</painOffset>
+                <minSeverity>0.1</minSeverity>
+                <healthOffset>1</healthOffset>
+                <statOffsets>
+                    <CarryingCapacity>5</CarryingCapacity>
+                </statOffsets>
+            </li>
+            <li Class="Pawnmorph.Hediffs.MutationStage">
+                <labelOverride>growing</labelOverride>
+                <painOffset>0.05</painOffset>
+                <minSeverity>0.5</minSeverity>
+                <healthOffset>2</healthOffset>
+                <statOffsets>
+                    <CarryingCapacity>10</CarryingCapacity>
+                </statOffsets>
+            </li>
+            <li Class="Pawnmorph.Hediffs.MutationStage">
+                <minSeverity>1</minSeverity>
+                <healthOffset>4</healthOffset>
+                <statOffsets>
+                    <CarryingCapacity>15</CarryingCapacity>
+                </statOffsets>
+            </li>
+        </stages>
+        <parts>
+            <li>Torso</li>
+        </parts>
+        <comps>
+            <li Class="Pawnmorph.Hediffs.CompProperties_MutationSeverityAdjust">
+                <severityPerDay>0.15</severityPerDay>
+            </li>
+        </comps>
+    </Pawnmorph.Hediffs.MutationDef>
 </Defs>

--- a/1.3/Defs/Mutations/AbstractMutations.xml
+++ b/1.3/Defs/Mutations/AbstractMutations.xml
@@ -45,45 +45,44 @@
 
     <Pawnmorph.Hediffs.MutationDef ParentName="PawnmorphPart" Name="PM_Earhole" Abstract="true">
         <label>Ear hole</label>
-        <description>[PAWN_nameDef]'s chest has bulked up significantly, making it not only stronger but more resistant to damage</description>
+        <description>TODO</description>
+		<graphics>
+			<LeftEarBehind>Parts/None/None</LeftEarBehind>
+			<RightEar>Parts/None/None</RightEar>
+			<RightEarBehindHead>Parts/None/None</RightEarBehindHead>
+			<LeftEar>Parts/None/None</LeftEar>
+		</graphics>
         <stages>
+			<li Class="Pawnmorph.Hediffs.MutationStage">
+				<label>initial</label>
+				<key>initial</key>
+				<description>[PAWN_nameDef]'s ears feel itchy, but nothing suspicious for now.</description>
+			</li>
             <li Class="Pawnmorph.Hediffs.MutationStage">
-                <labelOverride>growing</labelOverride>
+                <label>shrinking</label>
+				<key>initial</key>
                 <painOffset>0.1</painOffset>
+                <description>[PAWN_nameDef]'s ears are shrinking.</description>
             </li>
             <li Class="Pawnmorph.Hediffs.MutationStage">
-                <labelOverride>growing</labelOverride>
-                <painOffset>0.1</painOffset>
-                <minSeverity>0.1</minSeverity>
-                <healthOffset>1</healthOffset>
-                <statOffsets>
-                    <CarryingCapacity>5</CarryingCapacity>
-                </statOffsets>
-            </li>
-            <li Class="Pawnmorph.Hediffs.MutationStage">
-                <labelOverride>growing</labelOverride>
-                <painOffset>0.05</painOffset>
+                <label>flat</label>
+				<key>flat</key>
                 <minSeverity>0.5</minSeverity>
-                <healthOffset>2</healthOffset>
-                <statOffsets>
-                    <CarryingCapacity>10</CarryingCapacity>
-                </statOffsets>
+                <description>[PAWN_nameDef] no longer has any visible ears.</description>
             </li>
             <li Class="Pawnmorph.Hediffs.MutationStage">
+				<key>adapting</key>
                 <minSeverity>1</minSeverity>
-                <healthOffset>4</healthOffset>
-                <statOffsets>
-                    <CarryingCapacity>15</CarryingCapacity>
-                </statOffsets>
+                <description>[PAWN_nameDef] now has ear holes.</description>
             </li>
         </stages>
-        <parts>
-            <li>Torso</li>
-        </parts>
-        <comps>
-            <li Class="Pawnmorph.Hediffs.CompProperties_MutationSeverityAdjust">
-                <severityPerDay>0.15</severityPerDay>
-            </li>
-        </comps>
+		<comps>
+			<li Class="Pawnmorph.Hediffs.CompProperties_MutationSeverityAdjust">
+				<severityPerDay>0.8</severityPerDay>
+			</li>
+		</comps>
+		<parts>
+			<li>Ear</li>
+		</parts>
     </Pawnmorph.Hediffs.MutationDef>
 </Defs>

--- a/1.3/Patches/Core_HumanHedifGraphics.xml
+++ b/1.3/Patches/Core_HumanHedifGraphics.xml
@@ -85,30 +85,6 @@
 							<a0.0>Parts/None/None</a0.0>
 						</severity>
 					</EtherTurkeyBeak>
-					<EtherEmuBeak>
-						<path>Parts/Emu/Emu_Jaw</path>
-						<severity>
-							<a0.5>Parts/Emu/Emu_Jaw</a0.5>
-							<a0.1>Parts/Partials/PartialMuzzle/PartialBeak</a0.1>
-							<a0.0>Parts/None/None</a0.0>
-						</severity>
-					</EtherEmuBeak>
-					<EtherOstrichBeak>
-						<path>Parts/Ostrich/Ostrich_Jaw</path>
-						<severity>
-							<a0.5>Parts/Ostrich/Ostrich_Jaw</a0.5>
-							<a0.1>Parts/Partials/PartialMuzzle/PartialBeak</a0.1>
-							<a0.0>Parts/None/None</a0.0>
-						</severity>
-					</EtherOstrichBeak>
-					<EtherCassowaryBeak>
-						<path>Parts/Cassowary/Cassowary_Jaw</path>
-						<severity>
-							<a0.5>Parts/Cassowary/Cassowary_Jaw</a0.5>
-							<a0.1>Parts/Partials/PartialMuzzle/PartialBeak</a0.1>
-							<a0.0>Parts/None/None</a0.0>
-						</severity>
-					</EtherCassowaryBeak>
 					<EtherDuckBeak>
 						<path>Parts/Duck/Duck_Jaw</path>
 						<severity>
@@ -243,13 +219,6 @@
 					<li>FullHead</li>
 				</hiddenUnderApparelFor>
 				<hediffGraphics>
-					<EtherCassowaryBeak>
-						<path>Parts/Cassowary/Cassowary_Ornament</path>
-						<severity>
-							<a0.5>Parts/Cassowary/Cassowary_Ornament</a0.5>
-							<a0.0>Parts/None/None</a0.0>
-						</severity>
-					</EtherCassowaryBeak>
 					<EtherMuffaloSnout>
 						<path>Parts/Muffalo/Muffalo_Headfloof_B</path>
 						<severity>
@@ -462,9 +431,6 @@
 					<EtherRoughCurlyTail>Parts/Boar/Boar_Tail</EtherRoughCurlyTail>
 					<EtherTailfeathers>Parts/chickenface/chickentail</EtherTailfeathers>
 					<EtherTurkeyTailfeathers>Parts/Turkey/Turkey_Tail</EtherTurkeyTailfeathers>
-					<EtherEmuTailfeathers>Parts/Emu/Emu_Tail</EtherEmuTailfeathers>
-					<EtherOstrichTailfeathers>Parts/Ostrich/Ostrich_Tail</EtherOstrichTailfeathers>
-					<EtherCassowaryTailfeathers>Parts/Cassowary/Cassowary_Tail</EtherCassowaryTailfeathers>
 					<EtherGooseTailfeathers>Parts/Goose/Goose_Tail</EtherGooseTailfeathers>
 					<EtherDuckTailfeathers>Parts/Duck/Duck_Tail</EtherDuckTailfeathers>
 					<EtherCowTail>Parts/cowface/cowtail</EtherCowTail>

--- a/Source/Pawnmorphs/Esoteria/PawnmorpherModInit.cs
+++ b/Source/Pawnmorphs/Esoteria/PawnmorpherModInit.cs
@@ -135,15 +135,11 @@ namespace Pawnmorph
                     anchors.Clear();
                     anchors.AddRange(lq.Distinct()); //make sure the list is distinct 
 
+                    mutationStages.Clear();
+                    mutationStages.AddRange(mutation.stages.MakeSafe().OfType<MutationStage>());
+
                     foreach (var anchor in anchors)
                     {
-                        
-                        mutationStages.Clear();
-                        mutationStages.AddRange(mutation.stages.MakeSafe() //grab all mutations stages with graphics that pertain to this a
-                                                        .OfType<MutationStage>()
-                                                        .Where(m => m.graphics.MakeSafe()
-                                                                     .Any(s => s.anchorID == anchor)));
-
                         if (!dict.TryGetValue(anchor, out TaggedBodyAddon addon))
                         {
                             Log.Error($"unable to find body addon on human with anchor id \"{anchor}\"!");
@@ -197,11 +193,11 @@ namespace Pawnmorph
         private static HediffGraphic GenerateGraphicsFor([NotNull] List<MutationStage> mutationStages, [NotNull] MutationDef mutation, string anchorID)
         {
             List<MutationGraphicsData> mainData = mutation.graphics.MakeSafe().Where(g => g.anchorID == anchorID).ToList();
+
             List<(string path, float minSeverity)> stageData = mutationStages.Where(s => !s.graphics.NullOrEmpty())
-                                                                             .SelectMany(s => s.graphics.Where(g => g.anchorID
-                                                                                                                 == anchorID)
-                                                                                               .Select(g => (g.path,
-                                                                                                             s.minSeverity)))
+                                                                             .SelectMany(s => s.graphics
+                                                                                .Where(g => g.anchorID == anchorID)
+                                                                                .Select(g => (g.path, s.minSeverity)))
                                                                              .ToList();
 
             string mainPath = mainData.FirstOrDefault()?.path ?? stageData.FirstOrDefault().path; //get the main path 
@@ -224,14 +220,24 @@ namespace Pawnmorph
             for (var index = mutationStages.Count - 1; index >= 0; index--)
             {
                 MutationStage stage = mutationStages[index];
-                MutationGraphicsData
-                    graphic = stage.graphics.MakeSafe()
-                                   .FirstOrDefault(s => s.anchorID
-                                                     == anchorID); //fill the severity graphics if they are present in descending order 
-                if (graphic != null)
+
+                string path = null;
+                if (stage.graphics != null)
+                {
+                    // Hide anchor graphics from mutation layer if not defined on specific stage.
+                    path = stage.graphics.FirstOrDefault(s => s.anchorID == anchorID)?.path ?? "Parts/None/None";
+                }
+                else
+                {
+                    // If no graphics are defined on stage then default to whatever is set on mutation.
+                    path = mainPath;
+                }
+
+                // fill the severity graphics if they are present in descending order
+                if (string.IsNullOrWhiteSpace(path) == false)
                     severityLst.Add(new AlienPartGenerator.BodyAddonHediffSeverityGraphic
                     {
-                        path = graphic.path,
+                        path = path,
                         severity = stage.minSeverity
                     });
             }


### PR DESCRIPTION
Updated graphics processing to use mutation graphics if no <graphics> element is defined on stage.
If the mutation has an anchor defined that current stage *with* graphics element does not, then it assigns None texture to hide it.

Added generic ear hole and avian inherited.
Finished Ratite.