### PR TITLE
Issue 495 - muta-chamber error

### DIFF
--- a/Source/Pawnmorphs/Esoteria/Chambers/MutaChamber.cs
+++ b/Source/Pawnmorphs/Esoteria/Chambers/MutaChamber.cs
@@ -771,7 +771,7 @@ namespace Pawnmorph.Chambers
             {
                 case ChamberUse.Mutation:
                     tfRequest = null;
-                    FinalizeMutations();
+                    FinalizeMutations(pawn);
                     break;
                 case ChamberUse.Merge:
 
@@ -856,11 +856,9 @@ namespace Pawnmorph.Chambers
             SelectorComp.Enabled = false;
         }
 
-        private void FinalizeMutations()
+        private void FinalizeMutations([NotNull] Pawn pawn)
         {
             if (_addedMutationData == null) return;
-            var pawn = innerContainer?.FirstOrDefault() as Pawn;
-            if (pawn == null) return;
 
             for (int i = _curMutationIndex + 1; i < _addedMutationData.Count; i++)
             {

--- a/Source/Pawnmorphs/Esoteria/Chambers/MutaChamber.cs
+++ b/Source/Pawnmorphs/Esoteria/Chambers/MutaChamber.cs
@@ -689,7 +689,10 @@ namespace Pawnmorph.Chambers
 
         private void UpdatePawnVisuals([NotNull] Pawn pawn)
         {
-            var comp = pawn.GetComp<GraphicSys.GraphicsUpdaterComp>();
+            var comp = pawn.TryGetComp<GraphicSys.GraphicsUpdaterComp>();
+            if (comp == null)
+                return;
+
             comp.IsDirty = true;
             comp.CompTick();
         }

--- a/Source/Pawnmorphs/Esoteria/ThingComps/AnimalSelectorComp.cs
+++ b/Source/Pawnmorphs/Esoteria/ThingComps/AnimalSelectorComp.cs
@@ -19,8 +19,6 @@ namespace Pawnmorph.ThingComps
         private PawnKindDef _chosenKind;
 
 
-        
-
         /// <summary>
         /// delegate for the Animal Chosen event 
         /// </summary>
@@ -110,6 +108,19 @@ namespace Pawnmorph.ThingComps
 
         private Gizmo[] _cachedGizmoArr;
 
+
+        public override void Initialize(CompProperties props)
+        {
+            base.Initialize(props);
+
+            _cachedGizmo = new Command_Action()
+            {
+                action = GizmoAction,
+                defaultLabel = "none",
+                icon = PMTextures.AnimalSelectorIcon
+            };
+        }
+
         /// <summary>
         /// Comps the get gizmos extra.
         /// </summary>
@@ -126,23 +137,7 @@ namespace Pawnmorph.ThingComps
                 yield return Gizmo; 
         }
 
-        Command_Action Gizmo
-        {
-            get
-            {
-                if (_cachedGizmo == null)
-                {
-                    _cachedGizmo = new Command_Action()
-                    {
-                        action = GizmoAction,
-                        defaultLabel = "none",
-                        icon = PMTextures.AnimalSelectorIcon
-                    };
-                }
-
-                return _cachedGizmo; 
-            }
-        }
+        Command_Action Gizmo => _cachedGizmo;
 
         public void ResetSelection()
         {
@@ -177,6 +172,7 @@ namespace Pawnmorph.ThingComps
             }
         }
 
+
         /// <summary>
         ///     Posts the expose data.
         /// </summary>
@@ -184,7 +180,7 @@ namespace Pawnmorph.ThingComps
         {
             base.PostExposeData();
             Scribe_Defs.Look(ref _chosenKind, nameof(ChosenKind));
-            Scribe_Values.Look(ref _enabled, nameof(Enabled), true); 
+            Scribe_Values.Look(ref _enabled, nameof(Enabled), true);
         }
 
 


### PR DESCRIPTION
Moved gizmo initialization on SpeciesSelector to ensure it's always available.
Added null check in case pawn inside the chamber has no graphics comp.

**Closing issues**
closes #495