### PR TITLE
Issue 681 - beard and hair

### DIFF
--- a/1.3/Defs/Morphs/Animal/Reptile/Lacertilia/Iguana/Iguana_Parts.xml
+++ b/1.3/Defs/Morphs/Animal/Reptile/Lacertilia/Iguana/Iguana_Parts.xml
@@ -53,8 +53,11 @@
 			<Skullspike>Parts/Iguana/Iguana_Spines</Skullspike>
 		</graphics>
 		<parts>
-			<li>Skull</li>
+			<li>Head</li>
 		</parts>
+		<blockSites>
+			<li>Skull</li>
+		</blockSites>
 	</Pawnmorph.Hediffs.MutationDef>
 	
 </Defs>

--- a/1.3/Defs/Morphs/Animal/Reptile/Ophidia/Cobra/Cobra_Parts.xml
+++ b/1.3/Defs/Morphs/Animal/Reptile/Ophidia/Cobra/Cobra_Parts.xml
@@ -31,8 +31,11 @@
 			</li>
 		</stages>
 		<parts>
-			<li>Skull</li>
+			<li>Head</li>
 		</parts>
+		<blockSites>
+			<li>Skull</li>
+		</blockSites>
 		<!--Needs Stats-->
 	</Pawnmorph.Hediffs.MutationDef>
 	

--- a/1.3/Defs/StyleDefs/BeardDefs.xml
+++ b/1.3/Defs/StyleDefs/BeardDefs.xml
@@ -1,0 +1,8 @@
+<Defs>
+  <BeardDef>
+    <defName>PM_BeardHidden</defName>
+    <label>no beard</label>
+    <texPath>Things/Mote/Transparent</texPath>
+    <iconPath>Things/Mote/Transparent</iconPath>
+  </BeardDef>
+</Defs>

--- a/1.3/Defs/StyleDefs/HairDefs.xml
+++ b/1.3/Defs/StyleDefs/HairDefs.xml
@@ -1,0 +1,8 @@
+<Defs>
+  <HairDef>
+    <defName>PM_HairHidden</defName>
+    <label>no hair</label>
+    <styleGender>Any</styleGender>
+    <texPath>Things/Mote/Transparent</texPath>
+  </HairDef>
+</Defs>

--- a/1.3/Patches/Core_HumanHedifGraphics.xml
+++ b/1.3/Patches/Core_HumanHedifGraphics.xml
@@ -383,7 +383,7 @@
 				<anchorID>Skullspike</anchorID>
 				<colorChannel>SkinHair</colorChannel>
 				<path>Parts/None/None</path>
-				<bodyPart>Skull</bodyPart>
+				<bodyPart>Head</bodyPart>
 				<alignWithHead>true</alignWithHead>
 				<inFrontOfBody>true</inFrontOfBody>
 				<layerInvert>false</layerInvert>
@@ -418,7 +418,7 @@
 				<anchorID>CobraHood</anchorID>
 				<colorChannel>SkinHair</colorChannel>
 				<path>Parts/None/None</path>
-				<bodyPart>Skull</bodyPart>
+				<bodyPart>Head</bodyPart>
 				<alignWithHead>true</alignWithHead>
 				<inFrontOfBody>true</inFrontOfBody>
 				<layerInvert>false</layerInvert>
@@ -436,7 +436,7 @@
 				<anchorID>CobraHoodBackground</anchorID>
 				<colorChannel>SkinHair</colorChannel>
 				<path>Parts/None/None</path>
-				<bodyPart>Skull</bodyPart>
+				<bodyPart>Head</bodyPart>
 				<alignWithHead>true</alignWithHead>
 				<inFrontOfBody>false</inFrontOfBody>
 				<shaderType>CutoutSkin</shaderType>

--- a/Source/Pawnmorphs/Esoteria/Graphics/InitialGraphics.cs
+++ b/Source/Pawnmorphs/Esoteria/Graphics/InitialGraphics.cs
@@ -157,6 +157,11 @@ namespace Pawnmorph.GraphicSys
         }
 
         /// <summary>
+        /// Gets the pawn's original beard.
+        /// </summary>
+        public BeardDef Beard => _styleInfo?.Beard;
+
+        /// <summary>
         ///     Gets the initial body type of this pawn
         /// </summary>
         /// <value>
