### PR TITLE
Issue 517 - Incorrect notification message with intelli-boost

### DIFF
--- a/Languages/English/Keyed/FormerHumanNotifs.xml
+++ b/Languages/English/Keyed/FormerHumanNotifs.xml
@@ -31,9 +31,13 @@ As a feral {formerHuman_kindBase}, {formerHuman} will act no differently than ot
 
 
     <!-- 
-        other sapience levels are supported as well, just use the form $SapienceLevel_TransitionContent/$SapienceLevel_TransitionLabel 
-        ex: MostlyFeral_TransitionLabel/MostlyFeral_TransitionContent would show up for when a former human becomes 'mostly feral'
+        other sapience levels are supported as well, just use the form $SapienceLevel_IncreaseTransitionContent/$SapienceLevel_TransitionIncreaseLabel (or Decrease)
+        ex: MostlyFeral_TransitionIncreaseLabel/MostlyFeral_TransitionIncreaseContent would show up for when a former human becomes 'mostly feral'
     -->
-    <FormerHumanConflicted_TransitionLabel>[PAWN_nameDef] sapience has dropped significantly.</FormerHumanConflicted_TransitionLabel>
-    <FormerHumanConflicted_TransitionContent>[PAWN_nameDef] sapience has dropped to the point they are no longer considered a full colonist.</FormerHumanConflicted_TransitionContent>
+	<FormerHumanConflicted_DecreaseTransitionLabel>[PAWN_nameDef] sapience has dropped significantly.</FormerHumanConflicted_DecreaseTransitionLabel>
+	<FormerHumanConflicted_DecreaseTransitionContent>[PAWN_nameDef] sapience has dropped to the point they are no longer considered a full colonist.</FormerHumanConflicted_DecreaseTransitionContent>
+
+	<FormerHumanConflicted_IncreaseTransitionLabel>[PAWN_nameDef] sapience has increased.</FormerHumanConflicted_IncreaseTransitionLabel>
+	<FormerHumanConflicted_IncreaseTransitionContent>[PAWN_nameDef] sapience has increased to the point they are considered to be fully part of the colony.</FormerHumanConflicted_IncreaseTransitionContent>
+
 </LanguageData>

--- a/Source/Pawnmorphs/Esoteria/Hediffs/FormerHuman.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/FormerHuman.cs
@@ -98,12 +98,12 @@ namespace Pawnmorph.Hediffs
             if (CurStage is IExecutableStage exStage) exStage.EnteredStage(this);
         }
 
-        private void SapienceLevelChanged(Need_Control sender, Pawn pawn1, SapienceLevel sapiencelevel)
+        private void SapienceLevelChanged(Need_Control sender, Pawn pawn1, SapienceLevel oldLevel, SapienceLevel currentLevel)
         {
-            var idx = (int) sapiencelevel;
+            var idx = (int)currentLevel;
             if (idx < def.stages.Count) SetStage(idx);
 
-            SetLabel(sapiencelevel);
+            SetLabel(currentLevel);
         }
 
         private void SetLabel(SapienceLevel level)

--- a/Source/Pawnmorphs/Esoteria/Need_Control.cs
+++ b/Source/Pawnmorphs/Esoteria/Need_Control.cs
@@ -27,8 +27,9 @@ namespace Pawnmorph
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="pawn"></param>
-        /// <param name="sapienceLevel"></param>
-        public delegate void SapienceLevelChangedHandle(Need_Control sender, Pawn pawn, SapienceLevel sapienceLevel);
+        /// <param name="oldLevel"></param>
+        /// <param name="currentLevel"></param>
+        public delegate void SapienceLevelChangedHandle(Need_Control sender, Pawn pawn, SapienceLevel oldLevel, SapienceLevel currentLevel);
 
         private static HashSet<ThingDef> _enabledRaces;
 
@@ -373,7 +374,7 @@ namespace Pawnmorph
 
             if (pawn.Faction == Faction.OfPlayer) Find.ColonistBar?.MarkColonistsDirty();
 
