### PR TITLE
Allow multiple ClassInfluences in MutationDef

### DIFF
--- a/1.3/Defs/Morphs/Animal/PawFooted/Carnivora/Canid/Lupine/Arctic Wolf/ArcticWolf_Parts.xml
+++ b/1.3/Defs/Morphs/Animal/PawFooted/Carnivora/Canid/Lupine/Arctic Wolf/ArcticWolf_Parts.xml
@@ -28,11 +28,11 @@
 			<Tail>Parts/wolfface/wolftail</Tail>
 		</graphics>
 	</Pawnmorph.Hediffs.MutationDef>
-
+<!-- 
 	<Pawnmorph.Hediffs.MutationDef ParentName="PM_ArcticFurBase">
 		<defName>EtherArcticWolfFur</defName>
 		<label>arctic wolf fur</label>
 		<classInfluence>ArcticWolfMorph</classInfluence>
-	</Pawnmorph.Hediffs.MutationDef>
+	</Pawnmorph.Hediffs.MutationDef> -->
 	
 </Defs>

--- a/1.3/Defs/Morphs/Animal/PawFooted/Carnivora/Vulpine/Arctic Fox/ArcticFox_Parts.xml
+++ b/1.3/Defs/Morphs/Animal/PawFooted/Carnivora/Vulpine/Arctic Fox/ArcticFox_Parts.xml
@@ -28,10 +28,10 @@
 			<Tail>Parts/FoxArctic/ArcticFox_Tail</Tail>
 		</graphics>
 	</Pawnmorph.Hediffs.MutationDef>
-	
+<!-- 	
 	<Pawnmorph.Hediffs.MutationDef ParentName="PM_ArcticFurBase">
 		<defName>EtherArcticFoxFur</defName>
 		<label>arctic fox fur</label>
 		<classInfluence>ArcticFoxMorph</classInfluence>
-	</Pawnmorph.Hediffs.MutationDef>
+	</Pawnmorph.Hediffs.MutationDef> -->
 </Defs>

--- a/1.3/Defs/Morphs/Animal/PawFooted/Leporid/Snowhare/Snowhare_Parts.xml
+++ b/1.3/Defs/Morphs/Animal/PawFooted/Leporid/Snowhare/Snowhare_Parts.xml
@@ -28,10 +28,10 @@
 			<Tail>Parts/Hare/Hare_Tail</Tail>
 		</graphics>
 	</Pawnmorph.Hediffs.MutationDef>
-	
+<!-- 	
 	<Pawnmorph.Hediffs.MutationDef ParentName="PM_ArcticFurBase">
 		<defName>EtherSnowhareFur</defName>
 		<label>snow hare fur</label>
 		<classInfluence>SnowhareMorph</classInfluence>
-	</Pawnmorph.Hediffs.MutationDef>
+	</Pawnmorph.Hediffs.MutationDef> -->
 </Defs>

--- a/1.3/Defs/Morphs/Animal/PawFooted/Ursine/Polar Bear/PolarBear_Parts.xml
+++ b/1.3/Defs/Morphs/Animal/PawFooted/Ursine/Polar Bear/PolarBear_Parts.xml
@@ -28,10 +28,10 @@
 			<Tail>Parts/bearface/beartail</Tail>
 		</graphics>
 	</Pawnmorph.Hediffs.MutationDef>
-	
+<!-- 	
 	<Pawnmorph.Hediffs.MutationDef ParentName="PM_ArcticFurBase">
 		<defName>EtherPolarBearFur</defName>
 		<label>polar bear fur</label>
 		<classInfluence>PolarBearMorph</classInfluence>
-	</Pawnmorph.Hediffs.MutationDef>
+	</Pawnmorph.Hediffs.MutationDef> -->
 </Defs>

--- a/1.3/Defs/Mutations/SkinMutations.xml
+++ b/1.3/Defs/Mutations/SkinMutations.xml
@@ -61,7 +61,15 @@
 
 	<!-- Arctic fur -->
 	
