### PR TITLE
Added PM_BodySize stat to allow mutations to alter body size.

### DIFF
--- a/1.3/Defs/StatDefs/Utils.xml
+++ b/1.3/Defs/StatDefs/Utils.xml
@@ -8,4 +8,16 @@
         <displayPriorityInCategory>95</displayPriorityInCategory>
         <forInformationOnly>true</forInformationOnly>
     </StatDef>
+
+    
+    <StatDef ParentName="BaseMutagenic">
+        <defName>PM_BodySize</defName>
+        <label>altered body size</label>
+        <description>Mutations have caused this pawn to change size.</description>
+        <defaultBaseValue>1.0</defaultBaseValue>
+        <hideAtValue>1.0</hideAtValue>
+        <minValue>0.5</minValue>
+        <toStringStyle>PercentZero</toStringStyle>
+        <displayPriorityInCategory>75</displayPriorityInCategory>
+    </StatDef>
 </Defs>

--- a/Source/Pawnmorphs/Esoteria/HPatches/PawnPatches.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/PawnPatches.cs
@@ -206,5 +206,31 @@ namespace Pawnmorph.HPatches
             }
         }
 
+
+
+        static Dictionary<Pawn, Cached<float>> _pawnBodySizeStatCache = new Dictionary<Pawn, Cached<float>>();
+
+        [HarmonyPatch(nameof(Pawn.BodySize), MethodType.Getter), HarmonyPostfix]
+        static float GetBodySizePatch(float __result, [NotNull] Pawn __instance)
+        {
+            Cached<float> bodySizeModifier = null;
+            if (_pawnBodySizeStatCache.ContainsKey(__instance) == false)
+            {
+                bodySizeModifier = new Cached<float>(() => __instance.GetStatValueForPawn(PMStatDefOf.PM_BodySize, __instance));
+            }
+            else
+            {
+                if (__instance.IsHashIntervalTick(200))
+                {
+                    bodySizeModifier = _pawnBodySizeStatCache[__instance];
+                    bodySizeModifier.Recalculate();
+                }
+            }
+
+            if (bodySizeModifier != null)
+                return __result * bodySizeModifier.Value;
+
+            return __result;
+        }
     }
 }

--- a/Source/Pawnmorphs/Esoteria/PMStatDefOf.cs
+++ b/Source/Pawnmorphs/Esoteria/PMStatDefOf.cs
@@ -98,6 +98,11 @@ namespace Pawnmorph
         /// </summary>
         [NotNull] [UsedImplicitly] public static StatDef PM_MutagenPainSensitivity; 
 
+        /// <summary>
+        ///     Multiplier on the total pawn body size.
+        /// </summary>
+        public static StatDef PM_BodySize;
+        
 
         // ReSharper disable once NotNullMemberIsNotInitialized
         static PMStatDefOf()


### PR DESCRIPTION
![billede](https://user-images.githubusercontent.com/64704191/156654018-2c3a0601-d408-4ddf-8f30-9bea39b01975.png)
Renamed it to Altered body size.
"Mutations have caused this pawn to change size."