### PR TITLE
Use part efficiency instead of manipulation offsets for hand mutations

### DIFF
--- a/1.4/Defs/MorphsAndMutationDefs/Shared/HandMutations.xml
+++ b/1.4/Defs/MorphsAndMutationDefs/Shared/HandMutations.xml
@@ -443,7 +443,6 @@
 					<label>changing</label>
 					<description>[PAWN_nameDef]'s fingers have shrunken down significantly, making manipulating things much harder.</description>
 					<partEfficiencyOffset>-0.50</partEfficiencyOffset>
-					</capMods>
 				</values>
 			</li>
 			<li function="modify">

--- a/1.4/Defs/MorphsAndMutationDefs/Shared/HandMutations.xml
+++ b/1.4/Defs/MorphsAndMutationDefs/Shared/HandMutations.xml
@@ -205,34 +205,19 @@
 			<li function="modify">
 				<stageKey>unfamiliar</stageKey>
 				<values>
-					<capMods>
-						<li>
-							<capacity>Manipulation</capacity>
-							<offset>-0.10</offset>
-						</li>
-					</capMods>
+					<partEfficiencyOffset>-0.20</partEfficiencyOffset>
 				</values>
 			</li>
 			<li function="modify">
 				<stageKey>adapting</stageKey>
 				<values>
-					<capMods>
-						<li>
-							<capacity>Manipulation</capacity>
-							<offset>-0.25</offset>
-						</li>
-					</capMods>
+					<partEfficiencyOffset>-0.50</partEfficiencyOffset>
 				</values>
 			</li>
 			<li function="modify">
 				<stageKey>adapted</stageKey>
 				<values>
-					<capMods>
-						<li>
-							<capacity>Manipulation</capacity>
-							<offset>-0.15</offset>
-						</li>
-					</capMods>
+					<partEfficiencyOffset>-0.15</partEfficiencyOffset>
 				</values>
 			</li>
 		</stagePatches>
@@ -247,23 +232,13 @@
 			<li function="modify">
 				<stageKey>unfamiliar</stageKey>
 				<values>
-					<capMods>
-						<li>
-							<capacity>Manipulation</capacity>
-							<offset>-0.05</offset>
-						</li>
-					</capMods>
+					<partEfficiencyOffset>-0.10</partEfficiencyOffset>
 				</values>
 			</li>
 			<li function="modify">
 				<stageKey>adapting</stageKey>
 				<values>
-					<capMods>
-						<li>
-							<capacity>Manipulation</capacity>
-							<offset>-0.10</offset>
-						</li>
-					</capMods>
+					<partEfficiencyOffset>-0.20</partEfficiencyOffset>
 					<statOffsets>
 						<ArmorRating_Sharp>0.05</ArmorRating_Sharp>
 					</statOffsets>
@@ -272,12 +247,7 @@
 			<li function="modify">
 				<stageKey>adapted</stageKey>
 				<values>
-					<capMods>
-						<li>
-							<capacity>Manipulation</capacity>
-							<offset>-0.05</offset>
-						</li>
-					</capMods>
+					<partEfficiencyOffset>-0.10</partEfficiencyOffset>
 					<statOffsets>
 						<ArmorRating_Sharp>0.05</ArmorRating_Sharp>
 					</statOffsets>
@@ -316,12 +286,7 @@
 						<DrugCookingSpeed>0.05</DrugCookingSpeed>
 						<ArmorRating_Sharp>0.05</ArmorRating_Sharp>
 					</statOffsets>
-					<capMods>
-						<li>
-							<capacity>Manipulation</capacity>
-							<offset>-0.05</offset>
-						</li>
-					</capMods>
+					<partEfficiencyOffset>-0.10</partEfficiencyOffset>
 				</values>
 			</li>
 			<li function="modify">
@@ -469,12 +434,7 @@
 				<stageKey>unfamiliar</stageKey>
 				<values>
 					<description>[PAWN_nameDef]'s fingers have started shrinking alarmingly.</description>
-					<capMods>
-						<li>
-							<capacity>Manipulation</capacity>
-							<offset>-0.1</offset>
-						</li>
-					</capMods>
+					<partEfficiencyOffset>-0.20</partEfficiencyOffset>
 				</values>
 			</li>
 			<li function="modify">