-	<Pawnmorph.Hediffs.MutationDef Name="PM_ArcticFurBase" ParentName="FurredLimb" Abstract="true">
+	<Pawnmorph.Hediffs.MutationDef Name="PM_ArcticFur" ParentName="FurredLimb">
+		<defName>ArcticWolfFur</defName>
+		<label>arctic fur</label>
+		<classInfluences>
+			<li>ArcticWolfMorph</li>
+			<li>ArcticFoxMorph</li>
+			<li>SnowhareMorph</li>
+			<li>PolarBearMorph</li>
+		</classInfluences>
 		<stagePatches>
 			<li function="modify">
 				<stageKey>light</stageKey>

--- a/Schemas/MutationDef.xsd
+++ b/Schemas/MutationDef.xsd
@@ -75,6 +75,7 @@
             <xs:element name="mutationTale" minOccurs="0" type="xs:string" />
             <xs:element name="isTaggable" minOccurs="0" type="xs:boolean" />
             <xs:element name="classInfluence" minOccurs="0" type="xs:string" />
+            <xs:element name="classInfluences" minOccurs="0" type="ListOfStrings" />
             <xs:element name="mutationMemory" minOccurs="0" type="xs:string" />
             <xs:element name="memoryIgnoresLimit" minOccurs="0" type="xs:boolean" />
             <xs:element name="mutationLogRulePack" minOccurs="0" type="xs:string" />

--- a/Source/Pawnmorphs/Esoteria/AnimalClassDef.cs
+++ b/Source/Pawnmorphs/Esoteria/AnimalClassDef.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using JetBrains.Annotations;
 using Pawnmorph.Hediffs;
 using Pawnmorph.Utilities;
