### PR TITLE
Hide debug warnings

### DIFF
--- a/Source/Pawnmorphs/Esoteria/PawnmorphPatches.cs
+++ b/Source/Pawnmorphs/Esoteria/PawnmorphPatches.cs
@@ -318,7 +318,10 @@ namespace Pawnmorph
             {
                 if (methodInfo.methodInfo == null)
                 {
+#if DEBUG
+                    // Only show configuration errors in debug mode.
                     Log.Warning($"encountered null in {nameof(MassPatchFormerHumanChecks)}!");
+#endif
 
                     continue;
                 }

--- a/Source/Pawnmorphs/Esoteria/PawnmorpherModInit.cs
+++ b/Source/Pawnmorphs/Esoteria/PawnmorpherModInit.cs
@@ -54,8 +54,17 @@ namespace Pawnmorph
                 CheckForObsoletedComponents();
                 try
                 {
+
+
                     CheckForModConflicts();
+
+#if DEBUG
+                    // Only show configuration errors in debug mode.
                     DisplayGroupedModIssues();
+#endif
+
+
+
                 }
                 catch (Exception e) // just logging, ok to catch and swallow the exception 
                 {


### PR DESCRIPTION
Only show these warnings in debug mode, that way we don't have to repeatedly tell concerned users to ignore them.
We also don't want to throw warnings for integrating mods doing explicit injectors for end users.
