### PR TITLE
Fix #494 Species selector on Mutation Chamber has no description.

### DIFF
--- a/1.3/Defs/MutagenChamberNew.xml
+++ b/1.3/Defs/MutagenChamberNew.xml
@@ -71,6 +71,8 @@
             </li>
             <li Class="Pawnmorph.ThingComps.AnimalSelectorCompProperties">
                 <requiresTag>true</requiresTag>
+                <labelKey>PMAnimalPickerGizmo_Chamber</labelKey>
+                <descriptionKey>PMAnimalPickerGizmoDescription_Chamber</descriptionKey>
                 <alwaysAvailable>
                     <li>Chaocow</li>
                     <li>Chaofox</li>

--- a/1.3/Defs/Things/Buildings.xml
+++ b/1.3/Defs/Things/Buildings.xml
@@ -35,16 +35,6 @@
                 <scanFindGuaranteedDays>6</scanFindGuaranteedDays>
                 <soundWorking>ScannerGroundPenetrating_Ambience</soundWorking>
             </li>
-            <li Class="Pawnmorph.ThingComps.AnimalSelectorCompProperties">
-                <requiresTag>true</requiresTag>
-                <labelKey>PMAnimalPickerGizmo_Mutagun</labelKey>
-                <descriptionKey>PMAnimalPickerGizmoDescription_Mutagun</descriptionKey>
-                <raceFilter>
-                  <filterList>
-                    <li>PM_Chaothrumbo</li>
-                  </filterList>
-                </raceFilter>
-              </li>
         </comps>
         <altitudeLayer>Building</altitudeLayer>
         <canBeUsedUnderRoof>true</canBeUsedUnderRoof>

--- a/1.3/Defs/Things/TFWeapons.xml
+++ b/1.3/Defs/Things/TFWeapons.xml
@@ -267,6 +267,8 @@
 		<comps>
 			<li Class="Pawnmorph.ThingComps.AnimalSelectorCompProperties">
 				<requiresTag>true</requiresTag>
+				<labelKey>PMAnimalPickerGizmo_Mutagun</labelKey>
+				<descriptionKey>PMAnimalPickerGizmoDescription_Mutagun</descriptionKey>
 				<raceFilter>
 					<filterList>
 						<li>PM_Chaothrumbo</li>

--- a/Languages/English/Keyed/Chambers.xml
+++ b/Languages/English/Keyed/Chambers.xml
@@ -5,7 +5,6 @@
     <PMAnimalGenomeDescription>Stores the genetic information of {ANIMAL}.</PMAnimalGenomeDescription>
     <PMChamberAddingMutations>Adding mutations</PMChamberAddingMutations>
     <PMChamberTransforming> - Transforming {0} into {1}</PMChamberTransforming>
-    <PMMergeGizmo>Merge</PMMergeGizmo>
     <PMCannotTransformPrisoner>Cannot transform {0}.</PMCannotTransformPrisoner>
     <PMWaitingForPawn>Waiting for pawn.</PMWaitingForPawn>
     <PMWaitingForPawnMerging>Waiting for pawn.</PMWaitingForPawnMerging>
@@ -13,4 +12,11 @@
     <PMActive>Active.</PMActive>
     <PMWaitingForSpecialThing>Waiting for {0}</PMWaitingForSpecialThing>
     <PMChamberMissingSpecialThing>{0} is required.</PMChamberMissingSpecialThing>
+		<!-- Buttons -->
+		<PMPartPickerGizmo>Mutation Picker</PMPartPickerGizmo>
+		<PMPartPickerGizmoDescription>Precisely control mechanite configuration to select mutations for specific parts.</PMPartPickerGizmoDescription>
+    <PMMergeGizmo>Merge</PMMergeGizmo>
+		<PMMergeGizmoDescription>Merge two unfortunate pawns into one chaotic abomination.</PMMergeGizmoDescription>
+		<PMAnimalPickerGizmo>Animal Picker</PMAnimalPickerGizmo>
+		<PMAnimalPickerGizmoDescription>Select an animal for complete mutagenic transformation.</PMAnimalPickerGizmoDescription>
 </LanguageData>

--- a/Languages/English/Keyed/Chambers.xml
+++ b/Languages/English/Keyed/Chambers.xml
@@ -13,10 +13,10 @@
     <PMWaitingForSpecialThing>Waiting for {0}</PMWaitingForSpecialThing>
     <PMChamberMissingSpecialThing>{0} is required.</PMChamberMissingSpecialThing>
 		<!-- Buttons -->
