### PR TITLE
Optimizations and fixes for 1.4

### DIFF
--- a/Source/Pawnmorphs/Esoteria/DebugUtils/PMDebugActions.cs
+++ b/Source/Pawnmorphs/Esoteria/DebugUtils/PMDebugActions.cs
@@ -433,6 +433,22 @@ namespace Pawnmorph.DebugUtils
         }
 
 
+        [DebugAction("Pawnmorpher", "Make pawn alien.", actionType = DebugActionType.ToolMapForPawns, allowedGameStates = AllowedGameStates.PlayingOnMap)]
+        public static void MakePawnAlien(Pawn pawn)
+        {
+            if (pawn.def is ThingDef_AlienRace == false)
+                return;
+
+            List<DebugMenuOption> options = new List<DebugMenuOption>();
+
+            foreach (var alienRace in DefDatabase<ThingDef>.AllDefs.OfType<ThingDef_AlienRace>().Except(RaceGenerator.ImplicitRaces))
+            {
+                options.Add(new DebugMenuOption(alienRace.LabelCap, DebugMenuOptionMode.Action, () => RaceShiftUtilities.ChangePawnRace(pawn, alienRace)));
+            }
+
+            Find.WindowStack.Add(new Dialog_DebugOptionListLister(options));
+        }
+
 
         private static void MakePawnMorph([CanBeNull] MorphDef morph)
         {

--- a/Source/Pawnmorphs/Esoteria/Graphics/InitialGraphics.cs
+++ b/Source/Pawnmorphs/Esoteria/Graphics/InitialGraphics.cs
@@ -226,6 +226,11 @@ namespace Pawnmorph.GraphicSys
             }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether this <see cref="InitialGraphicsComp"/> is has scanned graphics that can be restored.
+        /// </summary>
+        public bool Scanned => _scanned;
+
         private Pawn Pawn => (Pawn) parent;
 
         /// <summary>Gets the debug string.</summary>

--- a/Source/Pawnmorphs/Esoteria/HPatches/Optional/PawnScaling.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/Optional/PawnScaling.cs
@@ -1,5 +1,7 @@
 ﻿using AlienRace;
+using Pawnmorph.GraphicSys;
 using Pawnmorph.Utilities;
