### PR TITLE
Issue 576 - Fixed mutations vanishing on pawn exiting chamber.

### DIFF
--- a/Source/Pawnmorphs/Esoteria/Chambers/MutaChamber.cs
+++ b/Source/Pawnmorphs/Esoteria/Chambers/MutaChamber.cs
@@ -1077,15 +1077,6 @@ namespace Pawnmorph.Chambers
             _lastTotal = _timer;
             sender.Reset();
 
-            //remove any mutations left over 
-            foreach (IReadOnlyMutationData mData in _addedMutationData.Where(m => !m.Removing))
-            {
-                var hediff =
-                    pawn.health?.hediffSet?.hediffs?.FirstOrDefault(h => h.def == mData.Mutation && h.Part == mData.Part) as
-                        Hediff_AddedMutation;
-                hediff?.MarkForRemoval();
-            }
-
             SelectorComp.Enabled = false;
         }
 


### PR DESCRIPTION
Closes #576

Maybe we should look into how it should work. 
I assume the reason for this code is to remove all existing mutations and then add them back to allow progressing from 0.
The issue now is that the pawn is put into stasis, and only 1 mutation is ticked at a time. And so if you only changed the severity of an existing mutation that then didn't get removed until pawn leaves chamber.

A different part of the code goes "if mutation already exist on pawn (as in you only changed severity) it just un-halts.
But by setting all mutations to immediately be removed, you could feasibly put a pawn into the chamber, part pick a single mutation, and immediately eject the pawn to get a quick removal of all mutations.
It also means that adding a completely new mutation and setting it to severity 3 would take as long as changing an existing mutation from 2 to 3.