### PR TITLE
Issue 487 - Fix for revertion triggering funerals for former humans with ideology.

### DIFF
--- a/Source/Pawnmorphs/Esoteria/TfSys/SimpleMechaniteMutagen.cs
+++ b/Source/Pawnmorphs/Esoteria/TfSys/SimpleMechaniteMutagen.cs
@@ -333,8 +333,7 @@ namespace Pawnmorph.TfSys
 
             currentConvertedAge = Math.Max(currentConvertedAge, FormerHumanUtilities.MIN_FORMER_HUMAN_AGE);
             long agedTicksDelta = (long)(currentConvertedAge - originalAge) * 3600000L; // 3600000f ticks per year.
-            transformedPawn.original.ageTracker.AgeBiologicalTicks += agedTicksDelta;
-
+            transformedPawn.original.ageTracker.AgeBiologicalTicks += agedTicksDelta; 
             var spawned = (Pawn) GenSpawn.Spawn(transformedPawn.original, animal.PositionHeld, animal.MapHeld);
 
             if (spawned.Faction != animal.Faction && rFaction == null) //if the responsible faction is null (no one knows who did it) have the reverted pawn join that faction   
@@ -366,6 +365,7 @@ namespace Pawnmorph.TfSys
                 Find.World.worldPawns.RemovePawn(animal);
 
             }
+            animal.ideo = null;
             animal.Destroy();
             return true;
         }


### PR DESCRIPTION
Setting the animal's ideology to null just before destroying it. There may be side effects.
closes #487 