+using RimWorld;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -19,6 +21,10 @@ namespace Pawnmorph.HPatches.Optional
     static class PawnScaling
     {
         static bool _enabled = false;
+        static Pawn _currentPawn;
+        static float _currentScaledBodySize;
+
+
 
         static bool Prepare(MethodBase original)
         {
@@ -35,6 +41,7 @@ namespace Pawnmorph.HPatches.Optional
         {
             LongEventHandler.ExecuteWhenFinished(() =>
             {
+                _currentPawn = null;
                 ResolveAllGraphics(pawn);
             });
         }
@@ -42,7 +49,7 @@ namespace Pawnmorph.HPatches.Optional
         // Updates all draw sizes on comp to specified size.
         private static void SetCompScales(AlienComp comp, Pawn pawn, float bodysize)
         {
-            float sizeOffset = GetScale(bodysize) / pawn.RaceProps.baseBodySize;
+            float sizeOffset = bodysize;
 
             var partGenerator = (pawn.def as ThingDef_AlienRace).alienRace.generalSettings.alienPartGenerator;
             Vector2 sizeOffsetVector = new Vector2(sizeOffset, sizeOffset);
@@ -57,7 +64,7 @@ namespace Pawnmorph.HPatches.Optional
         [HarmonyLib.HarmonyPatch(typeof(AlienComp), nameof(AlienComp.PostSpawnSetup)), HarmonyLib.HarmonyPostfix]
         private static void PostSpawnSetup(bool respawningAfterLoad, AlienComp __instance)
         {
-            SetCompScales(__instance, (Pawn)__instance.parent, ((Pawn)__instance.parent).BodySize);
+            SetCompScales(__instance, (Pawn)__instance.parent, GetScale((Pawn)__instance.parent));
         }
 
 
@@ -65,7 +72,7 @@ namespace Pawnmorph.HPatches.Optional
         [HarmonyLib.HarmonyPatch(typeof(Verse.PawnGraphicSet), nameof(Verse.PawnGraphicSet.ResolveAllGraphics)), HarmonyLib.HarmonyPostfix]
         private static void ResolveAllGraphics(Pawn ___pawn)
         {
-            float bodysize = ___pawn.BodySize;
+            float bodysize = GetScale(___pawn);
             if (bodysize == 1)
                 return;
 
@@ -81,7 +88,7 @@ namespace Pawnmorph.HPatches.Optional
         [HarmonyLib.HarmonyPatch(typeof(AlienRace.HarmonyPatches), nameof(AlienRace.HarmonyPatches.DrawAddonsFinalHook)), HarmonyLib.HarmonyPostfix]
         private static void DrawAddonsFinalHook(Pawn pawn, AlienRace.AlienPartGenerator.BodyAddon addon, ref Graphic graphic, ref Vector3 offsetVector, ref float angle, ref Material mat)
         {
-            float value = GetScale(pawn.BodySize) / pawn.RaceProps.baseBodySize;
+            float value = GetScale(pawn);
             offsetVector.x *= value;
             // Don't affect y layer
             offsetVector.z *= value;
@@ -94,14 +101,14 @@ namespace Pawnmorph.HPatches.Optional
         {
             if (portrait)
             {
-                cameraZoom *= 1f / GetScale(pawn.BodySize);
+                cameraZoom *= 1f / GetScale(pawn);
             }
         }
 
         [HarmonyLib.HarmonyPatch(typeof(GlobalTextureAtlasManager), nameof(GlobalTextureAtlasManager.TryGetPawnFrameSet)), HarmonyLib.HarmonyPrefix]
         private static bool TryGetPawnFrameSetPrefix(Pawn pawn)
         {
-            if (pawn.BodySize > 1.0f)
+            if (GetScale(pawn) > 1.0f)
                 return false;
 
             return true;
@@ -110,16 +117,22 @@ namespace Pawnmorph.HPatches.Optional
 
         // Calculate the rendered size based on body size
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static float GetScale(float bodysize)
+        private static float GetScale(Pawn pawn)
         {
-            return Mathf.Sqrt(bodysize);
+            if (_currentPawn != pawn)
+            {
+                _currentPawn = pawn;
+                _currentScaledBodySize = Mathf.Sqrt(pawn.BodySize / pawn.RaceProps.baseBodySize);
+            }
+            
+            return _currentScaledBodySize;
         }
 
         // Offset rendered pawn from actual position to move selection box to their feet.
         [HarmonyLib.HarmonyPatch(typeof(Pawn), nameof(Pawn.DrawAt)), HarmonyLib.HarmonyPrefix]
         private static void DrawAt(ref Vector3 drawLoc, bool flip, Pawn __instance)
         {
-            float bodySize = __instance.BodySize;
+            float bodySize = GetScale(__instance);
             // Don't offset draw position of animals sprites, and only care about those with more than 1 body size.
             if (__instance.RaceProps.Humanlike && bodySize != 1)
             {
@@ -127,7 +140,7 @@ namespace Pawnmorph.HPatches.Optional
                 // Offset drawn pawn sprite with half the height upward. 1 bodysize = 1 height.
                 // Only offset when standing.
                 if (__instance.GetPosture() == RimWorld.PawnPosture.Standing)
-                    drawLoc.z += (GetScale(bodySize) - 1) / 4f;
+                    drawLoc.z += (bodySize - __instance.RaceProps.baseBodySize) / 2f;
             }
         }
 
@@ -135,11 +148,11 @@ namespace Pawnmorph.HPatches.Optional
         [HarmonyLib.HarmonyPatch(typeof(PawnRenderer), nameof(PawnRenderer.BaseHeadOffsetAt)), HarmonyLib.HarmonyPostfix]
         private static void BaseHeadOffsetAt(Rot4 rotation, ref Vector3 __result, Pawn ___pawn)
         {
-            float bodySize = ___pawn.BodySize;
+            float bodySize = GetScale(___pawn);
             if (bodySize == 1)
                 return;
 
-            float size = Mathf.Floor(GetScale(bodySize) / ___pawn.RaceProps.baseBodySize * 10) / 10;
+            float size = Mathf.Floor(bodySize * 10) / 10;
             __result.z = __result.z * size;
             __result.x = __result.x * size;
         }

--- a/Source/Pawnmorphs/Esoteria/Hediffs/Hediff_StageChanges.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Hediff_StageChanges.cs
@@ -18,7 +18,8 @@ namespace Pawnmorph.Hediffs
         private int cachedStageIndex = -1;
         [Unsaved] private HediffStage cachedStage;
 
-        private List<Abilities.MutationAbility> abilities = new List<Abilities.MutationAbility>();
+        protected bool TickBase = true;
+
         private List<IStageChangeObserverComp> observerComps;
         private IEnumerable<IStageChangeObserverComp> ObserverComps
         {
@@ -66,7 +67,8 @@ namespace Pawnmorph.Hediffs
         /// </summary>
         public override void Tick()
         {
-            base.Tick();
+            if (TickBase)
+                base.Tick();
 
             int stageIndex = base.CurStageIndex; // Make sure to get the actual index from the base
             if (stageIndex != cachedStageIndex)
@@ -74,45 +76,10 @@ namespace Pawnmorph.Hediffs
                 var oldStage = cachedStage;
                 RecacheStage(stageIndex);
                 OnStageChanged(oldStage, cachedStage);
-                GenerateAbilities(cachedStage);
 
                 foreach (var comp in ObserverComps)
                     comp.OnStageChanged(oldStage, cachedStage);
             }
-
-            foreach (Abilities.MutationAbility ability in abilities)
-            {
-                ability.Tick();
-            }
-        }
-
-        private void GenerateAbilities(HediffStage stage)
-        {
-            if (stage is MutationStage mutationStage)
-            {
-                abilities = new List<Abilities.MutationAbility>();
-                if (mutationStage.abilities == null || mutationStage.abilities.Count == 0)
-                    return;
-
-                //Abilities.MutationAbility ability;
-                foreach (Abilities.MutationAbilityDef abilityDef in mutationStage.abilities)
-                {
-                    if (abilityDef.abilityClass.BaseType == typeof(Abilities.MutationAbility))
-                    {
-                        Abilities.MutationAbility ability = (Abilities.MutationAbility)Activator.CreateInstance(abilityDef.abilityClass, abilityDef);
-                        abilities.Add(ability);
-                        ability.Initialize(pawn);
-                    }
-                }
-            }
-        }
-
-        public override IEnumerable<Gizmo> GetGizmos()
-        {
-            foreach (Gizmo gizmo in base.GetGizmos()) yield return gizmo;
-
-            foreach (Abilities.MutationAbility item in abilities)
-                yield return item.Gizmo;
         }
 
         /// <summary>
@@ -137,17 +104,10 @@ namespace Pawnmorph.Hediffs
         {
             base.ExposeData();
             Scribe_Values.Look(ref cachedStageIndex, nameof(cachedStageIndex), base.CurStageIndex);
-            Scribe_Collections.Look(ref abilities, nameof(abilities));
 
             if (Scribe.mode == LoadSaveMode.PostLoadInit)
             {
                 RecacheStage(cachedStageIndex);
-
-                // Null if not previously saved.
-                if (abilities == null)
-                    abilities = new List<Abilities.MutationAbility>();
-
-                GenerateAbilities(cachedStage);
             }
         }
     }

--- a/Source/Pawnmorphs/Esoteria/Hybrids/RaceShiftUtilities.cs
+++ b/Source/Pawnmorphs/Esoteria/Hybrids/RaceShiftUtilities.cs
@@ -340,7 +340,7 @@ namespace Pawnmorph.Hybrids
                 return;
             }
 
-            if (graphicsComp == null)
+            if (graphicsComp == null || graphicsComp.Scanned == false)
                 return;
 
             //story.bodyType = graphicsComp.BodyType;

--- a/Source/Pawnmorphs/Esoteria/PawnmorpherModInit.cs
+++ b/Source/Pawnmorphs/Esoteria/PawnmorpherModInit.cs
@@ -532,8 +532,6 @@ namespace Pawnmorph
         {
             var pType = typeof(AlienPartGenerator.BodyAddon);
             var shaderField = pType.GetField("shaderType", BindingFlags.Instance | BindingFlags.NonPublic);
-            var prioritizationField = pType.GetField("prioritization", BindingFlags.Instance | BindingFlags.NonPublic);
-            var colorChannelField = pType.GetField("colorChannel", BindingFlags.Instance | BindingFlags.NonPublic);
             string aID = (addon as TaggedBodyAddon)?.anchorID; 
             var copy = new TaggedBodyAddon()
             { 
@@ -556,8 +554,16 @@ namespace Pawnmorph
                 layerInvert = addon.layerInvert,
                 variantCount = addon.variantCount,
                 hediffGraphics = addon.hediffGraphics.MakeSafe().ToList(),
+                ageGraphics = addon.ageGraphics.MakeSafe().ToList(),
+                damageGraphics = addon.damageGraphics.MakeSafe().ToList(),
+                bodytypeGraphics = addon.bodytypeGraphics.MakeSafe().ToList(),
+                genderGraphics = addon.genderGraphics.MakeSafe().ToList(),
+                headtypeGraphics = addon.headtypeGraphics.MakeSafe().ToList(),
+                traitGraphics = addon.traitGraphics.MakeSafe().ToList(),
                 alignWithHead = addon.alignWithHead,
                 
+                ColorChannel = addon.ColorChannel,
+
 
                 hiddenUnderApparelTag = addon.hiddenUnderApparelTag,
                 defaultOffsets = addon.defaultOffsets,
@@ -567,8 +573,6 @@ namespace Pawnmorph
             };
 
             shaderField.SetValue(copy, addon.ShaderType);
-            prioritizationField.SetValue(copy, prioritizationField.GetValue(addon));
-            colorChannelField.SetValue(copy, addon.ColorChannel);
 
             
             return copy;


### PR DESCRIPTION
Disabled core rimworld logic for mutation hediffs, as this type of hediffs never utilizes any of the underlying logic. Skipping it makes mutations significantly cheaper to maintain. (Stuff like hediffGivers, Vomiting, etc, is handled in core logic.)
Moved mutation abilities to mutation derived mutation type and moved all stage handling to the intermediate stage management type. (It was duplicated logic)
 - Now the mutations are basically only occasionally checking if severity crossed stage threshold and then triggers an update reacting to that and then returns to being inert performance wise.

Significantly reduced overhead of scaling logic and should now support races with different base size.
Might still be an issue related to calling HAR "ResolveAllGraphics" way too often. As far as I can tell, this also triggers a full rediscover of all textures needlessly.