### PR TITLE
Issue 372 - mutation log

### DIFF
--- a/1.3/Defs/Mutagens/defaultMutagen.xml
+++ b/1.3/Defs/Mutagens/defaultMutagen.xml
@@ -2,6 +2,12 @@
 <Defs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../Schemas/MutagenDef.xsd">
 	<Pawnmorph.MutagenDef ParentName="SimpleMutagenBase">
 		<defName>defaultMutagen</defName>
+		<!--<causeRulePack>
+			<rulesStrings>
+				<li>mutagen_cause->getting jabbed by an injector</li>
+				<li>mutagen_cause->injector</li>
+			</rulesStrings>
+		</causeRulePack>-->
 	</Pawnmorph.MutagenDef>
 	<Pawnmorph.MutagenDef ParentName="SimpleMutagenBase">
 		<defName>PM_ChamberMutagen</defName>
@@ -40,6 +46,12 @@
 
 	<Pawnmorph.MutagenDef ParentName="AspectGivingMutagenBase">
 		<defName>AspectGivingMutagen</defName>
+		<!--<causeRulePack>
+			<rulesStrings>
+				<li>mutagen_cause->getting jabbed by an injector</li>
+				<li>mutagen_cause->injector</li>
+			</rulesStrings>
+		</causeRulePack>-->
 	</Pawnmorph.MutagenDef>
 
 

--- a/1.3/Defs/RulePacks/CoveringMutationLogPacks.xml
+++ b/1.3/Defs/RulePacks/CoveringMutationLogPacks.xml
@@ -16,7 +16,7 @@
         <defName>FurGrowthLogPack</defName>
         <rulePack>
             <rulesStrings>
-                <li>label->fur</li>
+                <li>label_text->fur</li>
                 <li>bulk_label->coat</li>
             </rulesStrings>
         </rulePack>
@@ -26,7 +26,7 @@
         <defName>HideGrowthLogPack</defName>
         <rulePack>
             <rulesStrings>
-                <li>label->hide</li>
+                <li>label_text->hide</li>
                 <li>bulk_label->layer</li>
             </rulesStrings>
         </rulePack>
@@ -35,7 +35,7 @@
         <defName>ScaleGrowthLogPack</defName>
         <rulePack>
             <rulesStrings>
-                <li>label->scales</li>
+                <li>label_text->scales</li>
                 <li>bulk_label->coating</li>
             </rulesStrings>
         </rulePack>
@@ -45,7 +45,7 @@
         <defName>FeatherGrowthLogPack</defName>
         <rulePack>
             <rulesStrings>
-                <li>label->feathers</li>
+                <li>label_text->feathers</li>
                 <li>bulk_label->layer</li>
             </rulesStrings>
         </rulePack>

--- a/1.3/Defs/RulePacks/MutationPackBases.xml
+++ b/1.3/Defs/RulePacks/MutationPackBases.xml
@@ -36,10 +36,10 @@
     <RulePackDef Name="CustomMutationRulePackBase" Abstract="true">
         <rulePack>
             <rulesStrings>
-                <li>mutation_log->[pname] [initial] [action_group] [modifier_group] [a_an] [label_group] caused by [mutagen_cause].</li>
+                <li>mutation_log->[pname] [initial] [action_group] [modifier_group] [a_an] [label_group] [caused_by] [mutagen_cause].</li>
                 <li>action_group->[action]</li>
                 <li>modifier_group->[modifier]</li>
-                <li>label_group->[label]</li>
+                <li>label_group->[label_text]</li>
             </rulesStrings>
         </rulePack>
     </RulePackDef>
@@ -51,7 +51,7 @@
         <rulePack>
             <rulesStrings>
                 <li>initial->[PART_label]</li>
-                <li>label->[MUTATION_label]</li>
+                <li>label_text->[MUTATION_label]</li>
                 <li>pname->[PAWN_nameDef]'s</li>
             </rulesStrings>
         </rulePack>
@@ -61,7 +61,7 @@
         <rulePack>
             <rulesStrings>
                 <li>initial-></li> <!-- empty -->
-                <li>label->[MUTATION_label]</li>
+                <li>label_text->[MUTATION_label]</li>
                 <li>action->grew</li>
                 <li>pname->[PAWN_nameDef]</li>
             </rulesStrings>

--- a/Source/Pawnmorphs/Esoteria/HediffGiver_Mutation.cs
+++ b/Source/Pawnmorphs/Esoteria/HediffGiver_Mutation.cs
@@ -127,7 +127,7 @@ namespace Pawnmorph
             bool added = PawnmorphHediffGiverUtility.TryApply(pawn, hediff, partsToAffect, canAffectAnyLivePart, countToAffect, outAddedHediffs);
             if (addLogEntry && added && partsToAffect != null)
             {
-                AddMutationLogFor(pawn);
+                AddMutationLogFor(pawn, mutagenDef);
             }
 
             if (added)
@@ -141,9 +141,9 @@ namespace Pawnmorph
             return added;
         }
 
-        private void AddMutationLogFor(Pawn pawn)
+        private void AddMutationLogFor(Pawn pawn, MutagenDef mutagenDef)
         {
-            var log = new MutationLogEntry(pawn, hediff, null, partsToAffect);
+            var log = new MutationLogEntry(pawn, hediff, mutagenDef, partsToAffect);
             Find.PlayLog.Add(log);
         }
 
@@ -177,7 +177,7 @@ namespace Pawnmorph
             var hediffInst = HediffMaker.MakeHediff(hediff, pawn, recordToAdd);
             pawn.health.AddHediff(hediffInst, recordToAdd);
             DoMutationAddedEffects(pawn);
