### PR TITLE
Issue 475 - blank melds

### DIFF
--- a/Source/Pawnmorphs/Esoteria/DebugUtils/PMDebugActions.cs
+++ b/Source/Pawnmorphs/Esoteria/DebugUtils/PMDebugActions.cs
@@ -363,9 +363,17 @@ namespace Pawnmorph.DebugUtils
             if (pawn == null) return;
             var gComp = Find.World.GetComponent<PawnmorphGameComp>();
             (TransformedPawn pawn, TransformedStatus status)? tfPawn = gComp?.GetTransformedPawnContaining(pawn);
+
             TransformedPawn transformedPawn = tfPawn?.pawn;
+
             if (transformedPawn == null || tfPawn?.status != TransformedStatus.Transformed) return;
-            MutagenDef mut = transformedPawn.mutagenDef ?? MutagenDefOf.defaultMutagen;
+
+            MutagenDef mut = null;
+            if (transformedPawn is MergedPawns)
+                mut = MutagenDefOf.MergeMutagen;
+            else
+                mut = MutagenDefOf.defaultMutagen;
+
             mut.MutagenCached.TryRevert(transformedPawn);
         }
 

--- a/Source/Pawnmorphs/Esoteria/PawnTransferUtilities.cs
+++ b/Source/Pawnmorphs/Esoteria/PawnTransferUtilities.cs
@@ -108,15 +108,23 @@ namespace Pawnmorph
         {
             if (originals == null) throw new ArgumentNullException(nameof(originals));
             if (meld == null) throw new ArgumentNullException(nameof(meld));
+
             Pawn_SkillTracker mSkills = meld.skills;
-            if (mSkills == null) return;
+            if (mSkills == null)
+            {
+                Log.Warning($"sapient animal meld does not have a skill tracker");
+                return;
+            }
+
             var tmpDict = new Dictionary<SkillDef, int>();
             var passionDict = new Dictionary<SkillDef, int>();
             var count = 0;
             foreach (Pawn original in originals)
             {
                 Pawn_SkillTracker skills = original.skills;
-                if (skills == null) continue;
+                if (skills == null) 
+                    continue;
+
                 foreach (SkillRecord skill in skills.skills)
                 {
                     tmpDict[skill.def] = tmpDict.TryGetValue(skill.def) + skill.Level;
@@ -133,7 +141,7 @@ namespace Pawnmorph
             {
                 int skVal = Mathf.Min(10, Mathf.RoundToInt(keyValuePair.Value * scaleVal));
                 var passion = (Passion) Mathf.Min(passionDict.TryGetValue(keyValuePair.Key) / count, 2);
-                SkillRecord sk = mSkills.GetSkill(keyValuePair.Key);
+                SkillRecord sk = TryGetSkill(mSkills, keyValuePair.Key);
                 sk.Level = skVal;
                 sk.passion = passion;
             }

--- a/Source/Pawnmorphs/Esoteria/ThingComps/AlwaysMergedPawn.cs
+++ b/Source/Pawnmorphs/Esoteria/ThingComps/AlwaysMergedPawn.cs
@@ -73,10 +73,7 @@ namespace Pawnmorph.ThingComps
 
             (Pawn p1, Pawn p2) = FormerHumanPawnGenerator.GenerateRandomUnmergedHumans(sTracker.Pawn);
 
-            CleanupPawn(p1);
-            CleanupPawn(p2);
             Pawn[] tmpArr = {p1, p2};
-            MergedPawnUtilities.TransferToMergedPawn(tmpArr, sTracker.Pawn);  
 
             var tfPawn = new MergedPawns()
             {
@@ -90,6 +87,9 @@ namespace Pawnmorph.ThingComps
             //TODO figure out how relationships work for merged pawns 
 
             sTracker.EnterState(SapienceStateDefOf.MergedPawn, Rand.Range(0.2f, 1));
+
+            FormerHumanUtilities.TryAssignBackstoryToTransformedPawn(sTracker.Pawn, tmpArr[0]);
+            MergedPawnUtilities.TransferToMergedPawn(tmpArr, sTracker.Pawn);
 
             var mentalDef = sTracker.Pawn.MentalStateDef;
             if (mentalDef == MentalStateDefOf.Manhunter || mentalDef == MentalStateDefOf.ManhunterPermanent)


### PR DESCRIPTION
Fixed blank melds lacking both skills and background by moving skill transfer to after meld is initialized as former human.

closes #475