### PR TITLE
Issue 602 - Body purist

### DIFF
--- a/Source/Pawnmorphs/Esoteria/Graphics/InitialGraphics.cs
+++ b/Source/Pawnmorphs/Esoteria/Graphics/InitialGraphics.cs
@@ -34,6 +34,7 @@ namespace Pawnmorph.GraphicSys
 
         private BodyTypeDef _body;
         private ThingDef _scannedRace;
+        private ThingDef _originalRace;
 
         /// <summary>Gets the draw size.</summary>
         /// <value>The size of the custom draw.</value>
@@ -53,6 +54,18 @@ namespace Pawnmorph.GraphicSys
             get
             {
                 return _scannedRace;
+            }
+        }
+
+        /// <summary>Gets the pawn scanned pawn race.</summary>
+        public ThingDef OriginalRace
+        {
+            get
+            {
+                if (!_scanned)
+                    ScanGraphics();
+
+                return _originalRace;
             }
         }
 
@@ -253,6 +266,7 @@ namespace Pawnmorph.GraphicSys
             Scribe_Defs.Look(ref _hairDef, nameof(_hairDef));
             Scribe_Deep.Look(ref _styleInfo, "styleInfo");
             Scribe_Defs.Look(ref _scannedRace, nameof(_scannedRace));
+            Scribe_Defs.Look(ref _originalRace, nameof(_originalRace));
 
             if (Scribe.mode == LoadSaveMode.PostLoadInit)
             {
@@ -331,6 +345,9 @@ namespace Pawnmorph.GraphicSys
             _hairColor = Pawn.story.hairColor;
             _body = Pawn.story.bodyType;
             _scannedRace = Pawn.def;
+            
+            if (_originalRace == null)
+                _originalRace = Pawn.def;
 
 
             var styleTracker = Pawn.style;

--- a/Source/Pawnmorphs/Esoteria/Thoughts/Worker_HasMutations.cs
+++ b/Source/Pawnmorphs/Esoteria/Thoughts/Worker_HasMutations.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Pawnmorph.DefExtensions;
+using Pawnmorph.Hediffs;
 using Pawnmorph.Hybrids;
 using RimWorld;
 using UnityEngine;
@@ -16,11 +17,6 @@ namespace Pawnmorph.Thoughts
     /// </summary>
     public class Worker_HasMutations : ThoughtWorker
     {
-
-        private List<Thought> _scratchList = new List<Thought>(); 
-
-
-
         /// <summary>
         /// return the thought state for the given pawn 
         /// </summary>
@@ -28,22 +24,33 @@ namespace Pawnmorph.Thoughts
         /// <returns></returns>
         protected override ThoughtState CurrentStateInternal(Pawn p)
         {
-            if (!def.IsValidFor(p)) return false;
+            if (!def.IsValidFor(p)) 
+                return ThoughtState.Inactive;
+
             MutationTracker mutTracker = p.GetMutationTracker();
-            if (mutTracker == null) return false;
+            if (mutTracker == null) 
+                return ThoughtState.Inactive;
             
-            if (!mutTracker.AllMutations.Any()) return false;
 
-            var morph = p.def.GetMorphOfRace();
-            var influence = morph == null
-                                ? MorphUtilities.GetMaxInfluenceOfRace(p.def)
-                                : morph.GetMaxInfluenceForBody(p.RaceProps.body);
+            if (!mutTracker.AllMutations.Any()) 
+                return ThoughtState.Inactive;
+            
+            var nInfluence = mutTracker.TotalNormalizedInfluence;
+            
+            RaceMutationSettingsExtension racialMutations = p.def.TryGetRaceMutationSettings();
+            if (racialMutations != null)
+            {
+                foreach (var racialMutationGiver in racialMutations.mutationRetrievers.OfType<Hediffs.MutationRetrievers.AnimalClassRetriever>())
+                    nInfluence -= mutTracker.GetDirectNormalizedInfluence(racialMutationGiver.animalClass);
+                
+            }
 
-            var nInfluence = mutTracker.TotalInfluence / influence;
-            var idx = Mathf.Clamp(nInfluence * def.stages.Count, 0, def.stages.Count - 1);
+            var idx = Mathf.FloorToInt(Mathf.Clamp(nInfluence * def.stages.Count, 0, def.stages.Count - 1));
 
-            return ThoughtState.ActiveAtStage(Mathf.FloorToInt(idx));  
+            if (idx > 0)
+                return ThoughtState.ActiveAtStage(idx);
 
+            return ThoughtState.Inactive;
             
         }
     }


### PR DESCRIPTION
Modified mutation thought worker to ignore mutations assigned to race by default.
Affects both body purists and Mutation Affinity. Neither will react to morph influence of their own base species.
This means that to satisfy a Mutation Affinity Orassan, you **have** to use non-"Cat" mutations.
Thoughtworker runs approx. once every 60 ticks. (once per second at x1 speed)
Closes #602