-            AddMutationLogFor(pawn);
+            AddMutationLogFor(pawn, mutagen);
 
             return true; 
         }

--- a/Source/Pawnmorphs/Esoteria/MutationCauseUtility.cs
+++ b/Source/Pawnmorphs/Esoteria/MutationCauseUtility.cs
@@ -28,7 +28,7 @@ namespace Pawnmorph
             if (causes == null) throw new ArgumentNullException(nameof(causes));
             if (mutagen == null) throw new ArgumentNullException(nameof(mutagen));
 
-            causes.Add(MutationCauses.MUTAGEN_PREFIX, mutagen); 
+            causes.Add(MutationCauses.MUTAGEN_PREFIX, mutagen);
         }
 
 

--- a/Source/Pawnmorphs/Esoteria/MutationCauses.cs
+++ b/Source/Pawnmorphs/Esoteria/MutationCauses.cs
@@ -31,7 +31,7 @@ namespace Pawnmorph
         /// <summary>
         ///     The mutagen cause prefix
         /// </summary>
-        public const string MUTAGEN_PREFIX = "mutagen";
+        public const string MUTAGEN_PREFIX = "mutagen_cause";
 
         /// <summary>
         /// The precept prefix

--- a/Source/Pawnmorphs/Esoteria/MutationLogEntry.cs
+++ b/Source/Pawnmorphs/Esoteria/MutationLogEntry.cs
@@ -198,7 +198,7 @@ namespace Pawnmorph
                 grammarRequest.Rules.AddRange(pawnR);
                 grammarRequest.Rules.AddRange(mutR);
                 grammarRequest.Rules.AddRange(partRules);
-                return GrammarResolver.Resolve(RP_ROOT_RULE, grammarRequest, "mutation log", true);
+                return GrammarResolver.Resolve(RP_ROOT_RULE, grammarRequest, "mutation log", forceLog);
             }
             catch (Exception exception)
             {

--- a/Source/Pawnmorphs/Esoteria/MutationLogEntry.cs
+++ b/Source/Pawnmorphs/Esoteria/MutationLogEntry.cs
@@ -34,23 +34,7 @@ namespace Pawnmorph
         private HediffDef _mutationDef;
         private List<BodyPartDef> _mutatedRecords;
         private Pawn _pawn;
-        [CanBeNull] private MutagenDef _mutagenCause;
-        [CanBeNull] private MutationCauses _causes; 
-
-        
-        [NotNull] private MutagenDef BestMutagenCause
-        {
-            get
-            {
-                if (_mutagenCause == null)
-                {
-                    _mutagenCause = _causes?.GetAllCauses<MutagenDef>()?.FirstOrDefault()?.causeDef; 
-                    
-                }
-
-                return _mutagenCause ?? MutagenDefOf.defaultMutagen; 
-            }
-        }
+        private MutationCauses _causes; 
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MutationLogEntry"/> class.
@@ -71,8 +55,6 @@ namespace Pawnmorph
         {
             get
             {
-                if(_causes == null) _causes = new MutationCauses();
-                
                 return _causes; 
             }
         }
@@ -90,6 +72,10 @@ namespace Pawnmorph
             _mutatedRecords = mutatedParts.ToList();
             _pawn = pawn;
             _mutationDef = mutationDef;
+            _causes = new MutationCauses();
+
+            if (mutagenCause != null)
+                _causes.AddMutagenCause(mutagenCause);
         }
 
         /// <summary>
@@ -194,9 +180,16 @@ namespace Pawnmorph
                     grammarRequest.Rules.AddRange(_causes.GenerateRules());
                 }
 
-                if (!grammarRequest.HasRule(MUTAGEN_CAUSE_STRING))
+                if (grammarRequest.HasRule(MUTAGEN_CAUSE_STRING))
                 {
-                    grammarRequest.Rules.Add(new Rule_String(MUTAGEN_CAUSE_STRING, UNKNOWN_CAUSE.Translate()));
+                    
+                    grammarRequest.Rules.Add(new Rule_String("caused_by", "caused by"));
+                    //grammarRequest.Rules.Add(new Rule_String(MUTAGEN_CAUSE_STRING, UNKNOWN_CAUSE.Translate()));
+                }
+                else
+                {
+                    grammarRequest.Rules.Add(new Rule_String("caused_by", ""));
+                    grammarRequest.Rules.Add(new Rule_String(MUTAGEN_CAUSE_STRING, ""));
                 }
 
 
@@ -205,7 +198,7 @@ namespace Pawnmorph
                 grammarRequest.Rules.AddRange(pawnR);
                 grammarRequest.Rules.AddRange(mutR);
                 grammarRequest.Rules.AddRange(partRules);
-                return GrammarResolver.Resolve(RP_ROOT_RULE, grammarRequest, "mutation log", forceLog);
+                return GrammarResolver.Resolve(RP_ROOT_RULE, grammarRequest, "mutation log", true);
             }
             catch (Exception exception)
             {

--- a/Source/Pawnmorphs/Esoteria/Pawnmorph.csproj
+++ b/Source/Pawnmorphs/Esoteria/Pawnmorph.csproj
@@ -15,8 +15,8 @@
     <RimworldFolder Condition=" '$(RimworldFolder)' == '' ">..\..\..\..\..\RimWorldWin64_Data</RimworldFolder>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>false</DebugSymbols>
-    <DebugType>none</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\..\1.3\Assemblies\</OutputPath>
     <DefineConstants>TRACE;DEBUG</DefineConstants>


### PR DESCRIPTION
Hid cause if the cause has no rules provided.
Renamed "label" to "label_text" because it got confused default "label" (name of hediff).
Renamed "mutagen" to "mutagen_cause" to match what is expected by old code and XML.

Closes #372