### PR TITLE
Allow users to enable mutation visuals on specific races.

### DIFF
--- a/Languages/English/Keyed/Settings.xml
+++ b/Languages/English/Keyed/Settings.xml
@@ -22,8 +22,8 @@
 	<manhunterTfChance>Chance for pawns to go manhunter when transformed</manhunterTfChance>
 	<PMInjectorsRequireTagging>Injectors Require Tagging</PMInjectorsRequireTagging>
 	<PMInjectorsRequireTaggingTooltip>If true, tagging animals is required to make injectors.</PMInjectorsRequireTaggingTooltip>
-	<enableMutationVisualsButton>Show mutations on races.</enableMutationVisualsButton>
-	<enableMutationVisualsHeader>Enable mutations visuals for races.</enableMutationVisualsHeader>
-	<enableMutationVisualsText>Selected races will be patched to show mutations as if they were human, and depending on the race aesthetic results may vary.</enableMutationVisualsText>
-	<requiresRestart>Requires a game restart to take affect.</requiresRestart>
+	<PMEnableMutationVisualsButton>Show mutations on races.</PMEnableMutationVisualsButton>
+	<PMEnableMutationVisualsHeader>Enable mutations visuals for races.</PMEnableMutationVisualsHeader>
+	<PMEnableMutationVisualsText>Selected races will be patched to show mutations as if they were human, and depending on the race aesthetic results may vary.</PMEnableMutationVisualsText>
+	<PMRequiresRestart>Requires a game restart to take affect.</PMRequiresRestart>
 </LanguageData>

--- a/Languages/English/Keyed/Settings.xml
+++ b/Languages/English/Keyed/Settings.xml
@@ -22,4 +22,8 @@
 	<manhunterTfChance>Chance for pawns to go manhunter when transformed</manhunterTfChance>
 	<PMInjectorsRequireTagging>Injectors Require Tagging</PMInjectorsRequireTagging>
 	<PMInjectorsRequireTaggingTooltip>If true, tagging animals is required to make injectors.</PMInjectorsRequireTaggingTooltip>
+	<enableMutationVisualsButton>Show mutations on races.</enableMutationVisualsButton>
+	<enableMutationVisualsHeader>Enable mutations visuals for races.</enableMutationVisualsHeader>
+	<enableMutationVisualsText>Selected races will be patched to show mutations as if they were human, and depending on the race aesthetic results may vary.</enableMutationVisualsText>
+	<requiresRestart>Requires a game restart to take affect.</requiresRestart>
 </LanguageData>

--- a/Source/Pawnmorphs/Esoteria/Pawnmorph.csproj
+++ b/Source/Pawnmorphs/Esoteria/Pawnmorph.csproj
@@ -869,7 +869,9 @@
     <Compile Include="User Interface\AddedMutations.cs" />
     <Compile Include="User Interface\ButtonTexturesPM.cs" />
     <Compile Include="User Interface\Dialog_PartPicker.cs" />
+    <Compile Include="User Interface\Dialog_Popup.cs" />
     <Compile Include="User Interface\MutationData.cs" />
+    <Compile Include="User Interface\Settings\VisibleRaceSelection.cs" />
     <Compile Include="Utilities\Cached.cs" />
     <Compile Include="Utilities\CompCacher.cs" />
     <Compile Include="Utilities\Filter.cs" />

--- a/Source/Pawnmorphs/Esoteria/Pawnmorph.csproj
+++ b/Source/Pawnmorphs/Esoteria/Pawnmorph.csproj
@@ -871,7 +871,7 @@
     <Compile Include="User Interface\Dialog_PartPicker.cs" />
     <Compile Include="User Interface\Dialog_Popup.cs" />
     <Compile Include="User Interface\MutationData.cs" />
-    <Compile Include="User Interface\Settings\VisibleRaceSelection.cs" />
+    <Compile Include="User Interface\Settings\Dialog_VisibleRaceSelection.cs" />
     <Compile Include="Utilities\Cached.cs" />
     <Compile Include="Utilities\CompCacher.cs" />
     <Compile Include="Utilities\Filter.cs" />

--- a/Source/Pawnmorphs/Esoteria/PawnmorpherMod.cs
+++ b/Source/Pawnmorphs/Esoteria/PawnmorpherMod.cs
@@ -58,7 +58,7 @@ namespace Pawnmorph
 
             checkBoxSection.CheckboxLabeled("PMHazardousChaobulbs".Translate(), ref settings.hazardousChaobulbs, "PMHazardousChaobulbsTooltip".Translate());
 