-            SapienceLevelChanged?.Invoke(this, pawn, _currentLevel);
+            SapienceLevelChanged?.Invoke(this, pawn, oldLevel, newLevel);
             Find.HistoryEventsManager.RecordEvent(new HistoryEvent(PMHistoryEventDefOf.SapienceLevelChanged, pawn.Named(HistoryEventArgsNames.Doer), oldLevel.Named(OLD_SAPIENCE_LEVEL), newLevel.Named(NEW_SAPIENCE_LEVEL)));
             if (_currentLevel == SapienceLevel.PermanentlyFeral)
             {

--- a/Source/Pawnmorphs/Esoteria/SapienceStates/Animalistic.cs
+++ b/Source/Pawnmorphs/Esoteria/SapienceStates/Animalistic.cs
@@ -199,9 +199,9 @@ namespace Pawnmorph.SapienceStates
 
         private bool _waiting;
         private const float MTB = 1.5f;
-        private void SapienceLevelChanged(Need_Control sender, Pawn pawn, SapienceLevel sapiencelevel)
+        private void SapienceLevelChanged(Need_Control sender, Pawn pawn, SapienceLevel oldLevel, SapienceLevel currentLevel)
         {
-            if (sapiencelevel == SapienceLevel.Sapient)
+            if (currentLevel == SapienceLevel.Sapient)
             {
                 _waiting = true; 
             }

--- a/Source/Pawnmorphs/Esoteria/SapienceStates/FormerHuman.cs
+++ b/Source/Pawnmorphs/Esoteria/SapienceStates/FormerHuman.cs
@@ -293,21 +293,22 @@ namespace Pawnmorph.SapienceStates
 
         private bool _countdownStarted; 
 
-        private void OnSapienceLevelChanged(Need_Control sender, Pawn pawn, SapienceLevel sapienceLevel)
+        private void OnSapienceLevelChanged(Need_Control sender, Pawn pawn, SapienceLevel oldLevel, SapienceLevel currentLevel)
         {
-            if (sapienceLevel == SapienceLevel.Feral)
+            if (currentLevel == SapienceLevel.Feral)
             {
                 _countdownStarted = true; 
             }
 
             if(PawnUtility.ShouldSendNotificationAbout(pawn))
-                SendFHLetter(pawn, sapienceLevel);
+                SendFHLetter(pawn, oldLevel, currentLevel);
         }
 
-        private static void SendFHLetter(Pawn pawn, SapienceLevel sapienceLevel)
+        private static void SendFHLetter(Pawn pawn, SapienceLevel oldLevel, SapienceLevel currentLevel)
         {
-            // the translation keys should be $SapienceLevel_TransitionLabel and $SapienceLevel_TransitionContent
-            string translationLabel = "FormerHuman" + sapienceLevel + "_Transition";
+            // The translation keys should be $SapienceLevel_IncreaseTransitionLabel and $SapienceLevel_IncreaseTransitionContent (or Decrease).
+            string transition = oldLevel > currentLevel ? "Increase" : "Decrease"; //Enum: sapient is 0, feral is 4. So increase if the oldlevel is higher.
+            string translationLabel = "FormerHuman" + currentLevel + "_" + transition + "Transition";
             string letterLabelKey = translationLabel + "Label";
             string letterContentKey = translationLabel + "Content";
             TaggedString letterContent, letterLabel;

--- a/Source/Pawnmorphs/Esoteria/ThingComps/SapienceTracker.cs
+++ b/Source/Pawnmorphs/Esoteria/ThingComps/SapienceTracker.cs
@@ -278,7 +278,7 @@ namespace Pawnmorph.ThingComps
             }
         }
 
-        private void SapienceLevelChanges(Need_Control sender, Pawn pawn, SapienceLevel sapiencelevel)
+        private void SapienceLevelChanges(Need_Control sender, Pawn pawn, SapienceLevel oldLevel, SapienceLevel currentLevel)
         {
             if (pawn.Faction != Faction.OfPlayer) return;
 


### PR DESCRIPTION
Fixed wrong letterbox appearing when the sapience level is increasing.

Special messages when the sapience level is increasing can now be used.

closes https://github.com/Tachyonite/Pawnmorpher/issues/517