@@ -315,6 +320,8 @@ namespace Pawnmorph.GraphicSys
 
         private class StyleInfo : IExposable
         {
+            public BeardDef Beard => beardDef;
+
              BeardDef beardDef;
 
 

--- a/Source/Pawnmorphs/Esoteria/Graphics/InitialGraphics.cs
+++ b/Source/Pawnmorphs/Esoteria/Graphics/InitialGraphics.cs
@@ -159,7 +159,20 @@ namespace Pawnmorph.GraphicSys
         /// <summary>
         /// Gets the pawn's original beard.
         /// </summary>
-        public BeardDef Beard => _styleInfo?.Beard;
+        public BeardDef BeardDef
+        {
+            get
+            {
+                if (!_scanned)
+                    ScanGraphics();
+                return _styleInfo?.Beard;
+            }
+            set
+            {
+                if(_styleInfo != null)
+                    _styleInfo.Beard = value;
+            }
+        }
 
         /// <summary>
         ///     Gets the initial body type of this pawn
@@ -192,6 +205,10 @@ namespace Pawnmorph.GraphicSys
                     ScanGraphics();
                 return _hairDef;
             }
+            set
+            {
+                _hairDef = value;
+            }
         }
 
         private Pawn Pawn => (Pawn) parent;
@@ -205,6 +222,8 @@ namespace Pawnmorph.GraphicSys
             builder.AppendLine($"{nameof(SkinColor)} {SkinColor}");
             builder.AppendLine($"{nameof(HairColor)} {HairColor}");
             builder.AppendLine($"{nameof(CrownType)} {CrownType}");
+            builder.AppendLine($"{nameof(BeardDef)} {BeardDef}");
+            builder.AppendLine($"{nameof(HairDef)} {HairDef}");
             return builder.ToString();
         }
 
@@ -301,7 +320,10 @@ namespace Pawnmorph.GraphicSys
             _customPortraitDrawSize = comp.customPortraitDrawSize;
             _fixedGenderPostSpawn = comp.fixGenderPostSpawn;
             _skinColor = comp.GetSkinColor() ?? Color.white;
-            _hairDef = Pawn.story.hairDef;
+
+            if (Pawn.story.hairDef != PMStyleDefOf.PM_HairHidden)
+                _hairDef = Pawn.story.hairDef;
+
             _skinColorSecond = comp.GetSkinColor(false) ?? Color.white;
             _hairColorSecond = comp.ColorChannels.TryGetValue("hair")?.second ?? Color.white;
             _initialGender = Pawn.gender;
@@ -320,9 +342,13 @@ namespace Pawnmorph.GraphicSys
 
         private class StyleInfo : IExposable
         {
-            public BeardDef Beard => beardDef;
+            public BeardDef Beard
+            {
+                get => beardDef;
+                set => beardDef = value;
+            }
 
-             BeardDef beardDef;
+            BeardDef beardDef;
 
 
              HairDef nextHairDef;
@@ -370,7 +396,9 @@ namespace Pawnmorph.GraphicSys
 
             public void Scan([NotNull] Pawn_StyleTracker styleTracker)
             {
-                beardDef = styleTracker.beardDef;
+                if (styleTracker.beardDef != PMStyleDefOf.PM_BeardHidden)
+                    beardDef = styleTracker.beardDef;
+
                 nextHairDef = styleTracker.nextHairDef;
                 nextBeardDef = styleTracker.nextBeardDef;
 

--- a/Source/Pawnmorphs/Esoteria/Hediff_AddedMutation.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediff_AddedMutation.cs
@@ -5,6 +5,7 @@ using System.Text;
 using JetBrains.Annotations;
 using Pawnmorph.GraphicSys;
 using Pawnmorph.Hediffs;
+using Pawnmorph.HPatches;
 using Pawnmorph.Utilities;
 using RimWorld;
 using UnityEngine;
@@ -289,6 +290,17 @@ namespace Pawnmorph
                 {
                     Log.Error($"could not cast {otherMutation.def.defName} of type {otherMutation.def.GetType().Name} to {nameof(MutationDef)}!\n{e}");
                 }
+
+            if (Part.def == BodyPartDefOf.Head)
+            {
+                // Hide hair
+                pawn.story.hairDef = HairDefOf.Shaved;
+            }
+            else if (Part.def == BodyPartDefOf.Jaw)
+            {
+                // Hide beard
+                pawn.style.beardDef = BeardDefOf.NoBeard;
+            }
         }
 
         /// <summary>called after this instance is removed from the pawn</summary>
@@ -297,6 +309,22 @@ namespace Pawnmorph
             base.PostRemoved();
             if (!PawnGenerator.IsBeingGenerated(pawn))
                 pawn.GetMutationTracker()?.NotifyMutationRemoved(this);
+            
+            var initialGraphics = pawn.GetComp<InitialGraphicsComp>();
+            if (initialGraphics != null)
+            {
+                if (Part.def == BodyPartDefOf.Head)
+                {
+                    // Hide hair
+                    pawn.story.hairDef = initialGraphics.HairDef;
+                }
+                else if (Part.def == BodyPartDefOf.Jaw)
+                {
+                    // Hide beard
+                    if (initialGraphics.Beard != null)
+                        pawn.style.beardDef = initialGraphics.Beard;
+                }
+            }
         }
 
         /// <summary>

