### PR TITLE
Fix children scaling with the body size patch

### DIFF
--- a/Source/Pawnmorphs/Esoteria/HPatches/Optional/PawnScaling.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/Optional/PawnScaling.cs
@@ -115,14 +115,15 @@ namespace Pawnmorph.HPatches.Optional
         }
 
 
-        // Calculate the rendered size based on body size
+        // Calculate the scale multiplier based on Pawnmorpher's BodySize multiplier
+        // TODO: Add a toggle to allow scaling by any body size difference compared to normal instead
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static float GetScale(Pawn pawn)
         {
             if (_currentPawn != pawn)
             {
                 _currentPawn = pawn;
-                _currentScaledBodySize = Mathf.Sqrt(pawn.BodySize / pawn.RaceProps.baseBodySize);
+                _currentScaledBodySize = Mathf.Sqrt(StatsUtility.GetStat(pawn, PMStatDefOf.PM_BodySize, 300) ?? 1f);
             }
             
             return _currentScaledBodySize;


### PR DESCRIPTION
Fixes #762 

Currently, this changes the scale patch to only scale based on the PM_BodySize stat.  In the future it would be preferable to add a mod toggle to swap between that and scaling based on (mod-added) sources of body size changes.