+		<PMAnimalPickerGizmo_Chamber>Animal Picker</PMAnimalPickerGizmo_Chamber>
+		<PMAnimalPickerGizmoDescription_Chamber>Start a mutagenic transformation into the selected animal.</PMAnimalPickerGizmoDescription_Chamber>
 		<PMPartPickerGizmo>Mutation Picker</PMPartPickerGizmo>
-		<PMPartPickerGizmoDescription>Precisely control mechanite configuration to select mutations for specific parts.</PMPartPickerGizmoDescription>
-    <PMMergeGizmo>Merge</PMMergeGizmo>
+		<PMPartPickerGizmoDescription>Precisely control mechanite configuration to select mutations for specific body parts.</PMPartPickerGizmoDescription>
+		<PMMergeGizmo>Merge</PMMergeGizmo>
 		<PMMergeGizmoDescription>Merge two unfortunate pawns into one chaotic abomination.</PMMergeGizmoDescription>
-		<PMAnimalPickerGizmo>Animal Picker</PMAnimalPickerGizmo>
-		<PMAnimalPickerGizmoDescription>Select an animal for complete mutagenic transformation.</PMAnimalPickerGizmoDescription>
 </LanguageData>

--- a/Languages/English/Keyed/UI_Localization.xml
+++ b/Languages/English/Keyed/UI_Localization.xml
@@ -6,11 +6,10 @@
 	<MutationLogButtonText>Log</MutationLogButtonText>
 	<MutationLogHeader>Mutation Log</MutationLogHeader>
 
-	<!-- Pat Picker Stuff -->
+	<!-- Part Picker Stuff -->
 	<PPRemivingMutationDesc>Removing {MUTATION} mutation from {PAWN_nameDef}'s {PART}.</PPRemivingMutationDesc>
 	<PPAddingMutationDesc>Adding {MUTATION} mutation to {PAWN_nameDef}'s {PART} at a severity of {SEVERITY}.</PPAddingMutationDesc>
 	<PPNewMutationIsHalted>It will not progess further.</PPNewMutationIsHalted>
-	<PMPartPickerGizmo>Mutation Picker</PMPartPickerGizmo>
 	<!-- Info Card -->
 	<PmMorphInfo_NoMorph>No Morphs</PmMorphInfo_NoMorph>
 	<PmMorphInfo_MorphDisplay>{MORPH}</PmMorphInfo_MorphDisplay>

--- a/Languages/English/Keyed/Weapons.xml
+++ b/Languages/English/Keyed/Weapons.xml
@@ -1,0 +1,4 @@
+<LanguageData>
+	<PMAnimalPickerGizmo_Mutagun>Random</PMAnimalPickerGizmo_Mutagun>
+	<PMAnimalPickerGizmoDescription_Mutagun>Animal mutation to inflict on the target.</PMAnimalPickerGizmoDescription_Mutagun>
+</LanguageData>

--- a/Source/Pawnmorphs/Esoteria/Chambers/MutaChamber.cs
+++ b/Source/Pawnmorphs/Esoteria/Chambers/MutaChamber.cs
@@ -27,7 +27,11 @@ namespace Pawnmorph.Chambers
         private const float TF_ANIMAL_DURATION = 1.5f; //units are in days 
         private const float MIN_TRANSFORMATION_TIME = 0.5f * 60000; //minimum transformation time in ticks
         private const string PART_PICKER_GIZMO_LABEL = "PMPartPickerGizmo";
+        private const string PART_PICKER_GIZMO_DESC = "PMPartPickerGizmoDescription";
         private const string MERGING_GIZMO_LABEL = "PMMergeGizmo";
+        private const string MERGING_GIZMO_DESC = "PMMergeGizmoDescription";
+        private const string ANIMAL_PICKER_GIZMO_LABEL = "PMAnimalPickerGizmo";
+        private const string ANIMAL_PICKER_GIZMO_DESC = "PMAnimalPickerGizmoDescription";
         private const string DEBUG_FORCE_COMPLETION_GIZMO = "PMDebugForceChamberCompletion"; 
 
 
