### PR TITLE
Patch biosculptors to prevent bioregeneration from removing mutations

### DIFF
--- a/Source/Pawnmorphs/Esoteria/HPatches/BiosculpterPatches.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/BiosculpterPatches.cs
@@ -23,5 +23,14 @@ namespace Pawnmorph.HPatches
                 } 
             }
         }
+        
+        [HarmonyPatch(typeof(CompBiosculpterPod_HealingCycle), "WillHeal")]
+        static class DontHealMutations
+        {
+            static void Postfix(Pawn pawn, Hediff hediff, ref bool __result)
+            {
+                __result &= hediff is not Hediff_AddedMutation;
+            }
+        }
     }
 }

--- a/Source/Pawnmorphs/Esoteria/HPatches/BiosculpterPatches.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/BiosculpterPatches.cs
@@ -29,7 +29,8 @@ namespace Pawnmorph.HPatches
         {
             static void Postfix(Pawn pawn, Hediff hediff, ref bool __result)
             {
-                __result &= hediff is not Hediff_AddedMutation;
+                // Always prevent mutations from being healed by the biosculptor
+                if (hediff is Hediff_AddedMutation) __result = false;
             }
         }
     }


### PR DESCRIPTION
A simple patch to ensure biosculptors don't attempt to remove mutations during the bioregeneration cycle.  Compiled and tested successfully -- the pod was able to heal a brain scar, but it left the pawn's mutations alone.  Prior to this fix, ear mutations (and possibly eye mutations) would be removed by bioregeneration.