--- a/Source/Pawnmorphs/Esoteria/Hediff_AddedMutation.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediff_AddedMutation.cs
@@ -291,15 +291,18 @@ namespace Pawnmorph
                     Log.Error($"could not cast {otherMutation.def.defName} of type {otherMutation.def.GetType().Name} to {nameof(MutationDef)}!\n{e}");
                 }
 
-            if (Part.def == BodyPartDefOf.Head)
+            if (Def.RemoveComp?.layer == MutationLayer.Core)
             {
-                // Hide hair
-                pawn.story.hairDef = HairDefOf.Shaved;
-            }
-            else if (Part.def == BodyPartDefOf.Jaw)
-            {
-                // Hide beard
-                pawn.style.beardDef = BeardDefOf.NoBeard;
+                if (Part.def == BodyPartDefOf.Head)
+                {
+                    // Hide hair
+                    pawn.story.hairDef = HairDefOf.Shaved;
+                }
+                else if (Part.def == BodyPartDefOf.Jaw)
+                {
+                    // Hide beard
+                    pawn.style.beardDef = BeardDefOf.NoBeard;
+                }
             }
         }
 
@@ -309,20 +312,23 @@ namespace Pawnmorph
             base.PostRemoved();
             if (!PawnGenerator.IsBeingGenerated(pawn))
                 pawn.GetMutationTracker()?.NotifyMutationRemoved(this);
-            
-            var initialGraphics = pawn.GetComp<InitialGraphicsComp>();
-            if (initialGraphics != null)
+
+            if (Def.RemoveComp?.layer == MutationLayer.Core)
             {
-                if (Part.def == BodyPartDefOf.Head)
+                var initialGraphics = pawn.GetComp<InitialGraphicsComp>();
+                if (initialGraphics != null)
                 {
-                    // Hide hair
-                    pawn.story.hairDef = initialGraphics.HairDef;
-                }
-                else if (Part.def == BodyPartDefOf.Jaw)
-                {
-                    // Hide beard
-                    if (initialGraphics.Beard != null)
-                        pawn.style.beardDef = initialGraphics.Beard;
+                    if (Part.def == BodyPartDefOf.Head)
+                    {
+                        // Hide hair
+                        pawn.story.hairDef = initialGraphics.HairDef;
+                    }
+                    else if (Part.def == BodyPartDefOf.Jaw)
+                    {
+                        // Hide beard
+                        if (initialGraphics.Beard != null)
+                            pawn.style.beardDef = initialGraphics.Beard;
+                    }
                 }
             }
         }

--- a/Source/Pawnmorphs/Esoteria/Hybrids/RaceShiftUtilities.cs
+++ b/Source/Pawnmorphs/Esoteria/Hybrids/RaceShiftUtilities.cs
@@ -279,6 +279,12 @@ namespace Pawnmorph.Hybrids
 
             }
 
+
+            foreach (Hediff_AddedMutation mutation in pawn.health.hediffSet.hediffs.OfType<Hediff_AddedMutation>())
+            {
+                mutation.ApplyVisualAdjustment();
+            } 
+
             if (reRollTraits && race is ThingDef_AlienRace alienDef) 
                 ReRollRaceTraits(pawn, alienDef);
 

