### PR TITLE
Duplication error from inheritance.

### DIFF
--- a/1.3/Mods/Martens/Defs/Races.xml
+++ b/1.3/Mods/Martens/Defs/Races.xml
@@ -90,7 +90,7 @@
             <manhunterOnTameFailChance>0.05</manhunterOnTameFailChance>
             <manhunterOnDamageChance>0.25</manhunterOnDamageChance>
             <lifeExpectancy>18</lifeExpectancy>
-            <lifeStageAges>
+            <lifeStageAges Inherit="False">
                 <li>
                     <def>AnimalBabyTiny</def>
                     <minAge>0</minAge>


### PR DESCRIPTION
Removed inheritance from lifeStageAges to avoid duplication errors due to the parent already having this node.

closes #560