-            if (checkBoxSection.ButtonText("Show mutations on races."))
+            if (checkBoxSection.ButtonText("enableMutationVisualsButton".Translate()))
                 ShowVisibleRaceSelection();
 
             listingStandard.EndSection(checkBoxSection);

--- a/Source/Pawnmorphs/Esoteria/PawnmorpherMod.cs
+++ b/Source/Pawnmorphs/Esoteria/PawnmorpherMod.cs
@@ -1,4 +1,6 @@
 ﻿using Pawnmorph.DebugUtils;
+using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using Verse;
 
@@ -39,21 +41,29 @@ namespace Pawnmorph
         {
             Listing_Standard listingStandard = new Listing_Standard();
             listingStandard.Begin(inRect);
-            listingStandard.CheckboxLabeled("enableFalloutCheckboxLabel".Translate(), ref settings.enableFallout, "enableFalloutCheckboxTooltip".Translate());
-            listingStandard.CheckboxLabeled("enableMutagenLeakCheckboxLabel".Translate(), ref settings.enableMutagenLeak, "enableMutagenLeakCheckboxTooltip".Translate());
-            listingStandard.CheckboxLabeled("enableMutagenCheckboxLabel".Translate(), ref settings.enableMutagenShipPart, "enableMutagenCheckboxTooltip".Translate());
-            listingStandard.CheckboxLabeled("enableMutagenDiseasesCheckboxLabel".Translate(), ref settings.enableMutagenDiseases, "enableMutagenDiseasesCheckboxTooltip".Translate());
-            listingStandard.CheckboxLabeled("enableMutagenMeteorCheckboxLabel".Translate(), ref settings.enableMutagenMeteor, "enableMutagenMeteorCheckboxTooltip".Translate());
-            listingStandard.CheckboxLabeled("enableWildFormersCheckboxLabel".Translate(), ref settings.enableWildFormers, "enableWildFormersCheckboxTooltip".Translate());
-            listingStandard.CheckboxLabeled("ChamberDatabaseIgnoresDataLimit".Translate(),
+
+            Listing_Standard checkBoxSection = listingStandard.BeginSection(10 * Text.LineHeight);
+            checkBoxSection.ColumnWidth = inRect.width / 2;
+            checkBoxSection.CheckboxLabeled("enableFalloutCheckboxLabel".Translate(), ref settings.enableFallout, "enableFalloutCheckboxTooltip".Translate());
+            checkBoxSection.CheckboxLabeled("enableMutagenLeakCheckboxLabel".Translate(), ref settings.enableMutagenLeak, "enableMutagenLeakCheckboxTooltip".Translate());
+            checkBoxSection.CheckboxLabeled("enableMutagenCheckboxLabel".Translate(), ref settings.enableMutagenShipPart, "enableMutagenCheckboxTooltip".Translate());
+            checkBoxSection.CheckboxLabeled("enableMutagenDiseasesCheckboxLabel".Translate(), ref settings.enableMutagenDiseases, "enableMutagenDiseasesCheckboxTooltip".Translate());
+            checkBoxSection.CheckboxLabeled("enableMutagenMeteorCheckboxLabel".Translate(), ref settings.enableMutagenMeteor, "enableMutagenMeteorCheckboxTooltip".Translate());
+            checkBoxSection.CheckboxLabeled("enableWildFormersCheckboxLabel".Translate(), ref settings.enableWildFormers, "enableWildFormersCheckboxTooltip".Translate());
+            checkBoxSection.CheckboxLabeled("ChamberDatabaseIgnoresDataLimit".Translate(),
                                             ref settings.chamberDatabaseIgnoreStorageLimit,
                                             "ChamberDatabaseIgnoresDataLimitTooltip".Translate());
-            listingStandard.CheckboxLabeled("PMInjectorsRequireTagging".Translate(), ref settings.injectorsRequireTagging,
-                                            "PMInjectorsRequireTaggingTooltip".Translate()); 
+            checkBoxSection.CheckboxLabeled("PMInjectorsRequireTagging".Translate(), ref settings.injectorsRequireTagging,
+                                            "PMInjectorsRequireTaggingTooltip".Translate());
 
-            listingStandard.CheckboxLabeled("PMHazardousChaobulbs".Translate(), ref settings.hazardousChaobulbs, "PMHazardousChaobulbsTooltip".Translate());
+            checkBoxSection.CheckboxLabeled("PMHazardousChaobulbs".Translate(), ref settings.hazardousChaobulbs, "PMHazardousChaobulbsTooltip".Translate());
 
-            listingStandard.GapLine();
+            if (checkBoxSection.ButtonText("Show mutations on races."))
+                ShowVisibleRaceSelection();
+
+            listingStandard.EndSection(checkBoxSection);
+
+
             listingStandard.Label($"{"transformChanceSliderLabel".Translate()}: {settings.transformChance.ToString("F1")}%");
             settings.transformChance = listingStandard.Slider(settings.transformChance, 0f, 100f);
             listingStandard.Label($"{"formerChanceSliderLabel".Translate()}: {settings.formerChance.ToStringByStyle(ToStringStyle.PercentTwo)}");
@@ -86,7 +96,17 @@ namespace Pawnmorph
             }
 
             listingStandard.End();
+
             base.DoSettingsWindowContents(inRect);
+        }
+
+        private void ShowVisibleRaceSelection()
+        {
+            if (settings.visibleRaces == null)
+                settings.visibleRaces = new List<string>();
+
+            User_Interface.Settings.Dialog_VisibleRaceSelection raceSelection = new User_Interface.Settings.Dialog_VisibleRaceSelection(settings.visibleRaces);
+            Find.WindowStack.Add(raceSelection);
         }
 
         /// <summary>

