### PR TITLE
Prevent mutagun from turning pawns into invalid former humans.

### DIFF
--- a/1.3/Defs/Things/TFWeapons.xml
+++ b/1.3/Defs/Things/TFWeapons.xml
@@ -172,7 +172,7 @@
 			<damageDef>Bullet</damageDef>
 			<damageAmountBase>1</damageAmountBase>
 			<stoppingPower>10</stoppingPower>
-			<speed>15</speed>
+			<speed>50</speed>
 		</projectile>
 		<AddHediffChance>0.7</AddHediffChance>
 		<HediffToAdd>SyringeRifleHediff</HediffToAdd>
@@ -196,7 +196,7 @@
 			<damageDef>Bullet</damageDef>
 			<damageAmountBase>1</damageAmountBase>
 			<stoppingPower>10</stoppingPower>
-			<speed>15</speed>
+			<speed>50</speed>
 		</projectile>
 	</ThingDef>
 

--- a/Source/Pawnmorphs/Esoteria/Hediffs/SyringeRifleTf.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/SyringeRifleTf.cs
@@ -16,13 +16,24 @@ namespace Pawnmorph.Hediffs
     {
         private PawnKindDef _chosenKind;
 
+
         /// <summary>
         /// Gets a value indicating whether this instance should be removed.
         /// </summary>
         /// <value>
         ///   <c>true</c> if this instance should be removed; otherwise, <c>false</c>.
         /// </value>
-        public override bool ShouldRemove => MutationStatValue <= 0; 
+        public override bool ShouldRemove => MutationStatValue <= 0;
+
+
+        /// <summary>
+        /// Gets a random pawnkind animal
+        /// </summary>
+        private PawnKindDef ChooseRandomAnimal()
+        {   
+            return FormerHumanUtilities.AllRegularFormerHumanPawnkindDefs.RandomElement();
+        }
+        
 
         /// <summary>
         /// Initializes this instance with the given weapon
@@ -33,7 +44,7 @@ namespace Pawnmorph.Hediffs
             _chosenKind = weapon?.TryGetComp<AnimalSelectorComp>()?.ChosenKind;
             if (_chosenKind == null)
             {
-                _chosenKind = DefDatabase<PawnKindDef>.AllDefs.Where(p => p.RaceProps.Animal).RandomElement();
+                _chosenKind = ChooseRandomAnimal();
             }
 
             ResetMutationCaches();
@@ -54,7 +65,7 @@ namespace Pawnmorph.Hediffs
         {
             if (_chosenKind == null)
             {
-                _chosenKind = DefDatabase<PawnKindDef>.AllDefs.Where(p => p.RaceProps.Animal).RandomElement();
+                _chosenKind = ChooseRandomAnimal();
             }
             var tfRequest = new TransformationRequest(_chosenKind, pawn);
             var res = MutagenDefOf.defaultMutagen.MutagenCached.Transform(tfRequest);


### PR DESCRIPTION
Currently, Mutagun chooses the animal to transform the pawn into from a list of all animals. This can cause issues, as it may choose an animal that shouldn't ever be mutated into, such as a robot animal, or a(currently disabled) Dryad.

This patch changes the gun to choose from a list of normal former human animals. As a side effect, no Chaomorphs will appear out of the mutagun.

Also adjusted the Mutagun projectile and Tagging rifle projectile speeds from 15 to 50, which makes them not move at a slow motion pace