@@ -482,24 +442,15 @@
 				<values>
 					<label>changing</label>
 					<description>[PAWN_nameDef]'s fingers have shrunken down significantly, making manipulating things much harder.</description>
-					<capMods>
-						<li>
-							<capacity>Manipulation</capacity>
-							<offset>-0.25</offset>
-						</li>
+					<partEfficiencyOffset>-0.50</partEfficiencyOffset>
 					</capMods>
 				</values>
 			</li>
 			<li function="modify">
 				<stageKey>adapted</stageKey>
 				<values>
-					<description>[PAWN_nameDef]'s fingers have mostly disappeared into a lump of bird-skinned flesh, with many feathers protruding from the nub.</description>
-					<capMods>
-						<li>
-							<capacity>Manipulation</capacity>
-							<offset>-0.5</offset>
-						</li>
-					</capMods>
+					<description>[PAWN_nameDef]'s fingers have mostly disappeared into an almost-useless lump of bird-skinned flesh, with many feathers protruding from the nub.  </description>
+					<partEfficiencyOffset>-0.90</partEfficiencyOffset>
 					<!-- almost useless nub -->
 				</values>
 			</li>
@@ -863,12 +814,7 @@
 					<statOffsets>
 						<WorkSpeedGlobal>-0.1</WorkSpeedGlobal>
 					</statOffsets>
-					<capMods>
-						<li>
-							<capacity>Manipulation</capacity>
-							<offset>-0.2</offset>
-						</li>
-					</capMods>
+					<partEfficiencyOffset>-0.40</partEfficiencyOffset>
 				</values>
 			</li>
 			<li function="modify">
@@ -879,12 +825,7 @@
 						<MeleeWeapon_AverageArmorPenetration>0.05</MeleeWeapon_AverageArmorPenetration>
 						<WorkSpeedGlobal>-0.2</WorkSpeedGlobal>
 					</statOffsets>
-					<capMods>
-						<li>
-							<capacity>Manipulation</capacity>
-							<offset>-0.15</offset>
-						</li>
-					</capMods>
+					<partEfficiencyOffset>-0.30</partEfficiencyOffset>
 				</values>
 			</li>
 			<li function="modify">
@@ -895,12 +836,7 @@
 						<MeleeWeapon_AverageArmorPenetration>0.05</MeleeWeapon_AverageArmorPenetration>
 						<WorkSpeedGlobal>-0.1</WorkSpeedGlobal>
 					</statOffsets>
-					<capMods>
-						<li>
-							<capacity>Manipulation</capacity>
-							<offset>-0.1</offset>
-						</li>
-					</capMods>
+					<partEfficiencyOffset>-0.20</partEfficiencyOffset>
 				</values>
 			</li>
 		</stagePatches>

--- a/1.4/Defs/MorphsAndMutationDefs/Shared/HandMutations.xml
+++ b/1.4/Defs/MorphsAndMutationDefs/Shared/HandMutations.xml
@@ -217,7 +217,7 @@
 			<li function="modify">
 				<stageKey>adapted</stageKey>
 				<values>
-					<partEfficiencyOffset>-0.15</partEfficiencyOffset>
+					<partEfficiencyOffset>-0.30</partEfficiencyOffset>
 				</values>
 			</li>
 		</stagePatches>


### PR DESCRIPTION
A recent-ish changed reverted hand mutation manipulation penalties to use manipulation offsets instead of body part efficiency offsets.  This has some weird side effects, such as bird hands getting damaged causing the manipulation of the pawn's good hand to go down due to the manipulation-penalty-from-damage and manipulation offset stacking.

This PR just converts the manipulation penalties to the equivalent efficiency offsets instead.  Note that capacity penalties for hands is doubled since you have two of them, so the body part efficiency penalty must be twice as strong to have the same end result.

As a side note, I reduced the effective penalty for having two bird wing nubs from -100% to -90%.  Complete loss of manipulation was a bit too steep in my eyes, especially if a pawn was unlucky and didn't get a beak to offset it.  10% manipulation is almost as bad, but still allows them to at least attempt tasks in an emergency.  I'm willing to discuss and/or revert this change, however.