### PR TITLE
Issue 555 - Mutation tab breaks for newly added production mutations

### DIFF
--- a/Source/Pawnmorphs/Esoteria/HediffComp_Production.cs
+++ b/Source/Pawnmorphs/Esoteria/HediffComp_Production.cs
@@ -95,6 +95,12 @@ namespace Pawnmorph
             return true;
         }
 
+        public override void CompPostPostAdd(DamageInfo? dinfo)
+        {
+            base.CompPostPostAdd(dinfo);
+            UpdateCurrentStage();
+        }
+
         /// <summary>
         /// Recalculates current stage.
         /// </summary>


### PR DESCRIPTION
Fixed issue related to the optimizations in production comps where it didn't calculate initial stage.

**Closing issues**
closes #555