--- a/Source/Pawnmorphs/Esoteria/PMStyleDefOf.cs
+++ b/Source/Pawnmorphs/Esoteria/PMStyleDefOf.cs
@@ -1,0 +1,26 @@
+﻿// BackstoryDefOf.cs modified by Iron Wolf for Pawnmorph on 11/29/2019 7:35 AM
+// last updated 11/29/2019  7:35 AM
+
+using AlienRace;
+using JetBrains.Annotations;
+using RimWorld;
+
+#pragma warning disable 1591
+namespace Pawnmorph
+{
+    [DefOf]
+    public static class PMStyleDefOf
+    {
+        [NotNull, UsedImplicitly(ImplicitUseKindFlags.Assign)]
+        public static BeardDef PM_BeardHidden;
+
+        [NotNull, UsedImplicitly(ImplicitUseKindFlags.Assign)]
+        public static HairDef PM_HairHidden;
+
+
+        static PMStyleDefOf()
+        {
+            DefOfHelper.EnsureInitializedInCtor(typeof(PMStyleDefOf));
+        }
+    }
+}

--- a/Source/Pawnmorphs/Esoteria/Pawnmorph.csproj
+++ b/Source/Pawnmorphs/Esoteria/Pawnmorph.csproj
@@ -312,6 +312,7 @@
     <Compile Include="Abilities\MutationAbilityState.cs" />
     <Compile Include="Abilities\MutationAbilityType.cs" />
     <Compile Include="Abilities\TerrifyingRoar.cs" />
+    <Compile Include="PMStyleDefOf.cs" />
     <Compile Include="HPatches\Optional\PawnScaling.cs" />
     <Compile Include="Hediffs\Hediff_Bullrush.cs" />
     <Compile Include="HPatches\Optional\FoodStackMultiplier.cs" />

--- a/Source/Pawnmorphs/Esoteria/UserInterface/Dialog_PartPicker.cs
+++ b/Source/Pawnmorphs/Esoteria/UserInterface/Dialog_PartPicker.cs
@@ -12,6 +12,7 @@ using UnityEngine;
 using Verse;
 using Verse.Sound;
 using Pawnmorph.GraphicSys;
+using Pawnmorph.Hediffs.MutationRetrievers;
 
 namespace Pawnmorph.UserInterface
 {
@@ -580,6 +581,26 @@ namespace Pawnmorph.UserInterface
                         {
                             pawn.health.RemoveHediff(mutation);
                         }
+
+
+                        if (mutationDef.blockSites != null)
+                        {
+                            // Foreach body part blocked by added mutation
+                            foreach (var blockedPartDef in mutationDef.blockSites)
+                            {
+                                // Find all equivalent body part records
+                                foreach (BodyPartRecord partRecord in (skinSync ? cachedMutableCoreParts : cachedMutableParts).Where(m => m.def == blockedPartDef))
+                                {
+                                    // Remove all mutations on those body parts of same layer
+                                    foreach (Hediff_AddedMutation mutation in pawnCurrentMutations.Where(m => m.Part == partRecord && m.Def.RemoveComp.layer == layer))
+                                    {
+                                        pawn.health.RemoveHediff(mutation);
+                                    }
+                                    addedMutations.RemoveByPartAndLayer(partRecord, layer);
+                                }
+                            }
+                        }
+
                         foreach (BodyPartRecord part in parts)
                         {
                             addedMutations.RemoveByPartAndLayer(part, layer);
@@ -927,12 +948,9 @@ namespace Pawnmorph.UserInterface
                 }
                 if (!isWearingHat)
                 {
-                    if (addedMutations.Parts.Any(x => x.IsInGroup(BodyPartGroupDefOf.UpperHead)) == false)
-                    {
-                        // Draw hair
-                        Material hairMat = graphics.HairMatAt(previewRot);
-                        GenDraw.DrawMeshNowOrLater(hairMesh, hairOffset, quaternion, hairMat, false);
-                    }
+                    // Draw hair
+                    Material hairMat = graphics.HairMatAt(previewRot);
+                    GenDraw.DrawMeshNowOrLater(hairMesh, hairOffset, quaternion, hairMat, false);
                 }
             }
             if (toggleClothesEnabled)


### PR DESCRIPTION
Mutations now remove beard if on Jaw or hair if on Head. Then reverts to initial when removed.
Moved iguana spikes and cobra hood to be Head-based mutations to replace hair.
Added support for blockedSites in part picker.