### PR TITLE
Issue 542 - Fixed Gordon missing a name part and age.

### DIFF
--- a/Source/Pawnmorphs/Esoteria/IncidentWorker/SheepChef.cs
+++ b/Source/Pawnmorphs/Esoteria/IncidentWorker/SheepChef.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using HarmonyLib;
 using JetBrains.Annotations;
+using Pawnmorph.Utilities;
 using RimWorld;
 using UnityEngine;
 using Verse;
@@ -45,15 +46,14 @@ namespace Pawnmorph.IncidentWorkers
 
 
             IntVec3 loc = CellFinder.RandomClosewalkCellNear(result, map, 12);
-            Pawn pawn = PawnGenerator.GeneratePawn(kind);
-            GenSpawn.Spawn(pawn, loc, map, Rot4.Random);
-            pawn.SetFaction(Faction.OfPlayer);
-            var oPawn = GenerateGordon(pawn);
             
+            Pawn pawn = PawnGeneratorUtility.GenerateAnimal(kind, Faction.OfPlayer);
+            
+            var oPawn = GenerateGordon(pawn);
+            pawn.Name = oPawn.Name ?? pawn.Name;
 
             FormerHumanUtilities.MakeAnimalSapient(oPawn, pawn);
 
-            pawn.Name = oPawn.Name ?? pawn.Name; 
             if (pawn.story != null)
             {
                 pawn.story.adulthood = PMBackstoryDefOf.PM_SheepChef.backstory; 
@@ -76,6 +76,7 @@ namespace Pawnmorph.IncidentWorkers
             var pm = TfSys.TransformedPawn.Create(oPawn, pawn); 
             Find.World.GetComponent<PawnmorphGameComp>().AddTransformedPawn(pm);
 
+            GenSpawn.Spawn(pawn, loc, map, Rot4.Random);
             return true;
         }
 
@@ -100,7 +101,7 @@ namespace Pawnmorph.IncidentWorkers
             Faction faction = Faction.OfPlayer;
             bool useFirst = Rand.Bool;
             string firstName, lastName;
-            firstName = lastName = "";
+            firstName = lastName = null;
             if (useFirst)
                 firstName = "Gordon";
             else
@@ -121,7 +122,7 @@ namespace Pawnmorph.IncidentWorkers
             Pawn lPawn = PawnGenerator.GeneratePawn(local);
 
             var name = lPawn.Name as NameTriple;
-            lPawn.Name = new NameTriple(firstName, name?.Nick ?? firstName, lastName); 
+            lPawn.Name = new NameTriple(firstName ?? name.First, name.Nick ?? firstName, lastName ?? name.Last); 
 
 
             if (!BackstoryDatabase.TryGetWithIdentifier("chef", out Backstory back))

--- a/Source/Pawnmorphs/Esoteria/Pawnmorph.csproj
+++ b/Source/Pawnmorphs/Esoteria/Pawnmorph.csproj
@@ -855,6 +855,7 @@
     <Compile Include="Utilities\LinqUtils.cs" />
     <Compile Include="Utilities\MathUtilities.cs" />
     <Compile Include="Utilities\PatchUtilities.cs" />
+    <Compile Include="Utilities\PawnGeneratorUtility.cs" />
     <Compile Include="Utilities\RandUtilities.cs" />
     <Compile Include="Utilities\RWRaycast.cs" />
     <Compile Include="Utilities\SkillMod.cs" />

--- a/Source/Pawnmorphs/Esoteria/TransformerUtility.cs
+++ b/Source/Pawnmorphs/Esoteria/TransformerUtility.cs
@@ -403,7 +403,7 @@ namespace Pawnmorph
             if (originalPawn?.RaceProps == null) throw new ArgumentNullException(nameof(originalPawn));
             if (race == null) throw new ArgumentNullException(nameof(race));
 
-            return ConvertAge(originalPawn.RaceProps, race, originalPawn.ageTracker.AgeBiologicalYears);
+            return ConvertAge(originalPawn.RaceProps, race, originalPawn.ageTracker.AgeBiologicalYearsFloat);
         }
 
         

--- a/Source/Pawnmorphs/Esoteria/Utilities/PawnGeneratorUtility.cs
+++ b/Source/Pawnmorphs/Esoteria/Utilities/PawnGeneratorUtility.cs
@@ -1,0 +1,30 @@
+﻿using RimWorld;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Verse;
+
+namespace Pawnmorph.Utilities
+{
+    internal static class PawnGeneratorUtility
+    {
+        public static Pawn GenerateAnimal(PawnKindDef kind, Faction faction = null)
+        {;
+            Pawn pawn = PawnGenerator.GeneratePawn(kind, faction);
+
+
+            float minimumAnimalAge = TransformerUtility.ConvertAge(ThingDefOf.Human.race, kind.RaceProps, 17);
+            float ageOffset = minimumAnimalAge - pawn.ageTracker.AgeBiologicalYearsFloat;
+            if (ageOffset > 0)
+            {
+                long offsetTicks = (long)(ageOffset * 3600000L);
+                pawn.ageTracker.AgeBiologicalTicks += offsetTicks;
+                pawn.ageTracker.AgeChronologicalTicks += offsetTicks;
+            }
+
+            return pawn;
+        }
+    }
+}


### PR DESCRIPTION
Calculates the minimum sheep age to equate to 17 years old when reverted, and ensures that the spawned animal is at least that.
Also fixed a rounding issue when calculating age on reversion. Sheep must be at least 2.55 years old to match 17, however it rounded to 2.0 which equates to 14.

Closes #542