### PR TITLE
Issue #379 - Restore sapience to permanently feral.

### DIFF
--- a/Source/Pawnmorphs/Esoteria/ThingComps/SapienceTracker.cs
+++ b/Source/Pawnmorphs/Esoteria/ThingComps/SapienceTracker.cs
@@ -205,6 +205,10 @@ namespace Pawnmorph.ThingComps
                 var fhState = (FormerHuman) _sapienceState;
                 fhState.MakePermanentlyFeral();
                 SapienceLevel = SapienceLevel.PermanentlyFeral;
+
+                _sapienceState.Exit();
+                _sapienceState = null;
+                PawnComponentsUtility.AddAndRemoveDynamicComponents(Pawn);
             }
             catch (InvalidCastException e)
             {


### PR DESCRIPTION
Making a pawn permanently feral will now remove sapience state which also removes the sapience need. It is now no longer possible to increase or decrease sapience with debug tools or pills.

**Closing issues**
closes #379