--- a/Source/Pawnmorphs/Esoteria/PawnmorpherMod.cs
+++ b/Source/Pawnmorphs/Esoteria/PawnmorpherMod.cs
@@ -58,7 +58,7 @@ namespace Pawnmorph
 
             checkBoxSection.CheckboxLabeled("PMHazardousChaobulbs".Translate(), ref settings.hazardousChaobulbs, "PMHazardousChaobulbsTooltip".Translate());
 
-            if (checkBoxSection.ButtonText("enableMutationVisualsButton".Translate()))
+            if (checkBoxSection.ButtonText("PMEnableMutationVisualsButton".Translate()))
                 ShowVisibleRaceSelection();
 
             listingStandard.EndSection(checkBoxSection);

--- a/Source/Pawnmorphs/Esoteria/PawnmorpherModInit.cs
+++ b/Source/Pawnmorphs/Esoteria/PawnmorpherModInit.cs
@@ -50,6 +50,7 @@ namespace Pawnmorph
                 NotifySettingsChanged();
                 GenerateImplicitRaces();
                 TransferPatchesToExplicitRaces();
+                AddMutationsToWhitelistedRaces();
                 CheckForObsoletedComponents();
                 try
                 {
@@ -331,9 +332,25 @@ namespace Pawnmorph
                 }
 
             }
+        }
 
+        private static void AddMutationsToWhitelistedRaces()
+        {
+            List<AlienPartGenerator.BodyAddon> allAddons = GetAllAddonsToAdd().ToList();
 
-
+            foreach (string raceDefName in PawnmorpherMod.Settings.visibleRaces)
+            {
+                ThingDef_AlienRace race = (ThingDef_AlienRace)ThingDef.Named(raceDefName);
+                try
+                {
+                    AddAddonsToRace(race, allAddons);
+                    CheckDefaultOffsets(race, (ThingDef_AlienRace)ThingDefOf.Human);
+                }
+                catch (Exception e)
+                {
+                    Log.Error($"caught {e.GetType().Name} while trying to add mutation body graphics to {race.defName}!\n{e}");
+                }
+            }
         }
 
 