@@ -153,7 +154,7 @@ namespace Pawnmorph
             //no get mutation that give this influence 
             foreach (MutationDef mutationDef in DefDatabase<MutationDef>.AllDefsListForReading)
             {
-                if (mutationDef.classInfluence == this)
+                if (mutationDef.ClassInfluences.Contains(this))
                 {
                     _mutations.Add(mutationDef); 
                 }

--- a/Source/Pawnmorphs/Esoteria/AnimalClassUtilities.cs
+++ b/Source/Pawnmorphs/Esoteria/AnimalClassUtilities.cs
@@ -307,13 +307,17 @@ namespace Pawnmorph
             if (outDict == null) throw new ArgumentNullException(nameof(outDict));
 
             outDict.Clear();
+
             //initialize the returning dictionary with the direct influences 
             foreach (Hediff_AddedMutation mutation in mutations.OrderBy(x => x.Influence.Count))
             {
                 AnimalClassBase animalClass = null;
+
+                // If more than one influence, then find the highest of those influences already on pawn.
                 if (mutation.Influence.Count > 1)
                     animalClass = mutation.Influence.Where(x => outDict.ContainsKey(x)).OrderByDescending(x => outDict[x]).FirstOrDefault();
 
+                // If no existing matching influence was found or is only single-influence, then take the first.
                 if (animalClass == null)
                     animalClass = mutation.Influence[0];
 

--- a/Source/Pawnmorphs/Esoteria/DebugUtils/DebugLogUtils.MutationLogging.cs
+++ b/Source/Pawnmorphs/Esoteria/DebugUtils/DebugLogUtils.MutationLogging.cs
@@ -223,7 +223,7 @@ namespace Pawnmorph.DebugUtils
             var mClassRoot = new MClassificationInfo(root);
             foreach (MutationDef mut in MutationDef.AllMutations)
             {
-                if (mut.classInfluence == root) mClassRoot.mutations.Add(mut); 
+                if (mut.ClassInfluences.Contains(root)) mClassRoot.mutations.Add(mut); 
 
             }
 
@@ -252,7 +252,7 @@ namespace Pawnmorph.DebugUtils
 
             foreach (MutationDef allMutation in MutationDef.AllMutations)
             {
-                if (allMutation.classInfluence == cBase)
+                if (allMutation.ClassInfluences.Contains(cBase))
                 {
                     retVal.mutations.Add(allMutation);
                 }

--- a/Source/Pawnmorphs/Esoteria/DebugUtils/DebugLogUtils.cs
+++ b/Source/Pawnmorphs/Esoteria/DebugUtils/DebugLogUtils.cs
@@ -474,7 +474,7 @@ namespace Pawnmorph.DebugUtils
             // Build a dictionary of all defs, sorted by influence.
             Dictionary<AnimalClassBase, IEnumerable<MutationDef>> mutationDefsByInfluence = 
                 DefDatabase<AnimalClassBase>.AllDefs
-                .Select(k => new { k, v = DefDatabase<MutationDef>.AllDefs.Where(m => m.classInfluence == k) })
+                .Select(k => new { k, v = DefDatabase<MutationDef>.AllDefs.Where(m => m.ClassInfluences.Contains(k)) })
                 .ToDictionary(x => x.k, x => x.v);
             foreach (KeyValuePair<AnimalClassBase, IEnumerable<MutationDef>> entry in mutationDefsByInfluence)
             {

--- a/Source/Pawnmorphs/Esoteria/DebugUtils/DebugMenu_AddMutations.cs
+++ b/Source/Pawnmorphs/Esoteria/DebugUtils/DebugMenu_AddMutations.cs
@@ -24,7 +24,7 @@ namespace Pawnmorph.DebugUtils
 
         protected override void DoListingItems()
         {
-            var grouping = MutationDef.AllMutations.GroupBy(m => m.classInfluence);
+            var grouping = MutationDef.AllMutations.SelectMany(x => x.ClassInfluences.Select(y => (x, y))).GroupBy(m => m.y, m => m.x);
 
             foreach (IGrouping<AnimalClassBase, MutationDef> group in grouping)
             {

--- a/Source/Pawnmorphs/Esoteria/Hediff_AddedMutation.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediff_AddedMutation.cs
@@ -89,15 +89,15 @@ namespace Pawnmorph
         ///     The influence.
         /// </value>
         [NotNull]
-        public AnimalClassBase Influence
+        public List<AnimalClassBase> Influence
         {
             get
             {
                 if (def is MutationDef mDef)
-                    return mDef.classInfluence;
-                Log.Warning($"{def.defName} is a mutation but does not use {nameof(MutationDef)}! this will cause problems!");
+                    return mDef.ClassInfluences;
 
-                return AnimalClassDefOf.Animal;
+                Log.Warning($"{def.defName} is a mutation but does not use {nameof(MutationDef)}! this will cause problems!");
+                return new List<AnimalClassBase>() { AnimalClassDefOf.Animal };
             }
         }
 

--- a/Source/Pawnmorphs/Esoteria/Hediffs/Giver_MutationChaotic.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Giver_MutationChaotic.cs
@@ -65,7 +65,7 @@ namespace Pawnmorph.Hediffs
         {
             foreach (var blackMorph in blackListCategories.MakeSafe().SelectMany(c => c.AllMorphsInCategories))
             {
-                if (arg.classInfluence == blackMorph) return false;
+                if (arg.ClassInfluences.Any(x => x.Contains(blackMorph))) return false;
             }
 
             if (arg.IsRestricted && !allowRestricted) return false; 

--- a/Source/Pawnmorphs/Esoteria/Hediffs/MutationDef.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/MutationDef.cs
@@ -106,6 +106,9 @@ namespace Pawnmorph.Hediffs
         [NotNull] [UsedImplicitly(ImplicitUseKindFlags.Assign)]
         public AnimalClassBase classInfluence;
 
+        /// <summary>
+        /// The class influences if multiple.
+        /// </summary>
         [NotNull]
         [UsedImplicitly(ImplicitUseKindFlags.Assign)]
         public List<AnimalClassBase> classInfluences;
@@ -197,7 +200,9 @@ namespace Pawnmorph.Hediffs
             get { return RestrictionLevel > RestrictionLevel.UnRestricted; }
         }
 
-
+        /// <summary>
+        /// Gets the finalized collection of class influences regardless of how it was defined in the XML.
+        /// </summary>
         public List<AnimalClassBase> ClassInfluences 
         { 
             get

--- a/Source/Pawnmorphs/Esoteria/Hediffs/MutationDef.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/MutationDef.cs
@@ -22,8 +22,8 @@ namespace Pawnmorph.Hediffs
     public class MutationDef : HediffDef, IDebugString
     {
         [Unsaved()]
-        private MutationStage[] _cachedMutationStages; 
-        
+        private MutationStage[] _cachedMutationStages;
+
         /// <summary>
         ///     list of body parts this mutation can be added to
         /// </summary>
@@ -78,12 +78,12 @@ namespace Pawnmorph.Hediffs
         /// The graphics for this mutation 
         /// </summary>
         [CanBeNull]
-        public List<MutationGraphicsData> graphics = new List<MutationGraphicsData>(); 
+        public List<MutationGraphicsData> graphics = new List<MutationGraphicsData>();
 
         /// <summary>
         /// The abstract 'value' of this mutation, can be negative or zero if the mutation is in general negative 
         /// </summary>
-        public int value; 
+        public int value;
 
         /// <summary>
         ///     the rule pack to use when generating mutation logs for this mutation
@@ -97,14 +97,18 @@ namespace Pawnmorph.Hediffs
         /// <summary>
         /// if this mutation should be removed instantly by a reverter
         /// </summary>
-        public bool removeInstantly; 
-        
+        public bool removeInstantly;
+
         /// <summary>
         ///     The class this part gives influence for
         /// </summary>
         /// only should be set if morphInfluence is not set!
         [NotNull] [UsedImplicitly(ImplicitUseKindFlags.Assign)]
         public AnimalClassBase classInfluence;
+
+        [NotNull]
+        [UsedImplicitly(ImplicitUseKindFlags.Assign)]
+        public List<AnimalClassBase> classInfluences;
 
         /// <summary>The mutation memory</summary>
         [CanBeNull] public ThoughtDef mutationMemory;
@@ -193,6 +197,18 @@ namespace Pawnmorph.Hediffs
             get { return RestrictionLevel > RestrictionLevel.UnRestricted; }
         }
 
+
+        public List<AnimalClassBase> ClassInfluences 
+        { 
+            get
+            {
+                if (classInfluences == null)
+                    classInfluences = new List<AnimalClassBase>() { classInfluence ?? AnimalClassDefOf.Animal };
+                
+                return classInfluences;
+            }
+        }
+
         /// <summary>
         /// Gets the restriction level of this mutation
         /// </summary>
@@ -268,8 +284,8 @@ namespace Pawnmorph.Hediffs
         public bool GivesInfluence([NotNull] AnimalClassDef classDef)
         {
             if (classDef == null) throw new ArgumentNullException(nameof(classDef));
-            if (classInfluence == null) return false;
-            return classDef.Contains(classInfluence);
+            if (ClassInfluences == null) return false;
+            return ClassInfluences.Any(x => classDef.Contains(x));
         }
 
         /// <summary>
@@ -281,8 +297,8 @@ namespace Pawnmorph.Hediffs
         public bool GivesInfluence([NotNull] MorphDef morph)
         {
             if (morph == null) throw new ArgumentNullException(nameof(morph));
-            if (classInfluence == null) return false;
-            return classInfluence.Contains(morph);
+            if (ClassInfluences == null) return false;
+            return ClassInfluences.Any(x => x.Contains(morph));
         }
 
         /// <summary>
@@ -291,7 +307,6 @@ namespace Pawnmorph.Hediffs
         public override void ResolveReferences()
         {
             base.ResolveReferences();
-            classInfluence = classInfluence ?? AnimalClassDefOf.Animal;
 
             if (mutationMemory == null)
             {

--- a/Source/Pawnmorphs/Esoteria/Hediffs/MutationRetrievers/Morph.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/MutationRetrievers/Morph.cs
@@ -2,6 +2,7 @@
 // last updated 10/24/2020  11:51 AM
 
 using System.Collections.Generic;
+using System.Linq;
 using Verse;
 
 namespace Pawnmorph.Hediffs.MutationRetrievers
@@ -46,7 +47,7 @@ namespace Pawnmorph.Hediffs.MutationRetrievers
         /// </returns>
         public bool CanGenerate(MutationDef mDef)
         {
-            return mDef.classInfluence.Contains(animalClass); 
+            return mDef.ClassInfluences.Any(x => x.Contains(animalClass)); 
         }
     }
 }

--- a/Source/Pawnmorphs/Esoteria/MorphCategoryDef.cs
+++ b/Source/Pawnmorphs/Esoteria/MorphCategoryDef.cs
@@ -51,7 +51,7 @@ namespace Pawnmorph
                     if(associatedMutationCategory == null) continue;
                     foreach (MutationDef mutation in MutationDef.AllMutations)
                     {
-                        if (mutation.classInfluence == morph)
+                        if (mutation.ClassInfluences.Contains(morph))
                         {
                             mutation.categories = mutation.categories ?? new List<MutationCategoryDef>(); 
                             if(!mutation.categories.Contains(associatedMutationCategory))

--- a/Source/Pawnmorphs/Esoteria/MorphDef.cs
+++ b/Source/Pawnmorphs/Esoteria/MorphDef.cs
@@ -293,7 +293,7 @@ namespace Pawnmorph
                             continue; //do not allow restricted parts for higher up in the hierarchy to show up unless allowAllRestrictedParts is set to true
                     }
 
-                    if (mutation.classInfluence == curNode) tmpList.Add(mutation);
+                    if (mutation.ClassInfluences.Contains(curNode)) tmpList.Add(mutation);
                 }
 
                 foreach (MutationDef mutationDef in tmpList)

--- a/Source/Pawnmorphs/Esoteria/MorphUtilities.cs
+++ b/Source/Pawnmorphs/Esoteria/MorphUtilities.cs
@@ -399,11 +399,15 @@ namespace Pawnmorph
 
             foreach (MutationDef mutationDef in enumerable)
             {
-                if (mutationDef.classInfluence is MorphDef morph)
+                foreach (AnimalClassBase animalClass in mutationDef.ClassInfluences)
                 {
-                    if (!lst.Contains(morph))
+                    if (animalClass is MorphDef morph)
                     {
-                        lst.Add(morph);
+                        if (!lst.Contains(morph))
+                        {
+                            lst.Add(morph);
+                            break;
+                        }
                     }
                 }
             }

--- a/Source/Pawnmorphs/Esoteria/MutationUtilities.cs
+++ b/Source/Pawnmorphs/Esoteria/MutationUtilities.cs
@@ -82,7 +82,7 @@ namespace Pawnmorph
             //check for parts with 'Animal' influence, these might be because of a mistake 
 
             var mutationDefs =
-                MutationDef.AllMutations.Where(m => m.classInfluence == null || m.classInfluence == AnimalClassDefOf.Animal)
+                MutationDef.AllMutations.Where(m => m.ClassInfluences == null || m.ClassInfluences.Contains(AnimalClassDefOf.Animal))
                            .ToList();
             if (mutationDefs.Count > 0)
             {
@@ -201,7 +201,7 @@ namespace Pawnmorph
             if (!dict.TryGetValue(mutation, out bool val))
             {
                 val = ideo.VeneratedAnimals.MakeSafe()
-                          .Any(a => a.TryGetBestMorphOfAnimal() == mutation.classInfluence);
+                          .Any(a => mutation.ClassInfluences.Contains(a.TryGetBestMorphOfAnimal()));
                 dict[mutation] = val;
             }
 

--- a/Source/Pawnmorphs/Esoteria/PreceptComps/VeneratedMutation.cs
+++ b/Source/Pawnmorphs/Esoteria/PreceptComps/VeneratedMutation.cs
@@ -27,11 +27,17 @@ namespace Pawnmorph.PreceptComps
             ThingDef animal = null;
             var mut = historyEvent.GetArg<Hediff_AddedMutation>(PMHistoryEventArgsNames.MUTATION);
 
-            if (!(mut.Def.classInfluence is MorphDef mInfluence)) return null;
 
-            foreach (ThingDef ideoA in ideo.VeneratedAnimals)
-                if (mInfluence.AllAssociatedAnimals.Contains(ideoA))
-                    return ideoA;
+            foreach (AnimalClassBase animalClass in mut.Def.ClassInfluences)
+            {
+                if (animalClass is MorphDef morph)
+                {
+                    foreach (ThingDef ideoA in ideo.VeneratedAnimals)
+                        if (morph.AllAssociatedAnimals.Contains(ideoA))
+                            return ideoA;
+                }
+            }
+
 
             return null; 
         }

--- a/Source/Pawnmorphs/Esoteria/User Interface/Dialog_PartPicker.cs
+++ b/Source/Pawnmorphs/Esoteria/User Interface/Dialog_PartPicker.cs
@@ -491,7 +491,7 @@ namespace Pawnmorph.User_Interface
                 foreach (MutationLayer layer in cachedMutationLayersByPartDef[parts.FirstOrDefault().def])
                 {
                     mutations = pawnCurrentMutations.Where(m => parts.Contains(m.Part) && m.Def.RemoveComp.layer == layer).ToList();
-                    buttonLabel = $"{layer.ToString().Translate()}: {(mutations.NullOrEmpty() ? NO_MUTATIONS_LOC_STRING.Translate().ToString() : string.Join(", ", mutations.Select(m => $"{m.Def.LabelCap} ({m.Def.classInfluence.label.CapitalizeFirst()})").Distinct()))}";
+                    buttonLabel = $"{layer.ToString().Translate()}: {(mutations.NullOrEmpty() ? NO_MUTATIONS_LOC_STRING.Translate().ToString() : string.Join(", ", mutations.Select(m => $"{m.Def.LabelCap} ({String.Join(", ", m.Def.ClassInfluences.Select(x => x.label.CapitalizeFirst()))})").Distinct()))}";
                     DrawPartButtons(ref curY, partListViewRect, mutations, parts, layer, buttonLabel);
                 }
             }
@@ -508,7 +508,7 @@ namespace Pawnmorph.User_Interface
                     mutations = pawnCurrentMutations.Where(m => parts.Contains(m.Part) && m.Def.RemoveComp.layer == MutationLayer.Core).ToList();
                     layer = MutationLayer.Core;
                 }
-                buttonLabel = $"{(mutations.NullOrEmpty() ? NO_MUTATIONS_LOC_STRING.Translate().ToString() : string.Join(", ", mutations.Select(m => $"{m.Def.LabelCap} ({m.Def.classInfluence.label.CapitalizeFirst()})").Distinct()))}";
+                buttonLabel = $"{(mutations.NullOrEmpty() ? NO_MUTATIONS_LOC_STRING.Translate().ToString() : string.Join(", ", mutations.Select(m => $"{m.Def.LabelCap} ({String.Join(", ", m.Def.ClassInfluences.Select(x => x.label.CapitalizeFirst()))})").Distinct()))}";
                 DrawPartButtons(ref curY, partListViewRect, mutations, parts, layer, buttonLabel);
             }
         }
@@ -557,7 +557,7 @@ namespace Pawnmorph.User_Interface
                         recachePreview = true;
                         RecachePawnMutations();
                     }
-                    options.Add(new FloatMenuOption($"{mutationDef.LabelCap} ({mutationDef.classInfluence.label.CapitalizeFirst()})", addMutation));
+                    options.Add(new FloatMenuOption($"{mutationDef.LabelCap} ({String.Join(", ", mutationDef.ClassInfluences.Select(x => x.label.CapitalizeFirst()))})", addMutation));
                 }
                 Find.WindowStack.Add(new FloatMenu(options));
             }


### PR DESCRIPTION
Change proposal to allow multiple class influences on mutations for shared mutations.

MutationDef now supports defining "classInfluence" or "classInfluences" in XML, and a new property "ClassInfluences" provide the total list regardless of how it has been added in the def.

The influence calculation now sorts mutations by number of influences to calculate singular first and then for those with more than 1 class, it finds the first class already existing and is counted as that.

There is some "issue" right now that if you have "Ursine" then arctic fur won't be counted as "Polar Bear" because it doesn't check inheritance tree. As soon as some other "Polar Bear" mutation is added, then both the Ursine and Arctic Fur would be counted as that as well, so I don't know how big the issue actually is, and if it is worth the extra performance cost to solve.

It should be relatively easy to make it count as the first class on a pawn which match an inherited class of one of the mutation's classes if there is no direct match. (In this case Polar Bear would match with Ursine and be picked and then cause both to be counted as such)

It might be a big enough change that it should rather be merged to Dev instead of Morph-Balance branch, to avoid future conflicts.

It should change nothing of the existing behaviour.