@@ -203,7 +207,8 @@ namespace Pawnmorph.Chambers
                     {
                         action = OpenPartPicker,
                         icon = PMTextures.PartPickerIcon,
-                        defaultLabel = PART_PICKER_GIZMO_LABEL.Translate()
+                        defaultLabel = PART_PICKER_GIZMO_LABEL.Translate(),
+                        defaultDesc = PART_PICKER_GIZMO_DESC.Translate()
                     };
 
                 return _ppGizmo;
@@ -219,7 +224,8 @@ namespace Pawnmorph.Chambers
                     {
                         icon = PMTextures.MergingIcon,
                         action = EnterMergingIdle,
-                        defaultLabel = MERGING_GIZMO_LABEL.Translate()
+                        defaultLabel = MERGING_GIZMO_LABEL.Translate(),
+                        defaultDesc = MERGING_GIZMO_DESC.Translate()
                     };
 
                 return _mergingGizmo;
@@ -246,7 +252,11 @@ namespace Pawnmorph.Chambers
         {
             get
             {
-                if (_aSelector == null) _aSelector = GetComp<AnimalSelectorComp>();
+                if (_aSelector == null)
+                {
+                    _aSelector = GetComp<AnimalSelectorComp>();
+                    _aSelector.SetCommandLabels(ANIMAL_PICKER_GIZMO_LABEL, ANIMAL_PICKER_GIZMO_DESC);
+                }
                 if (_aSelector == null) Log.ErrorOnce("unable to find animal selector on mutachamber!", thingIDNumber);
 
                 return _aSelector;

--- a/Source/Pawnmorphs/Esoteria/Chambers/MutaChamber.cs
+++ b/Source/Pawnmorphs/Esoteria/Chambers/MutaChamber.cs
@@ -30,8 +30,6 @@ namespace Pawnmorph.Chambers
         private const string PART_PICKER_GIZMO_DESC = "PMPartPickerGizmoDescription";
         private const string MERGING_GIZMO_LABEL = "PMMergeGizmo";
         private const string MERGING_GIZMO_DESC = "PMMergeGizmoDescription";
-        private const string ANIMAL_PICKER_GIZMO_LABEL = "PMAnimalPickerGizmo";
-        private const string ANIMAL_PICKER_GIZMO_DESC = "PMAnimalPickerGizmoDescription";
         private const string DEBUG_FORCE_COMPLETION_GIZMO = "PMDebugForceChamberCompletion"; 
 
 
@@ -255,7 +253,6 @@ namespace Pawnmorph.Chambers
                 if (_aSelector == null)
                 {
                     _aSelector = GetComp<AnimalSelectorComp>();
-                    _aSelector.SetCommandLabels(ANIMAL_PICKER_GIZMO_LABEL, ANIMAL_PICKER_GIZMO_DESC);
                 }
                 if (_aSelector == null) Log.ErrorOnce("unable to find animal selector on mutachamber!", thingIDNumber);
 

--- a/Source/Pawnmorphs/Esoteria/Chambers/MutaChamber.cs
+++ b/Source/Pawnmorphs/Esoteria/Chambers/MutaChamber.cs
@@ -250,10 +250,7 @@ namespace Pawnmorph.Chambers
         {
             get
             {
-                if (_aSelector == null)
-                {
-                    _aSelector = GetComp<AnimalSelectorComp>();
-                }
+                if (_aSelector == null) _aSelector = GetComp<AnimalSelectorComp>();
                 if (_aSelector == null) Log.ErrorOnce("unable to find animal selector on mutachamber!", thingIDNumber);
 
                 return _aSelector;

--- a/Source/Pawnmorphs/Esoteria/ThingComps/AnimalSelectorComp.cs
+++ b/Source/Pawnmorphs/Esoteria/ThingComps/AnimalSelectorComp.cs
@@ -40,9 +40,6 @@ namespace Pawnmorph.ThingComps
         /// </summary>
         public event OnClickHandler OnClick;
 
-        private string _customLabelKey;
-        private string _customDescriptionKey;
-
         private bool _enabled = true;
         /// <summary>
         /// Gets or sets a value indicating whether this <see cref="AnimalSelectorComp"/> is enabled.
@@ -117,21 +114,9 @@ namespace Pawnmorph.ThingComps
             {
                 action = GizmoAction,
                 icon = PMTextures.AnimalSelectorIcon,
-                defaultLabel = "none",
-                defaultDesc = "Select Animal"
+                defaultLabel = Props.labelKey.Translate(),
+                defaultDesc = Props.descriptionKey.Translate()
             };
-        }
-
-        public void SetCommandLabels(string labelKey, string descriptionKey)
-        {
-            _customLabelKey = labelKey;
-            _customDescriptionKey = descriptionKey;
-
-            if (_cachedGizmo != null)
-            {
-                _cachedGizmo.defaultLabel = _customLabelKey.Translate();
-                _cachedGizmo.defaultDesc = _customDescriptionKey.Translate();
-            }
         }
 
         /// <summary>
@@ -159,7 +144,7 @@ namespace Pawnmorph.ThingComps
                     _cachedGizmo = new Command_Action()
                     {
                         action = GizmoAction,
-                        defaultLabel = "none",
+                        defaultLabel = Props.labelKey.Translate(),
                         icon = PMTextures.AnimalSelectorIcon
                     };
                 }
@@ -170,8 +155,8 @@ namespace Pawnmorph.ThingComps
 
         public void ResetSelection()
         {
-            _cachedGizmo.defaultLabel = _customLabelKey.Translate();
-            _cachedGizmo.defaultDesc = _customDescriptionKey.Translate();
+            _cachedGizmo.defaultLabel = Props.labelKey.Translate();
+            _cachedGizmo.defaultDesc = Props.descriptionKey.Translate();
             _cachedGizmo.icon = PMTextures.AnimalSelectorIcon;
         }
 
@@ -249,6 +234,17 @@ namespace Pawnmorph.ThingComps
         ///     if an animal must be tagged by the tagging rifle
         /// </summary>
         public bool requiresTag;
+
+        /// <summary>
+        ///     Label of selector button gizmo. Localised key.
+        /// </summary>
+        public string labelKey;
+
+        /// <summary>
+        ///     Tooltip of selector button gizmo. Localised key.
+        /// </summary>
+        public string descriptionKey;
+
 
         /// <summary>
         /// list of animals always available for selection 

--- a/Source/Pawnmorphs/Esoteria/ThingComps/AnimalSelectorComp.cs
+++ b/Source/Pawnmorphs/Esoteria/ThingComps/AnimalSelectorComp.cs
@@ -18,9 +18,6 @@ namespace Pawnmorph.ThingComps
     {
         private PawnKindDef _chosenKind;
 
-
-        
-
         /// <summary>
         /// delegate for the Animal Chosen event 
         /// </summary>
@@ -43,6 +40,8 @@ namespace Pawnmorph.ThingComps
         /// </summary>
         public event OnClickHandler OnClick;
 
+        private string _customLabelKey;
+        private string _customDescriptionKey;
 
         private bool _enabled = true;
         /// <summary>
@@ -110,6 +109,31 @@ namespace Pawnmorph.ThingComps
 
         private Gizmo[] _cachedGizmoArr;
 
+        public override void Initialize(CompProperties props)
+        {
+            base.Initialize(props);
+
+            _cachedGizmo = new Command_Action()
+            {
+                action = GizmoAction,
+                icon = PMTextures.AnimalSelectorIcon,
+                defaultLabel = "none",
+                defaultDesc = "Select Animal"
+            };
+        }
+
+        public void SetCommandLabels(string labelKey, string descriptionKey)
+        {
+            _customLabelKey = labelKey;
+            _customDescriptionKey = descriptionKey;
+
+            if (_cachedGizmo != null)
+            {
+                _cachedGizmo.defaultLabel = _customLabelKey.Translate();
+                _cachedGizmo.defaultDesc = _customDescriptionKey.Translate();
+            }
+        }
+
         /// <summary>
         /// Comps the get gizmos extra.
         /// </summary>
@@ -146,7 +170,8 @@ namespace Pawnmorph.ThingComps
 
         public void ResetSelection()
         {
-            _cachedGizmo.defaultLabel = "none";
+            _cachedGizmo.defaultLabel = _customLabelKey.Translate();
+            _cachedGizmo.defaultDesc = _customDescriptionKey.Translate();
             _cachedGizmo.icon = PMTextures.AnimalSelectorIcon;
         }
 


### PR DESCRIPTION
Added label and description to AnimalSelectorCompProperties xml in chamber and mutagun.
AnimalSelectorComp now uses label and description defined in properties.
Added Weapons LanguageData file.
Added labels and descriptions for chamber and mutagun.

closes  #494