--- a/Source/Pawnmorphs/Esoteria/PawnmorpherModInit.cs
+++ b/Source/Pawnmorphs/Esoteria/PawnmorpherModInit.cs
@@ -340,7 +340,10 @@ namespace Pawnmorph
 
             foreach (string raceDefName in PawnmorpherMod.Settings.visibleRaces)
             {
-                ThingDef_AlienRace race = (ThingDef_AlienRace)ThingDef.Named(raceDefName);
+                ThingDef_AlienRace race = (ThingDef_AlienRace)DefDatabase<ThingDef>.GetNamedSilentFail(raceDefName);
+                if (race == null)
+                    continue;
+
                 try
                 {
                     AddAddonsToRace(race, allAddons);

--- a/Source/Pawnmorphs/Esoteria/PawnmorpherSettings.cs
+++ b/Source/Pawnmorphs/Esoteria/PawnmorpherSettings.cs
@@ -1,4 +1,5 @@
 ﻿using Pawnmorph.DebugUtils;
+using System.Collections.Generic;
 using Verse;
 
 namespace Pawnmorph
@@ -69,7 +70,15 @@ namespace Pawnmorph
         /// <summary>
         /// The current log level
         /// </summary>
-        public LogLevel logLevel = LogLevel.Warnings; 
+        public LogLevel logLevel = LogLevel.Warnings;
+
+        /// <summary>
+        /// List of races whitelisted to have visible mutations.
+        /// </summary>
+        public List<string> visibleRaces;
+
+
+
 
         /// <summary> The part that writes our settings to file. Note that saving is by ref. </summary>
         public override void ExposeData()
@@ -90,6 +99,7 @@ namespace Pawnmorph
             Scribe_Values.Look(ref friendlyManhunterTfChance, nameof(friendlyManhunterTfChance));
             Scribe_Values.Look(ref chamberDatabaseIgnoreStorageLimit, nameof(chamberDatabaseIgnoreStorageLimit));
             Scribe_Values.Look(ref hazardousChaobulbs, nameof(hazardousChaobulbs), true);
+            Scribe_Collections.Look(ref visibleRaces, nameof(visibleRaces));
             if (Scribe.mode == LoadSaveMode.PostLoadInit)
             {
                 if (formerChance > 1) formerChance /= 100f; 

--- a/Source/Pawnmorphs/Esoteria/User Interface/Dialog_Popup.cs
+++ b/Source/Pawnmorphs/Esoteria/User Interface/Dialog_Popup.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+using Verse;
+
+namespace Pawnmorph.User_Interface
+{
+    internal class Dialog_Popup : Window
+    {
+        private readonly string _message;
+        private static Vector2 CONTINUE_BUTTON_SIZE = new Vector2(120f, 40f);
+        private Vector2 _initialSize;
+
+        public Dialog_Popup(string message, Vector2 size)
+        {
+            _message = message;
+            _initialSize = size;
+            _initialSize.y += CONTINUE_BUTTON_SIZE.y;
+            _initialSize.x = Math.Max(_initialSize.x, CONTINUE_BUTTON_SIZE.x);
+        }
+
+        public override Vector2 InitialSize => _initialSize;
+
+        public override void DoWindowContents(Rect inRect)
+        {
+            Widgets.Label(inRect, _message);
+
+            float x = inRect.width / 2 - CONTINUE_BUTTON_SIZE.x / 2;
+            float y = inRect.height - CONTINUE_BUTTON_SIZE.y - 5;
+
+            if (Widgets.ButtonText(new Rect(new Vector2(x, y), CONTINUE_BUTTON_SIZE), "Continue"))
+                this.Close(true);
+        }
+    }
+}

--- a/Source/Pawnmorphs/Esoteria/User Interface/Settings/Dialog_VisibleRaceSelection.cs
+++ b/Source/Pawnmorphs/Esoteria/User Interface/Settings/Dialog_VisibleRaceSelection.cs
@@ -59,13 +59,13 @@ namespace Pawnmorph.User_Interface.Settings
         {
             float curY = 0;
             Text.Font = GameFont.Medium;
-            Widgets.Label(new Rect(0, curY, inRect.width, Text.LineHeight), "enableMutationVisualsHeader".Translate());
+            Widgets.Label(new Rect(0, curY, inRect.width, Text.LineHeight), "PMEnableMutationVisualsHeader".Translate());
 
             curY += Text.LineHeight;
 
             Text.Font = GameFont.Small;
             Rect descriptionRect = new Rect(0, curY, inRect.width, 60);
-            Widgets.Label(descriptionRect, "enableMutationVisualsText".Translate());
+            Widgets.Label(descriptionRect, "PMEnableMutationVisualsText".Translate());
 
             curY += descriptionRect.height;
 
@@ -123,7 +123,7 @@ namespace Pawnmorph.User_Interface.Settings
 
         private void ApplyChanges()
         {
-            Find.WindowStack.Add(new Dialog_Popup("requiresRestart".Translate(), new Vector2(300, 100)));
+            Find.WindowStack.Add(new Dialog_Popup("PMRequiresRestart".Translate(), new Vector2(300, 100)));
             _settingsReference.Clear();
             _settingsReference.AddRange(_selectedAliens.Where(x => x.Value).Select(x => x.Key.defName).ToList());
         }

--- a/Source/Pawnmorphs/Esoteria/User Interface/Settings/Dialog_VisibleRaceSelection.cs
+++ b/Source/Pawnmorphs/Esoteria/User Interface/Settings/Dialog_VisibleRaceSelection.cs
@@ -59,13 +59,13 @@ namespace Pawnmorph.User_Interface.Settings
         {
             float curY = 0;
             Text.Font = GameFont.Medium;
-            Widgets.Label(new Rect(0, curY, inRect.width, Text.LineHeight), "Enable visible mutations for races.");
+            Widgets.Label(new Rect(0, curY, inRect.width, Text.LineHeight), "enableMutationVisualsHeader".Translate());
 
             curY += Text.LineHeight;
 
             Text.Font = GameFont.Small;
             Rect descriptionRect = new Rect(0, curY, inRect.width, 60);
-            Widgets.Label(descriptionRect, "Selected races will be patched to show mutations as if they were human, and depending on the race aesthetic results may vary.");
+            Widgets.Label(descriptionRect, "enableMutationVisualsText".Translate());
 
             curY += descriptionRect.height;
 
@@ -123,7 +123,7 @@ namespace Pawnmorph.User_Interface.Settings
 
         private void ApplyChanges()
         {
-            Find.WindowStack.Add(new Dialog_Popup("Requires a game restart to take affect.", new Vector2(300, 100)));
+            Find.WindowStack.Add(new Dialog_Popup("requiresRestart".Translate(), new Vector2(300, 100)));
             _settingsReference.Clear();
             _settingsReference.AddRange(_selectedAliens.Where(x => x.Value).Select(x => x.Key.defName).ToList());
         }

--- a/Source/Pawnmorphs/Esoteria/User Interface/Settings/VisibleRaceSelection.cs
+++ b/Source/Pawnmorphs/Esoteria/User Interface/Settings/VisibleRaceSelection.cs
@@ -1,0 +1,143 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+using Verse;
+using Verse.Sound;
+
+namespace Pawnmorph.User_Interface.Settings
+{
+    internal class Dialog_VisibleRaceSelection : Window
+    {
+        private const string APPLY_BUTTON_LOC_STRING = "ApplyButtonText";
+        private const string RESET_BUTTON_LOC_STRING = "ResetButtonText";
+        private const string CANCEL_BUTTON_LOC_STRING = "CancelButtonText";
+        private static Vector2 APPLY_BUTTON_SIZE = new Vector2(120f, 40f);
+        private static Vector2 RESET_BUTTON_SIZE = new Vector2(120f, 40f);
+        private static Vector2 CANCEL_BUTTON_SIZE = new Vector2(120f, 40f);
+        private const float SPACER_SIZE = 17f;
+
+
+
+        private Vector2 _scrollPosition = new Vector2(0, 0);
+        private string _searchText = string.Empty;
+        private IEnumerable<AlienRace.ThingDef_AlienRace> _aliens;
+        private Dictionary<AlienRace.ThingDef_AlienRace, bool> _selectedAliens;
+        List<string> _settingsReference;
+
+        public Dialog_VisibleRaceSelection(List<string> settingsReference)
+        {
+            _settingsReference = settingsReference;
+            _selectedAliens = new Dictionary<AlienRace.ThingDef_AlienRace, bool>();
+        }
+
+        public override void PostOpen()
+        {
+            base.PostOpen();
+            RefreshAliens();
+        }
+
+        private void RefreshAliens()
+        {
+            IEnumerable<AlienRace.ThingDef_AlienRace> aliens = DefDatabase<AlienRace.ThingDef_AlienRace>.AllDefsListForReading;
+
+            aliens = aliens.Except((AlienRace.ThingDef_AlienRace)ThingDef.Named("Human"));
+
+            // Exclude implicit and explicit morph races.
+            aliens = aliens.Except(Hybrids.RaceGenerator.ImplicitRaces);
+            aliens = aliens.Except(MorphDef.AllDefs.Where(m => m.ExplicitHybridRace != null).Select(m => m.ExplicitHybridRace).Cast<AlienRace.ThingDef_AlienRace>());
+            aliens = aliens.Where(x => MutagenDefOf.defaultMutagen.CanInfect(x));
+
+            _aliens = aliens;
+            _selectedAliens = aliens.Where(x => _settingsReference.Contains(x.defName)).ToDictionary(x => x, x => true);
+        }
+
+
+        public override void DoWindowContents(Rect inRect)
+        {
+            float curY = 0;
+            Text.Font = GameFont.Medium;
+            Widgets.Label(new Rect(0, curY, inRect.width, Text.LineHeight), "Enable visible mutations for races.");
+
+            curY += Text.LineHeight;
+
+            Text.Font = GameFont.Small;
+            Rect descriptionRect = new Rect(0, curY, inRect.width, 60);
+            Widgets.Label(descriptionRect, "Selected races will be patched to show mutations as if they were human, and depending on the race aesthetic results may vary.");
+
+            curY += descriptionRect.height;
+
+            _searchText = Widgets.TextArea(new Rect(0, curY, 200f, 28f), _searchText);
+            if (Widgets.ButtonText(new Rect(205, curY, 28, 28), "X"))
+                _searchText = "";
+
+            curY += 35;
+
+            float totalHeight = inRect.height - Math.Max(APPLY_BUTTON_SIZE.y, Math.Max(RESET_BUTTON_SIZE.y, CANCEL_BUTTON_SIZE.y));
+            totalHeight -= 100;
+
+            Rect listbox = new Rect(0, 0, inRect.width - 20, (_aliens.Count() + 1) * Text.LineHeight);
+            Widgets.BeginScrollView(new Rect(0, curY, inRect.width, totalHeight), ref _scrollPosition, listbox);
+
+            Text.Font = GameFont.Tiny;
+            Listing_Standard lineListing = new Listing_Standard(listbox, () => _scrollPosition);
+            lineListing.Begin(listbox);
+
+            string searchText = _searchText.ToLower();
+            foreach (var item in _aliens)
+            {
+                if (searchText == "" || item.LabelCap.ToString().ToLower().Contains(searchText))
+                {
+                    bool current = _selectedAliens.TryGetValue(item, false);
+                    lineListing.CheckboxLabeled(item.LabelCap, ref current, item.modContentPack.ModMetaData.Name);
+                    _selectedAliens[item] = current;
+                }
+            }
+            lineListing.End();
+
+            Widgets.EndScrollView();
+
+            // Draw the apply, reset and cancel buttons.
+            float buttonVertPos = inRect.height - Math.Max(APPLY_BUTTON_SIZE.y, Math.Max(RESET_BUTTON_SIZE.y, CANCEL_BUTTON_SIZE.y));
+            float applyHorPos = inRect.width / 2 - APPLY_BUTTON_SIZE.x - RESET_BUTTON_SIZE.x / 2 - SPACER_SIZE;
+            float resetHorPos = inRect.width / 2 - RESET_BUTTON_SIZE.x / 2;
+            float cancelHorPos = inRect.width / 2 + RESET_BUTTON_SIZE.x / 2 + SPACER_SIZE;
+            if (Widgets.ButtonText(new Rect(applyHorPos, buttonVertPos, APPLY_BUTTON_SIZE.x, APPLY_BUTTON_SIZE.y), APPLY_BUTTON_LOC_STRING.Translate()))
+            {
+                OnAcceptKeyPressed();
+            }
+            if (Widgets.ButtonText(new Rect(resetHorPos, buttonVertPos, RESET_BUTTON_SIZE.x, RESET_BUTTON_SIZE.y), RESET_BUTTON_LOC_STRING.Translate()))
+            {
+                RimWorld.SoundDefOf.Checkbox_TurnedOff.PlayOneShotOnCamera(null);
+                RefreshAliens();
+            }
+            if (Widgets.ButtonText(new Rect(cancelHorPos, buttonVertPos, CANCEL_BUTTON_SIZE.x, CANCEL_BUTTON_SIZE.y), CANCEL_BUTTON_LOC_STRING.Translate()))
+            {
+                OnCancelKeyPressed();
+            }
+        }
+
+
+
+        private void ApplyChanges()
+        {
+            Find.WindowStack.Add(new Dialog_Popup("Requires a game restart to take affect.", new Vector2(300, 100)));
+            _settingsReference.Clear();
+            _settingsReference.AddRange(_selectedAliens.Where(x => x.Value).Select(x => x.Key.defName).ToList());
+        }
+
+        public override void OnCancelKeyPressed()
+        {
+            base.OnCancelKeyPressed();
+        }
+
+        public override void OnAcceptKeyPressed()
+        {
+            ApplyChanges();
+
+            base.OnAcceptKeyPressed();
+        }
+    }
+}


### PR DESCRIPTION
Added a settings configuration to allow players to select what third-party (mutatable!) races to be patched as if they were human.

The selection list excludes human, explicit morphs and incompatible races.