### PR TITLE
Issue 550 - Replaced tagged restriction filter for injectors to HarmonyPatch

### DIFF
--- a/Source/Pawnmorphs/Esoteria/HPatches/RecipeDefPatch.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/RecipeDefPatch.cs
@@ -14,7 +14,7 @@ namespace Pawnmorph.HPatches
     internal class RecipeDefPatch
     {
         static PawnmorpherSettings _settings;
-        static Dictionary<ThingDef, MorphDef> _injectorMorphMapping;
+        static Dictionary<int, MorphDef> _injectorMorphMapping;
 
         public static void Prepare(MethodBase original)
         {
@@ -26,7 +26,7 @@ namespace Pawnmorph.HPatches
 
             List<MorphDef> allMorphs = MorphDef.AllDefs.ToList();
 
-            _injectorMorphMapping = new Dictionary<ThingDef, MorphDef>(_injectors.Count);
+            _injectorMorphMapping = new Dictionary<int, MorphDef>(_injectors.Count);
             foreach (var injector in _injectors)
             {
                 IngestionOutcomeDoer_GiveHediff hediff = injector.ingestible.outcomeDoers.OfType<IngestionOutcomeDoer_GiveHediff>().FirstOrDefault();
@@ -34,7 +34,7 @@ namespace Pawnmorph.HPatches
                 {
                     MorphDef morphDef = allMorphs.FirstOrDefault(m => m.fullTransformation == hediff.hediffDef);
                     if (morphDef != null)
-                        _injectorMorphMapping[injector] = morphDef;
+                        _injectorMorphMapping[injector.index] = morphDef;
                 }
             }
         }
@@ -45,7 +45,7 @@ namespace Pawnmorph.HPatches
             // If recipe is available (Has been researched)
             if (__result && _settings.injectorsRequireTagging && __instance.ProducedThingDef != null)
             {
-                if (_injectorMorphMapping.TryGetValue(__instance.ProducedThingDef, out var morphDef))
+                if (_injectorMorphMapping.TryGetValue(__instance.ProducedThingDef.index, out var morphDef))
                 {
                     if (DebugSettings.godMode)
                         return true;

--- a/Source/Pawnmorphs/Esoteria/HPatches/RecipeDefPatch.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/RecipeDefPatch.cs
@@ -1,0 +1,59 @@
+﻿using HarmonyLib;
+using Pawnmorph.Chambers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Verse;
+
+namespace Pawnmorph.HPatches
+{
+    [HarmonyPatch(typeof(RecipeDef))]
+    internal class RecipeDefPatch
+    {
+        static PawnmorpherSettings _settings;
+        static Dictionary<ThingDef, MorphDef> _injectorMorphMapping;
+
+        public static void Prepare(MethodBase original)
+        {
+            if (original != null)
+                return;
+
+            _settings = LoadedModManager.GetMod<PawnmorpherMod>().GetSettings<PawnmorpherSettings>();
+            List<ThingDef> _injectors = PMThingCategoryDefOf.Injector.SortedChildThingDefs;
+
+            List<MorphDef> allMorphs = MorphDef.AllDefs.ToList();
+
+            _injectorMorphMapping = new Dictionary<ThingDef, MorphDef>(_injectors.Count);
+            foreach (var injector in _injectors)
+            {
+                IngestionOutcomeDoer_GiveHediff hediff = injector.ingestible.outcomeDoers.OfType<IngestionOutcomeDoer_GiveHediff>().FirstOrDefault();
+                if (hediff != null && hediff.hediffDef != null)
+                {
+                    MorphDef morphDef = allMorphs.FirstOrDefault(m => m.fullTransformation == hediff.hediffDef);
+                    if (morphDef != null)
+                        _injectorMorphMapping[injector] = morphDef;
+                }
+            }
+        }
+
+        [HarmonyPatch(nameof(RecipeDef.AvailableNow), MethodType.Getter), HarmonyPostfix]
+        public static bool AvailableNow(bool __result, RecipeDef __instance)
+        {
+            // If recipe is available (Has been researched)
+            if (__result && _settings.injectorsRequireTagging && __instance.ProducedThingDef != null)
+            {
+                if (_injectorMorphMapping.TryGetValue(__instance.ProducedThingDef, out var morphDef))
+                {
+                    if (DebugSettings.godMode)
+                        return true;
+
+                    return morphDef.IsTagged();
+                }                
+            }
+            return __result;
+        }
+    }
+}

--- a/Source/Pawnmorphs/Esoteria/ITabs/InjectorBills.cs
+++ b/Source/Pawnmorphs/Esoteria/ITabs/InjectorBills.cs
@@ -26,31 +26,6 @@ namespace Pawnmorph.ITabs
         private Bill mouseoverBill;
 
         private static readonly Vector2 WinSize = new Vector2(420f, 480f);
-
-        [CanBeNull]
-        MorphDef MorphFromSyringeRecipe([NotNull] RecipeDef rDef)
-        {
-            var ingestible = rDef.ProducedThingDef?.ingestible; //get the morph required to be tagged by checking the hediff the ingestion outcome doer gives a pawn and comparing that with the 
-            if (ingestible == null) return null; //full and/or partial tf hediff stored in MorphDef
-            var fOutcomeDoer = ingestible.outcomeDoers?.OfType<IngestionOutcomeDoer_GiveHediff>().FirstOrDefault(); //this is hacky and need to figure out a more elegant solution that doesn't 
-            var morphHDef = fOutcomeDoer?.hediffDef; //required all injector or morph xml files to be updated 
-            if (morphHDef == null) return null;
-            return MorphDef.AllDefs.FirstOrDefault(m => m.fullTransformation == morphHDef
-                                                     || m.partialTransformation == morphHDef); 
-        }
-
-
-        bool CanUseRecipe(RecipeDef recipe)
-        {
-            if(!(recipe.AvailableNow && recipe.AvailableOnNow(SelTable))) return false;
-            if (!LoadedModManager.GetMod<PawnmorpherMod>().GetSettings<PawnmorpherSettings>().injectorsRequireTagging)
-                return true; 
-            
-            
-            var mDef = MorphFromSyringeRecipe(recipe);
-            return mDef?.IsTagged() != false; 
-        }
-
         [TweakValue("PMInterface", 0f, 128f)]
         private static float PasteX = 48f;
 
@@ -109,7 +84,7 @@ namespace Pawnmorph.ITabs
                 for (int i = 0; i < SelTable.def.AllRecipes.Count; i++)
                 {
                     RecipeDef recipe = SelTable.def.AllRecipes[i];
-                    if (CanUseRecipe(recipe))
+                    if (recipe.AvailableNow)
                     {
                         var tempRecipe = recipe;
                         list.Add(new FloatMenuOption(recipe.LabelCap, delegate

--- a/Source/Pawnmorphs/Esoteria/Pawnmorph.csproj
+++ b/Source/Pawnmorphs/Esoteria/Pawnmorph.csproj
@@ -314,6 +314,7 @@
     <Compile Include="Abilities\TerrifyingRoar.cs" />
     <Compile Include="Hediffs\Hediff_Bullrush.cs" />
     <Compile Include="HPatches\PawnHealthTrackerPatches.cs" />
+    <Compile Include="HPatches\RecipeDefPatch.cs" />
     <Compile Include="Jobs\Giver_Producer.cs" />
     <Compile Include="SkyFallerDefOf.cs" />
     <Compile Include="AddMorphsToPawn.cs" />


### PR DESCRIPTION
This allows the tagging requirement to be effective even if the entire UI is replaced.