### PR TITLE
Fix a number of compile warnings

### DIFF
--- a/Source/Pawnmorphs/Esoteria/Abilities/Bullrush.cs
+++ b/Source/Pawnmorphs/Esoteria/Abilities/Bullrush.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Verse;
+﻿using Verse;
 
 namespace Pawnmorph.Abilities
 {

--- a/Source/Pawnmorphs/Esoteria/Abilities/Flight.cs
+++ b/Source/Pawnmorphs/Esoteria/Abilities/Flight.cs
@@ -1,10 +1,5 @@
 ﻿using Pawnmorph.Utilities;
 using RimWorld;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Verse;
 
 namespace Pawnmorph.Abilities

--- a/Source/Pawnmorphs/Esoteria/Abilities/MutationAbility.cs
+++ b/Source/Pawnmorphs/Esoteria/Abilities/MutationAbility.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using UnityEngine;
 using Verse;
 

--- a/Source/Pawnmorphs/Esoteria/Abilities/MutationAbility.cs
+++ b/Source/Pawnmorphs/Esoteria/Abilities/MutationAbility.cs
@@ -85,6 +85,7 @@ namespace Pawnmorph.Abilities
         /// Initializes the ability with the specified pawn.
         /// </summary>
         /// <param name="pawn">The pawn.</param>
+        /// <param name="def">The ability def.</param>
         public void Initialize(Pawn pawn, MutationAbilityDef def = null)
         {
             _pawn = pawn;

--- a/Source/Pawnmorphs/Esoteria/Abilities/MutationAbilityDef.cs
+++ b/Source/Pawnmorphs/Esoteria/Abilities/MutationAbilityDef.cs
@@ -42,6 +42,9 @@ namespace Pawnmorph.Abilities
 
         private Texture2D _iconTextureCache;
 
+        /// <summary>
+        /// The texture for the ability icon
+        /// </summary>
         public Texture2D IconTexture
         {
             get 
@@ -51,6 +54,9 @@ namespace Pawnmorph.Abilities
             }
         }
 
+        /// <summary>
+        /// Loads the icon texture into the texture cache
+        /// </summary>
         public void CacheTexture()
         {
             if (_iconTextureCache == null)

--- a/Source/Pawnmorphs/Esoteria/Abilities/MutationAbilityDef.cs
+++ b/Source/Pawnmorphs/Esoteria/Abilities/MutationAbilityDef.cs
@@ -1,9 +1,4 @@
-﻿using RimWorld;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System;
 using UnityEngine;
 using Verse;
 

--- a/Source/Pawnmorphs/Esoteria/Abilities/MutationAbilityState.cs
+++ b/Source/Pawnmorphs/Esoteria/Abilities/MutationAbilityState.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Pawnmorph.Abilities
+﻿namespace Pawnmorph.Abilities
 {
     /// <summary>
     /// Different mutation ability states.

--- a/Source/Pawnmorphs/Esoteria/Abilities/MutationAbilityType.cs
+++ b/Source/Pawnmorphs/Esoteria/Abilities/MutationAbilityType.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Pawnmorph.Abilities
+﻿namespace Pawnmorph.Abilities
 {
     /// <summary>
     /// Different types of mutation abilities.

--- a/Source/Pawnmorphs/Esoteria/Abilities/Skyfallers/FlightSkyFaller.cs
+++ b/Source/Pawnmorphs/Esoteria/Abilities/Skyfallers/FlightSkyFaller.cs
@@ -1,9 +1,5 @@
-﻿using RimWorld;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System;
+using RimWorld;
 using UnityEngine;
 using Verse;
 

--- a/Source/Pawnmorphs/Esoteria/Abilities/TerrifyingRoar.cs
+++ b/Source/Pawnmorphs/Esoteria/Abilities/TerrifyingRoar.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Verse;
+﻿using Verse;
 
 namespace Pawnmorph.Abilities
 {

--- a/Source/Pawnmorphs/Esoteria/AddMorphsToPawn.cs
+++ b/Source/Pawnmorphs/Esoteria/AddMorphsToPawn.cs
@@ -1,4 +1,5 @@
 ﻿using Verse;
+
 #pragma warning disable 1591 //this is going to be re worked, disabling for now 
 
 namespace Pawnmorph

--- a/Source/Pawnmorphs/Esoteria/AnimalClassDef.cs
+++ b/Source/Pawnmorphs/Esoteria/AnimalClassDef.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using JetBrains.Annotations;
 using Pawnmorph.Hediffs;
 using Pawnmorph.Utilities;

--- a/Source/Pawnmorphs/Esoteria/AnimalClassDefOf.cs
+++ b/Source/Pawnmorphs/Esoteria/AnimalClassDefOf.cs
@@ -1,8 +1,8 @@
 ﻿// AnimalClassDefOf.cs modified by Iron Wolf for Pawnmorph on 01/10/2020 5:25 PM
 // last updated 01/10/2020  5:25 PM
 
-using JetBrains.Annotations;
 using RimWorld;
+
 #pragma warning disable 1591
 
 // ReSharper disable NotNullMemberIsNotInitialized

--- a/Source/Pawnmorphs/Esoteria/Aspect.cs
+++ b/Source/Pawnmorphs/Esoteria/Aspect.cs
@@ -1,12 +1,11 @@
-﻿using System.Text;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using JetBrains.Annotations;
 using Pawnmorph.Utilities;
 using RimWorld;
 using UnityEngine;
 using Verse;
-using System;
 
 namespace Pawnmorph
 {

--- a/Source/Pawnmorphs/Esoteria/AspectDefOf.cs
+++ b/Source/Pawnmorphs/Esoteria/AspectDefOf.cs
@@ -3,6 +3,7 @@
 
 using JetBrains.Annotations;
 using RimWorld;
+
 #pragma warning disable 1591
 namespace Pawnmorph
 {

--- a/Source/Pawnmorphs/Esoteria/AspectGiver.cs
+++ b/Source/Pawnmorphs/Esoteria/AspectGiver.cs
@@ -2,7 +2,6 @@
 // last updated 12/16/2019  11:53 AM
 
 using System.Collections.Generic;
-using System.Security.Policy;
 using JetBrains.Annotations;
 using Pawnmorph.DefExtensions;
 using Pawnmorph.Utilities;

--- a/Source/Pawnmorphs/Esoteria/Aspects/Coloration.cs
+++ b/Source/Pawnmorphs/Esoteria/Aspects/Coloration.cs
@@ -1,13 +1,7 @@
-﻿using JetBrains.Annotations;
-using Pawnmorph.Dialogs;
+﻿using System;
+using JetBrains.Annotations;
 using Pawnmorph.GraphicSys;
-using Pawnmorph.Hybrids;
 using RimWorld;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using UnityEngine;
 using Verse;
 using static Pawnmorph.SimplePawnColorSet;

--- a/Source/Pawnmorphs/Esoteria/Aspects/Prideful.cs
+++ b/Source/Pawnmorphs/Esoteria/Aspects/Prideful.cs
@@ -1,10 +1,7 @@
 ﻿// SplitMind.cs created by Iron Wolf for Pawnmorph on 05/09/2020 1:18 PM
 // last updated 05/09/2020  1:18 PM
 
-using System;
-using Pawnmorph.Utilities;
 using RimWorld;
-using Verse;
 
 namespace Pawnmorph.Aspects
 {

--- a/Source/Pawnmorphs/Esoteria/Aspects/Prideful.cs
+++ b/Source/Pawnmorphs/Esoteria/Aspects/Prideful.cs
@@ -14,6 +14,7 @@ namespace Pawnmorph.Aspects
     /// <seealso cref="Pawnmorph.Aspect" />
     public class Prideful : Aspect 
     {
+        /// <inheritdoc />
         protected override void PostAdd()
         {
             TraitSet traitSet = Pawn.story?.traits;
@@ -22,6 +23,7 @@ namespace Pawnmorph.Aspects
             base.PostAdd();
         }
 
+        /// <inheritdoc />
         public override void PostRemove()
         {
             TraitSet traitSet = Pawn.story?.traits;

--- a/Source/Pawnmorphs/Esoteria/BackstoryDefOf.cs
+++ b/Source/Pawnmorphs/Esoteria/BackstoryDefOf.cs
@@ -1,7 +1,6 @@
 ﻿// BackstoryDefOf.cs modified by Iron Wolf for Pawnmorph on 11/29/2019 7:35 AM
 // last updated 11/29/2019  7:35 AM
 
-using AlienRace;
 using JetBrains.Annotations;
 using RimWorld;
 

--- a/Source/Pawnmorphs/Esoteria/BodyUtilities.cs
+++ b/Source/Pawnmorphs/Esoteria/BodyUtilities.cs
@@ -78,7 +78,13 @@ namespace Pawnmorph
         }
 
 
-
+        /// <summary>
+        /// Gets a body part that is equivalent to partRecord from the given bodyDef, if one exists.
+        /// </summary>
+        /// <param name="bodyDef">The body def to check</param>
+        /// <param name="partRecord">The body part to search for</param>
+        /// <returns>The matching <see cref="BodyPartRecord"/> from bodyDef, if one exists, or null otherwise</returns>
+        /// <exception cref="ArgumentNullException"></exception>
         [CanBeNull]
         public static BodyPartRecord GetRecord([NotNull] this BodyDef bodyDef, [NotNull] BodyPartRecord partRecord)
         {

--- a/Source/Pawnmorphs/Esoteria/Buildings/MutagenTank.cs
+++ b/Source/Pawnmorphs/Esoteria/Buildings/MutagenTank.cs
@@ -1,12 +1,7 @@
 ﻿// MutaniteCentrifuge.cs created by Iron Wolf for Pawnmorph on 03/25/2020 6:14 AM
 // last updated 03/25/2020  6:14 AM
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using PipeSystem;
-using RimWorld;
 using UnityEngine;
 using Verse;
 

--- a/Source/Pawnmorphs/Esoteria/Chambers/AnimalTfControllers/ChaoThrumbo.cs
+++ b/Source/Pawnmorphs/Esoteria/Chambers/AnimalTfControllers/ChaoThrumbo.cs
@@ -3,7 +3,6 @@
 
 using RimWorld;
 using Verse;
-using Verse.AI;
 
 namespace Pawnmorph.Chambers.AnimalTfControllers
 {

--- a/Source/Pawnmorphs/Esoteria/Chambers/ChamberJobDefOf.cs
+++ b/Source/Pawnmorphs/Esoteria/Chambers/ChamberJobDefOf.cs
@@ -3,6 +3,7 @@
 
 using RimWorld;
 using Verse;
+
 #pragma warning disable 1591
 namespace Pawnmorph.Chambers
 {

--- a/Source/Pawnmorphs/Esoteria/Chambers/ChamberTfInitiationReport.cs
+++ b/Source/Pawnmorphs/Esoteria/Chambers/ChamberTfInitiationReport.cs
@@ -2,7 +2,6 @@
 // last updated 06/25/2021  5:26 PM
 
 using System;
-using System.Runtime.Remoting.Messaging;
 
 namespace Pawnmorph.Chambers
 {

--- a/Source/Pawnmorphs/Esoteria/Chambers/GenomeDefGenerator.cs
+++ b/Source/Pawnmorphs/Esoteria/Chambers/GenomeDefGenerator.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Resources;
 using System.Text;
 using HarmonyLib;
 using JetBrains.Annotations;

--- a/Source/Pawnmorphs/Esoteria/ChaomorphUtilities.cs
+++ b/Source/Pawnmorphs/Esoteria/ChaomorphUtilities.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.Contracts;
 using System.Linq;
 using JetBrains.Annotations;
 using Pawnmorph.DefExtensions;

--- a/Source/Pawnmorphs/Esoteria/ColorGenerator_HSL.cs
+++ b/Source/Pawnmorphs/Esoteria/ColorGenerator_HSL.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using UnityEngine;
+﻿using UnityEngine;
 using Verse;
 
 namespace Pawnmorph

--- a/Source/Pawnmorphs/Esoteria/CompMutagenicRadius.cs
+++ b/Source/Pawnmorphs/Esoteria/CompMutagenicRadius.cs
@@ -1,11 +1,10 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
-using Pawnmorph.Hediffs;
 using Pawnmorph.Utilities;
-using Verse;
 using RimWorld;
 using UnityEngine;
+using Verse;
 
 namespace Pawnmorph
 {

--- a/Source/Pawnmorphs/Esoteria/CompTargetable_TransformableCorpse.cs
+++ b/Source/Pawnmorphs/Esoteria/CompTargetable_TransformableCorpse.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using RimWorld;
 using Verse;
+
 #pragma warning disable 1591
 namespace Pawnmorph
 {

--- a/Source/Pawnmorphs/Esoteria/Comp_MutagenicFixWorstCondition.cs
+++ b/Source/Pawnmorphs/Esoteria/Comp_MutagenicFixWorstCondition.cs
@@ -7,8 +7,6 @@ using System.Linq;
 using JetBrains.Annotations;
 using Pawnmorph.DefExtensions;
 using Pawnmorph.Hediffs;
-using Pawnmorph.TfSys;
-using Pawnmorph.Utilities;
 using RimWorld;
 using Verse;
 

--- a/Source/Pawnmorphs/Esoteria/Comp_PlayerPickedColoration.cs
+++ b/Source/Pawnmorphs/Esoteria/Comp_PlayerPickedColoration.cs
@@ -1,10 +1,5 @@
 ﻿using Pawnmorph.Dialogs;
 using RimWorld;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Verse;
 
 namespace Pawnmorph

--- a/Source/Pawnmorphs/Esoteria/Damage/MutagenicDamageUtilities.cs
+++ b/Source/Pawnmorphs/Esoteria/Damage/MutagenicDamageUtilities.cs
@@ -4,7 +4,6 @@
 using System;
 using JetBrains.Annotations;
 using Pawnmorph.Hediffs;
-using RimWorld;
 using UnityEngine;
 using Verse;
 

--- a/Source/Pawnmorphs/Esoteria/Damage/Worker_MutagenicCut.cs
+++ b/Source/Pawnmorphs/Esoteria/Damage/Worker_MutagenicCut.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using Pawnmorph.Hediffs;
 using Verse;
 
 namespace Pawnmorph.Damage

--- a/Source/Pawnmorphs/Esoteria/Damage/Worker_MutagenicInjury.cs
+++ b/Source/Pawnmorphs/Esoteria/Damage/Worker_MutagenicInjury.cs
@@ -151,7 +151,7 @@ namespace Pawnmorph.Damage
                 new BattleLogEntry_ExplosionImpact(explosion.instigator, t, explosion.weapon, explosion.projectile, def);
             Find.BattleLog.Add(battleLogEntry_ExplosionImpact);
 
-            pawn.stances?.StaggerFor(95);
+            pawn.stances?.stagger?.StaggerFor(95);
         }
 
 

--- a/Source/Pawnmorphs/Esoteria/DeathActionWorker_MutagenicExplosion.cs
+++ b/Source/Pawnmorphs/Esoteria/DeathActionWorker_MutagenicExplosion.cs
@@ -5,7 +5,6 @@ using Pawnmorph.Hediffs;
 using RimWorld;
 using Verse;
 
-
 namespace EtherGun
 {
     /// <summary>

--- a/Source/Pawnmorphs/Esoteria/DebugUtils/DebugLogUtils.Aliens.cs
+++ b/Source/Pawnmorphs/Esoteria/DebugUtils/DebugLogUtils.Aliens.cs
@@ -8,7 +8,6 @@ using AlienRace;
 using JetBrains.Annotations;
 using Pawnmorph.Hediffs;
 using RimWorld;
-using UnityEngine.Video;
 using Verse;
 
 namespace Pawnmorph.DebugUtils

--- a/Source/Pawnmorphs/Esoteria/DebugUtils/DebugLogUtils.FoodOptimizations.cs
+++ b/Source/Pawnmorphs/Esoteria/DebugUtils/DebugLogUtils.FoodOptimizations.cs
@@ -10,10 +10,8 @@ using HarmonyLib;
 using JetBrains.Annotations;
 using Pawnmorph.Utilities;
 using RimWorld;
-using RimWorld.Planet;
 using UnityEngine;
 using Verse;
-using Verse.AI;
 
 namespace Pawnmorph.DebugUtils
 {

--- a/Source/Pawnmorphs/Esoteria/DebugUtils/DebugLogUtils.Hediffs.cs
+++ b/Source/Pawnmorphs/Esoteria/DebugUtils/DebugLogUtils.Hediffs.cs
@@ -1,13 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using HarmonyLib;
-using JetBrains.Annotations;
-using Pawnmorph.Hediffs;
-using Pawnmorph.Thoughts;
 using Pawnmorph.Utilities;
-using RimWorld;
 using Verse;
 
 #pragma warning disable 1591

--- a/Source/Pawnmorphs/Esoteria/DebugUtils/DebugLogUtils.Logging.cs
+++ b/Source/Pawnmorphs/Esoteria/DebugUtils/DebugLogUtils.Logging.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using JetBrains.Annotations;
 using Verse;
+
 #pragma warning disable 1591
 
 namespace Pawnmorph.DebugUtils

--- a/Source/Pawnmorphs/Esoteria/DebugUtils/DebugLogUtils.MutationLogging.cs
+++ b/Source/Pawnmorphs/Esoteria/DebugUtils/DebugLogUtils.MutationLogging.cs
@@ -11,7 +11,6 @@ using JetBrains.Annotations;
 using Pawnmorph.Hediffs;
 using Pawnmorph.Utilities;
 using RimWorld;
-using UnityEngine;
 using Verse;
 
 namespace Pawnmorph.DebugUtils

--- a/Source/Pawnmorphs/Esoteria/DebugUtils/DebugLogUtils.ThoughtListing.cs
+++ b/Source/Pawnmorphs/Esoteria/DebugUtils/DebugLogUtils.ThoughtListing.cs
@@ -1,7 +1,6 @@
 ﻿// DebugLogUtils.ThoughtListing.cs created by Iron Wolf for Pawnmorph on //2020 
 // last updated 02/29/2020  1:42 PM
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -11,6 +10,7 @@ using Pawnmorph.Hediffs;
 using Pawnmorph.Thoughts;
 using RimWorld;
 using Verse;
+
 #pragma warning disable 1591
 namespace Pawnmorph.DebugUtils
 {

--- a/Source/Pawnmorphs/Esoteria/DebugUtils/DebugLogUtils.cs
+++ b/Source/Pawnmorphs/Esoteria/DebugUtils/DebugLogUtils.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Text;
-using AlienRace;
 using HarmonyLib;
 using JetBrains.Annotations;
 using Pawnmorph.Chambers;
@@ -15,7 +14,6 @@ using Pawnmorph.Hediffs;
 using Pawnmorph.Utilities;
 using RimWorld;
 using UnityEngine;
-using UnityEngine.Windows.WebCam;
 using Verse;
 
 #pragma warning disable 1591

--- a/Source/Pawnmorphs/Esoteria/DebugUtils/PMDebugActions.cs
+++ b/Source/Pawnmorphs/Esoteria/DebugUtils/PMDebugActions.cs
@@ -5,13 +5,15 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using AlienRace;
+using HarmonyLib;
 using JetBrains.Annotations;
 using Pawnmorph.Chambers;
+using Pawnmorph.FormerHumans;
+using Pawnmorph.Genebank.Model;
 using Pawnmorph.GraphicSys;
 using Pawnmorph.Hediffs;
 using Pawnmorph.Hybrids;
-using Pawnmorph.Jobs;
-using Pawnmorph.Social;
 using Pawnmorph.TfSys;
 using Pawnmorph.ThingComps;
 using Pawnmorph.UserInterface;
@@ -20,10 +22,6 @@ using RimWorld;
 using UnityEngine;
 using Verse;
 using Verse.AI;
-using HarmonyLib;
-using AlienRace;
-using Pawnmorph.FormerHumans;
-using Pawnmorph.Genebank.Model;
 
 namespace Pawnmorph.DebugUtils
 {

--- a/Source/Pawnmorphs/Esoteria/DebugUtils/PMDebugActions.cs
+++ b/Source/Pawnmorphs/Esoteria/DebugUtils/PMDebugActions.cs
@@ -467,10 +467,6 @@ namespace Pawnmorph.DebugUtils
             if (mutList.Count == 0) 
                 return;
 
-            var i = 0;
-            List<Hediff_AddedMutation> givenList = new List<Hediff_AddedMutation>();
-            List<MutationDef> triedGive = new List<MutationDef>();
-
             foreach (MutationDef mutation in mutations)
                 MutationUtilities.AddMutation(pawn, mutation);
 

--- a/Source/Pawnmorphs/Esoteria/DebugUtils/Pawnmorpher_InteractionWeightLogDialogue.cs
+++ b/Source/Pawnmorphs/Esoteria/DebugUtils/Pawnmorpher_InteractionWeightLogDialogue.cs
@@ -7,6 +7,7 @@ using System.Text;
 using Pawnmorph.Social;
 using RimWorld;
 using Verse;
+
 #pragma warning disable 01591
 namespace Pawnmorph.DebugUtils
 {

--- a/Source/Pawnmorphs/Esoteria/DefExtensions/AnimalSelectorOverrides.cs
+++ b/Source/Pawnmorphs/Esoteria/DefExtensions/AnimalSelectorOverrides.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Verse;
+﻿using Verse;
 
 namespace Pawnmorph.DefExtensions
 {

--- a/Source/Pawnmorphs/Esoteria/DefExtensions/ChaomorphExtension.cs
+++ b/Source/Pawnmorphs/Esoteria/DefExtensions/ChaomorphExtension.cs
@@ -1,7 +1,6 @@
 ﻿// ChaomorphExtension.cs created by Iron Wolf for Pawnmorph on 09/26/2020 5:27 PM
 // last updated 09/26/2020  5:27 PM
 
-using System.Collections.Generic;
 using JetBrains.Annotations;
 using RimWorld;
 using Verse;

--- a/Source/Pawnmorphs/Esoteria/DefExtensions/FormerHumanSettings.cs
+++ b/Source/Pawnmorphs/Esoteria/DefExtensions/FormerHumanSettings.cs
@@ -1,9 +1,6 @@
 ﻿// FormerHumanSettings.cs modified by Iron Wolf for Pawnmorph on 12/24/2019 9:20 AM
 // last updated 12/24/2019  9:20 AM
 
-using System.Collections.Generic;
-using AlienRace;
-using JetBrains.Annotations;
 using Pawnmorph.FormerHumans;
 using Pawnmorph.TfSys;
 using RimWorld;

--- a/Source/Pawnmorphs/Esoteria/DefExtensions/InteractionGroupExtension.cs
+++ b/Source/Pawnmorphs/Esoteria/DefExtensions/InteractionGroupExtension.cs
@@ -1,7 +1,6 @@
 ﻿// InteractionGroupExtension.cs modified by Iron Wolf for Pawnmorph on 12/11/2019 5:47 PM
 // last updated 12/11/2019  5:47 PM
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;

--- a/Source/Pawnmorphs/Esoteria/DefExtensions/MemeRestriction.cs
+++ b/Source/Pawnmorphs/Esoteria/DefExtensions/MemeRestriction.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
-using Pawnmorph.Utilities;
 using RimWorld;
 using Verse;
 

--- a/Source/Pawnmorphs/Esoteria/DefExtensions/MorphRestriction.cs
+++ b/Source/Pawnmorphs/Esoteria/DefExtensions/MorphRestriction.cs
@@ -4,7 +4,6 @@
 using Pawnmorph.Hybrids;
 using Pawnmorph.Utilities;
 using Verse;
-using Verse.Noise;
 
 namespace Pawnmorph.DefExtensions
 {

--- a/Source/Pawnmorphs/Esoteria/DefExtensions/MutantPlantExtension.cs
+++ b/Source/Pawnmorphs/Esoteria/DefExtensions/MutantPlantExtension.cs
@@ -6,7 +6,6 @@ using JetBrains.Annotations;
 using Pawnmorph.Utilities;
 using RimWorld;
 using Verse;
-using Verse.Noise;
 
 namespace Pawnmorph.DefExtensions
 {

--- a/Source/Pawnmorphs/Esoteria/DefExtensions/TFTransferable.cs
+++ b/Source/Pawnmorphs/Esoteria/DefExtensions/TFTransferable.cs
@@ -5,7 +5,6 @@ using System;
 using JetBrains.Annotations;
 using Pawnmorph.Utilities;
 using Verse;
-using Verse.Noise;
 
 namespace Pawnmorph.DefExtensions
 {

--- a/Source/Pawnmorphs/Esoteria/DefExtensions/VeneratedAnimalMutationThought_TransferWorker.cs
+++ b/Source/Pawnmorphs/Esoteria/DefExtensions/VeneratedAnimalMutationThought_TransferWorker.cs
@@ -46,7 +46,7 @@ namespace Pawnmorph.DefExtensions
                 newThought.veneratedAnimalLabel = oThought.veneratedAnimalLabel;
                 return newThought;
             }
-            catch (InvalidCastException e)
+            catch (InvalidCastException)
             {
                 Log.Error($"unable to create new thought of {originalThought.def.defName}! unable to cast {originalThought.GetType().Name} to {nameof(MutationMemory_VeneratedAnimal)}");
                 throw; 

--- a/Source/Pawnmorphs/Esoteria/DefExtensions/VeneratedAnimalMutationThought_TransferWorker.cs
+++ b/Source/Pawnmorphs/Esoteria/DefExtensions/VeneratedAnimalMutationThought_TransferWorker.cs
@@ -2,7 +2,6 @@
 // last updated 08/03/2021  4:09 PM
 
 using System;
-using Pawnmorph.PreceptComps;
 using Pawnmorph.Thoughts;
 using Pawnmorph.Thoughts.Precept;
 using RimWorld;

--- a/Source/Pawnmorphs/Esoteria/Designations/RecruitSapientFormerHuman.cs
+++ b/Source/Pawnmorphs/Esoteria/Designations/RecruitSapientFormerHuman.cs
@@ -1,7 +1,6 @@
 ﻿// RecruitSapientFormerHuman.cs created by Iron Wolf for Pawnmorph on 03/15/2020 2:54 PM
 // last updated 03/15/2020  2:54 PM
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;

--- a/Source/Pawnmorphs/Esoteria/Dialogs/ColonistColorPicker.cs
+++ b/Source/Pawnmorphs/Esoteria/Dialogs/ColonistColorPicker.cs
@@ -1,6 +1,5 @@
 ﻿using Pawnmorph.Aspects;
 using Pawnmorph.GraphicSys;
-using System;
 using UnityEngine;
 using Verse;
 using static Pawnmorph.SimplePawnColorSet;

--- a/Source/Pawnmorphs/Esoteria/FormerHumanStatus.cs
+++ b/Source/Pawnmorphs/Esoteria/FormerHumanStatus.cs
@@ -1,10 +1,6 @@
 ﻿// FormerHumanStatus.cs modified by Iron Wolf for Pawnmorph on 11/29/2019 7:53 AM
 // last updated 11/29/2019  7:53 AM
 
-using System;
-using System.ComponentModel;
-using Pawnmorph.ThingComps;
-
 namespace Pawnmorph
 {
     /// <summary>

--- a/Source/Pawnmorphs/Esoteria/FormerHumanUtilities.cs
+++ b/Source/Pawnmorphs/Esoteria/FormerHumanUtilities.cs
@@ -5,11 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using AlienRace;
 using JetBrains.Annotations;
-using Pawnmorph.DebugUtils;
 using Pawnmorph.DefExtensions;
-using Pawnmorph.Letters;
+using Pawnmorph.FormerHumans;
 using Pawnmorph.Hediffs;
 using Pawnmorph.TfSys;
 using Pawnmorph.ThingComps;
@@ -19,7 +17,6 @@ using RimWorld;
 using UnityEngine;
 using Verse;
 using Verse.AI;
-using Pawnmorph.FormerHumans;
 
 namespace Pawnmorph
 {

--- a/Source/Pawnmorphs/Esoteria/GameCondition_MutagenicFallout.cs
+++ b/Source/Pawnmorphs/Esoteria/GameCondition_MutagenicFallout.cs
@@ -1,10 +1,9 @@
 ﻿using System.Collections.Generic;
 using JetBrains.Annotations;
 using Pawnmorph.DefExtensions;
-using Pawnmorph.Utilities;
 using RimWorld;
-using Verse;
 using UnityEngine;
+using Verse;
 
 namespace Pawnmorph
 {

--- a/Source/Pawnmorphs/Esoteria/Genebank/ChamberDatabase.cs
+++ b/Source/Pawnmorphs/Esoteria/Genebank/ChamberDatabase.cs
@@ -66,12 +66,14 @@ namespace Pawnmorph.Chambers
 		/// <summary>
 		///     Gets the tagged animals.
 		/// </summary>
-		/// <value>
-		///     The tagged animals.
-		/// </value>
+		/// <value>The tagged animals.</value>
 		[NotNull]
 		public IReadOnlyList<PawnKindDef> TaggedAnimals => GetEntryValues<PawnKindDef>();
 
+        /// <summary>
+        /// Gets the saved mutation templates.
+        /// </summary>
+        /// <value>The saved mutation templates.</value>
         public IReadOnlyList<MutationTemplate> MutationTemplates => GetEntryValues<MutationTemplate>();
 
 		/// <summary>

--- a/Source/Pawnmorphs/Esoteria/Genebank/ChamberDatabase.cs
+++ b/Source/Pawnmorphs/Esoteria/Genebank/ChamberDatabase.cs
@@ -4,14 +4,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Configuration;
-using AlienRace;
 using JetBrains.Annotations;
 using Pawnmorph.DebugUtils;
 using Pawnmorph.Genebank.Model;
 using Pawnmorph.Hediffs;
 using Pawnmorph.UserInterface.PartPicker;
-using Pawnmorph.Utilities;
 using Pawnmorph.Utilities.Collections;
 using RimWorld.Planet;
 using UnityEngine;

--- a/Source/Pawnmorphs/Esoteria/Genebank/DatabaseUtilities.cs
+++ b/Source/Pawnmorphs/Esoteria/Genebank/DatabaseUtilities.cs
@@ -5,10 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
-using Pawnmorph.DebugUtils;
 using Pawnmorph.DefExtensions;
 using Pawnmorph.Hediffs;
-using RimWorld;
 using UnityEngine;
 using Verse;
 

--- a/Source/Pawnmorphs/Esoteria/Genebank/GenebankEntry.cs
+++ b/Source/Pawnmorphs/Esoteria/Genebank/GenebankEntry.cs
@@ -1,9 +1,4 @@
 ﻿using Pawnmorph.Chambers;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Verse;
 
 namespace Pawnmorph.Genebank.Model

--- a/Source/Pawnmorphs/Esoteria/Genebank/IGenebankEntry.cs
+++ b/Source/Pawnmorphs/Esoteria/Genebank/IGenebankEntry.cs
@@ -9,10 +9,30 @@ using System.Threading.Tasks;
 
 namespace Pawnmorph.Genebank.Model
 {
+	/// <summary>
+	/// An interface for various kinds of data that can be stored in genebanks
+	/// </summary>
 	public interface IGenebankEntry : Verse.IExposable
 	{
+		/// <summary>
+		/// Returns the caption for the genebank entry
+		/// </summary>
+		/// <returns>The genebank entry caption</returns>
 		string GetCaption();
+		
+		/// <summary>
+		/// Computes the required amount of storage to store this genebank entry
+		/// </summary>
+		/// <returns>The required storage, in kMb</returns>
 		int GetRequiredStorage();
+		
+		/// <summary>
+		/// Tests for any additional requirements preventing this entry from being added to the database
+		/// (Not including basic stuff like sufficient storage space)
+		/// </summary>
+		/// <param name="database">The chamber database</param>
+		/// <param name="reason">A string for returning the reason why an entry cannot be added</param>
+		/// <returns>True if the entry can be added to database, false if it cannot</returns>
 		bool CanAddToDatabase(ChamberDatabase database, out string reason);
 	}
 }

--- a/Source/Pawnmorphs/Esoteria/Genebank/IGenebankEntry.cs
+++ b/Source/Pawnmorphs/Esoteria/Genebank/IGenebankEntry.cs
@@ -1,11 +1,4 @@
-﻿using JetBrains.Annotations;
-using Pawnmorph.Chambers;
-using Pawnmorph.UserInterface.PartPicker;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Pawnmorph.Chambers;
 
 namespace Pawnmorph.Genebank.Model
 {

--- a/Source/Pawnmorphs/Esoteria/Genebank/Model/AnimalGenebankEntry.cs
+++ b/Source/Pawnmorphs/Esoteria/Genebank/Model/AnimalGenebankEntry.cs
@@ -1,10 +1,4 @@
 ﻿using Pawnmorph.Chambers;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel.Design.Serialization;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Verse;
 
 namespace Pawnmorph.Genebank.Model

--- a/Source/Pawnmorphs/Esoteria/Genebank/Model/MutationGenebankEntry.cs
+++ b/Source/Pawnmorphs/Esoteria/Genebank/Model/MutationGenebankEntry.cs
@@ -1,11 +1,5 @@
 ﻿using Pawnmorph.Chambers;
 using Pawnmorph.Hediffs;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using UnityEngine;
 using Verse;
 
 namespace Pawnmorph.Genebank.Model

--- a/Source/Pawnmorphs/Esoteria/Genebank/Model/TemplateGenebankEntry.cs
+++ b/Source/Pawnmorphs/Esoteria/Genebank/Model/TemplateGenebankEntry.cs
@@ -1,11 +1,5 @@
 ﻿using Pawnmorph.Chambers;
 using Pawnmorph.UserInterface.PartPicker;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using UnityEngine;
 using Verse;
 
 namespace Pawnmorph.Genebank.Model

--- a/Source/Pawnmorphs/Esoteria/Graphics/GraphicsUpdaterComp.cs
+++ b/Source/Pawnmorphs/Esoteria/Graphics/GraphicsUpdaterComp.cs
@@ -2,11 +2,9 @@
 // last updated 09/13/2019  8:14 AM
 
 #pragma warning disable 1591
-using System.Linq;
 using AlienRace;
 using JetBrains.Annotations;
 using Pawnmorph.Hybrids;
-using RimWorld;
 using UnityEngine;
 using Verse;
 using static Pawnmorph.DebugUtils.DebugLogUtils;

--- a/Source/Pawnmorphs/Esoteria/Graphics/MorphGraphicsUtils.cs
+++ b/Source/Pawnmorphs/Esoteria/Graphics/MorphGraphicsUtils.cs
@@ -2,8 +2,6 @@
 // last updated 09/13/2019  9:51 AM
 
 using System;
-using System.Linq;
-using System.Runtime.InteropServices;
 using AlienRace;
 using JetBrains.Annotations;
 using Pawnmorph.Hybrids;

--- a/Source/Pawnmorphs/Esoteria/Graphics/MutationGraphicsData.cs
+++ b/Source/Pawnmorphs/Esoteria/Graphics/MutationGraphicsData.cs
@@ -2,7 +2,6 @@
 // last updated 08/15/2021  12:52 PM
 
 using System.Xml;
-using System.Xml.Serialization;
 using JetBrains.Annotations;
 
 namespace Pawnmorph.GraphicSys

--- a/Source/Pawnmorphs/Esoteria/HPatches/AnimalInteractionPatches.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/AnimalInteractionPatches.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using HarmonyLib;
 using JetBrains.Annotations;
 using Pawnmorph.Hediffs;
-using Pawnmorph.Hybrids;
 using RimWorld;
 using Verse;
 using Verse.AI;

--- a/Source/Pawnmorphs/Esoteria/HPatches/AnimalPenUtilityPatches.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/AnimalPenUtilityPatches.cs
@@ -1,11 +1,11 @@
 ﻿// AnimalPenUtilityPatches.cs created by Iron Wolf for Pawnmorph on 07/06/2021 8:36 PM
 // last updated 07/06/2021  8:36 PM
 
-using HarmonyLib;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
+using HarmonyLib;
 using Verse;
 
 namespace Pawnmorph.HPatches

--- a/Source/Pawnmorphs/Esoteria/HPatches/ApparelUtilityPatches.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/ApparelUtilityPatches.cs
@@ -2,7 +2,6 @@
 // last updated 09/16/2020  8:34 AM
 
 using System.Collections.Generic;
-using System.Linq;
 using HarmonyLib;
 using RimWorld;
 using Verse;

--- a/Source/Pawnmorphs/Esoteria/HPatches/CorpsePatch.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/CorpsePatch.cs
@@ -1,10 +1,6 @@
-﻿using HarmonyLib;
-using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
+using HarmonyLib;
 using Verse;
 
 namespace Pawnmorph.HPatches

--- a/Source/Pawnmorphs/Esoteria/HPatches/FloatMenuMakerMapPatches.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/FloatMenuMakerMapPatches.cs
@@ -14,6 +14,7 @@ using RimWorld;
 using UnityEngine;
 using Verse;
 using Verse.AI;
+
 #pragma warning disable 1591
 namespace Pawnmorph
 {

--- a/Source/Pawnmorphs/Esoteria/HPatches/FoodUtilityPatches.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/FoodUtilityPatches.cs
@@ -1,7 +1,6 @@
 ﻿// FoodUtilityPatches.cs modified by Iron Wolf for Pawnmorph on 01/19/2020 4:33 PM
 // last updated 01/19/2020  4:33 PM
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/Source/Pawnmorphs/Esoteria/HPatches/GamePatches.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/GamePatches.cs
@@ -1,11 +1,7 @@
-﻿using HarmonyLib;
-using JetBrains.Annotations;
-using RimWorld;
-using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using HarmonyLib;
+using RimWorld;
 using Verse;
 
 namespace Pawnmorph.HPatches

--- a/Source/Pawnmorphs/Esoteria/HPatches/GatherableBodyResourcePatch.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/GatherableBodyResourcePatch.cs
@@ -1,14 +1,12 @@
 ﻿// GatherableBodyResourcePatch.cs modified by Iron Wolf for Pawnmorph on 12/02/2019 4:26 PM
 // last updated 12/02/2019  4:26 PM
 
-using HarmonyLib;
-using JetBrains.Annotations;
-using Pawnmorph.GraphicSys;
-using RimWorld;
-using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Reflection.Emit;
+using HarmonyLib;
+using JetBrains.Annotations;
+using RimWorld;
 using UnityEngine;
 using Verse;
 

--- a/Source/Pawnmorphs/Esoteria/HPatches/GizmoPatches.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/GizmoPatches.cs
@@ -1,10 +1,5 @@
-﻿using HarmonyLib;
-using RimWorld;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using HarmonyLib;
 using Verse;
 
 namespace Pawnmorph.HPatches

--- a/Source/Pawnmorphs/Esoteria/HPatches/HealthCardUtilsPatch.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/HealthCardUtilsPatch.cs
@@ -1,15 +1,15 @@
-﻿using RimWorld;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
 using System.Text;
 using HarmonyLib;
 using Pawnmorph.Utilities;
+using RimWorld;
 using UnityEngine;
 using Verse;
-using System.Reflection.Emit;
-using System;
 using static Pawnmorph.Utilities.PatchUtilities;
-using System.Reflection;
 
 namespace Pawnmorph
 {

--- a/Source/Pawnmorphs/Esoteria/HPatches/HealthUtilityPatch.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/HealthUtilityPatch.cs
@@ -1,11 +1,9 @@
-﻿using HarmonyLib;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
+using HarmonyLib;
 using Verse;
 using static Pawnmorph.Utilities.PatchUtilities;
 

--- a/Source/Pawnmorphs/Esoteria/HPatches/HediffDefPatches.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/HediffDefPatches.cs
@@ -8,7 +8,6 @@ using HarmonyLib;
 using JetBrains.Annotations;
 using Pawnmorph.Hediffs;
 using Pawnmorph.Utilities;
-using RimWorld;
 using Verse;
 
 namespace Pawnmorph.HPatches

--- a/Source/Pawnmorphs/Esoteria/HPatches/HediffSetPatches.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/HediffSetPatches.cs
@@ -1,13 +1,11 @@
 ﻿// HediffSetPatches.cs created by Iron Wolf for Pawnmorph on 08/25/2021 6:13 PM
 // last updated 08/25/2021  6:14 PM
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using HarmonyLib;
-using UnityEngine.SocialPlatforms;
 using Verse;
 
 namespace Pawnmorph.HPatches

--- a/Source/Pawnmorphs/Esoteria/HPatches/HuntingPatches.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/HuntingPatches.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using HarmonyLib;
 using JetBrains.Annotations;
 using RimWorld;

--- a/Source/Pawnmorphs/Esoteria/HPatches/InteractionPatches.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/InteractionPatches.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
-using System.Runtime.CompilerServices;
 using System.Text;
 using HarmonyLib;
 using JetBrains.Annotations;

--- a/Source/Pawnmorphs/Esoteria/HPatches/MentalBreakPatches.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/MentalBreakPatches.cs
@@ -7,7 +7,6 @@ using HarmonyLib;
 using JetBrains.Annotations;
 using Pawnmorph.DefExtensions;
 using Pawnmorph.Utilities;
-using RimWorld;
 using Verse;
 using Verse.AI;
 

--- a/Source/Pawnmorphs/Esoteria/HPatches/Mods/CompactHediffs/CustomHealthCardUtilsPatch.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/Mods/CompactHediffs/CustomHealthCardUtilsPatch.cs
@@ -1,11 +1,9 @@
-﻿using HarmonyLib;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
-using System.Text;
-using System.Threading.Tasks;
+using HarmonyLib;
 using Verse;
 using static Pawnmorph.Utilities.PatchUtilities;
 

--- a/Source/Pawnmorphs/Esoteria/HPatches/Optional/FoodStackMultiplier.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/Optional/FoodStackMultiplier.cs
@@ -1,11 +1,6 @@
-﻿using HarmonyLib;
+﻿using System.Reflection;
+using HarmonyLib;
 using RimWorld;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using UnityEngine;
 using Verse;
 

--- a/Source/Pawnmorphs/Esoteria/HPatches/Optional/OptionalPatchAttribute.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/Optional/OptionalPatchAttribute.cs
@@ -1,10 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using Verse;
 
 namespace Pawnmorph.HPatches.Optional

--- a/Source/Pawnmorphs/Esoteria/HPatches/Optional/PawnScaling.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/Optional/PawnScaling.cs
@@ -1,18 +1,11 @@
-﻿using AlienRace;
-using Pawnmorph.GraphicSys;
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using AlienRace;
 using Pawnmorph.Utilities;
 using RimWorld;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
 using UnityEngine;
 using Verse;
 using static AlienRace.AlienPartGenerator;
-using static RimWorld.PawnUtility;
 
 namespace Pawnmorph.HPatches.Optional
 {

--- a/Source/Pawnmorphs/Esoteria/HPatches/PawnCapacityUtilsPatch.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/PawnCapacityUtilsPatch.cs
@@ -7,10 +7,7 @@ using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using HarmonyLib;
-using Pawnmorph.DebugUtils;
-using UnityEngine;
 using Verse;
-using static HarmonyLib.Code;
 using static Pawnmorph.Utilities.PatchUtilities;
 
 #pragma warning disable 1591

--- a/Source/Pawnmorphs/Esoteria/HPatches/PawnCompPatches.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/PawnCompPatches.cs
@@ -2,13 +2,11 @@
 // last updated 11/27/2019  1:16 PM
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using HarmonyLib;
 using JetBrains.Annotations;
-using Pawnmorph.Chambers;
 using Pawnmorph.DefExtensions;
 using Pawnmorph.Utilities;
 using RimWorld;

--- a/Source/Pawnmorphs/Esoteria/HPatches/PawnComponentPatches.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/PawnComponentPatches.cs
@@ -1,12 +1,9 @@
 ﻿// PawnComponentPatches.cs created by Iron Wolf for Pawnmorph on 11/27/2019 1:00 PM
 // last updated 11/27/2019  1:00 PM
 
-using System;
 using HarmonyLib;
 using RimWorld;
 using Verse;
-using Verse.AI;
-using Verse.Noise;
 
 #pragma warning disable 1591
 

--- a/Source/Pawnmorphs/Esoteria/HPatches/PawnGeneratorPatches.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/PawnGeneratorPatches.cs
@@ -2,16 +2,13 @@
 // last updated 11/02/2019  10:07 AM
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using AlienRace;
 using HarmonyLib;
 using JetBrains.Annotations;
 using Pawnmorph.Factions;
 using Pawnmorph.Hediffs;
 using RimWorld;
 using Verse;
-using Verse.Noise;
 
 #pragma warning disable 1591
 namespace Pawnmorph.HPatches

--- a/Source/Pawnmorphs/Esoteria/HPatches/PawnGraphicSetPatch.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/PawnGraphicSetPatch.cs
@@ -1,9 +1,4 @@
 ﻿using HarmonyLib;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Verse;
 
 namespace Pawnmorph.HPatches

--- a/Source/Pawnmorphs/Esoteria/HPatches/PawnGroupKindWorkerPatches.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/PawnGroupKindWorkerPatches.cs
@@ -1,14 +1,6 @@
 ﻿// PawnGroupKindWorkerPatches.cs created by Iron Wolf for Pawnmorph on 10/30/2019 1:00 PM
 // last updated 10/30/2019  1:01 PM
 
-using System.Collections.Generic;
-using System.Linq;
-using AlienRace;
-using Pawnmorph.Factions;
-using Pawnmorph.Utilities;
-using RimWorld;
-using Verse;
-
 #pragma warning disable 1591
 
 namespace Pawnmorph.HPatches

--- a/Source/Pawnmorphs/Esoteria/HPatches/PawnHealthTrackerPatches.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/PawnHealthTrackerPatches.cs
@@ -1,10 +1,5 @@
 ﻿using HarmonyLib;
 using JetBrains.Annotations;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Verse;
 
 namespace Pawnmorph.HPatches

--- a/Source/Pawnmorphs/Esoteria/HPatches/PawnHealthTrackerPatches.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/PawnHealthTrackerPatches.cs
@@ -9,8 +9,9 @@ using Verse;
 
 namespace Pawnmorph.HPatches
 {
+    [UsedImplicitly]
     [HarmonyPatch(typeof(Pawn_HealthTracker))]
-    public static class PawnHealthTrackerPatches
+    internal static class PawnHealthTrackerPatches
     {
         [HarmonyPatch(nameof(Pawn_HealthTracker.LethalDamageThreshold), MethodType.Getter), HarmonyPostfix]
         static float LethalDamageThresholdPostfix(float __result, [NotNull] Pawn ___pawn)

--- a/Source/Pawnmorphs/Esoteria/HPatches/PlantPatches.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/PlantPatches.cs
@@ -8,7 +8,6 @@ using System.Reflection;
 using System.Reflection.Emit;
 using HarmonyLib;
 using JetBrains.Annotations;
-using Pawnmorph.DebugUtils;
 using Pawnmorph.DefExtensions;
 using Pawnmorph.Plants;
 using RimWorld;

--- a/Source/Pawnmorphs/Esoteria/HPatches/PortraitCachePatches.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/PortraitCachePatches.cs
@@ -1,7 +1,6 @@
 ﻿// PortraitCachePatches.cs created by Iron Wolf for Pawnmorph on 03/08/2020 11:05 AM
 // last updated 03/08/2020  11:05 AM
 
-using System.Linq;
 using HarmonyLib;
 using JetBrains.Annotations;
 using RimWorld;

--- a/Source/Pawnmorphs/Esoteria/HPatches/RecipeDefPatch.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/RecipeDefPatch.cs
@@ -1,11 +1,8 @@
-﻿using HarmonyLib;
-using Pawnmorph.Chambers;
-using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
+using HarmonyLib;
+using Pawnmorph.Chambers;
 using Verse;
 
 namespace Pawnmorph.HPatches

--- a/Source/Pawnmorphs/Esoteria/HPatches/RitualPatches.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/RitualPatches.cs
@@ -1,7 +1,6 @@
 ﻿// RitualPatches.cs created by Iron Wolf for Pawnmorph on 09/09/2021 6:50 AM
 // last updated 09/09/2021  6:50 AM
 
-using System.Linq;
 using HarmonyLib;
 using Pawnmorph.TfSys;
 using RimWorld;

--- a/Source/Pawnmorphs/Esoteria/HPatches/SelectorPatch.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/SelectorPatch.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using HarmonyLib;
-using JetBrains.Annotations;
 using RimWorld;
 using Verse;
 

--- a/Source/Pawnmorphs/Esoteria/HPatches/StatPart_IsCorpseFreshPatches.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/StatPart_IsCorpseFreshPatches.cs
@@ -1,11 +1,5 @@
 ﻿using HarmonyLib;
 using RimWorld;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Verse;
 
 namespace Pawnmorph.HPatches
 {

--- a/Source/Pawnmorphs/Esoteria/HPatches/StatWorkerPatches.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/StatWorkerPatches.cs
@@ -8,6 +8,7 @@ using HarmonyLib;
 using Pawnmorph.Utilities;
 using RimWorld;
 using Verse;
+
 #pragma warning disable 1591
 namespace Pawnmorph.HPatches
 {

--- a/Source/Pawnmorphs/Esoteria/HPatches/ThingOwnerUtilityPatches.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/ThingOwnerUtilityPatches.cs
@@ -3,7 +3,6 @@
 
 using HarmonyLib;
 using Pawnmorph.Chambers;
-using RimWorld;
 using Verse;
 
 namespace Pawnmorph.HPatches

--- a/Source/Pawnmorphs/Esoteria/HPatches/ToolPatches.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/ToolPatches.cs
@@ -1,7 +1,6 @@
 ﻿// ToolPatches.cs created by Iron Wolf for Pawnmorph on 08/25/2021 4:35 PM
 // last updated 08/25/2021  4:35 PM
 
-using System;
 using HarmonyLib;
 using RimWorld;
 using Verse;

--- a/Source/Pawnmorphs/Esoteria/HairDefOf.cs
+++ b/Source/Pawnmorphs/Esoteria/HairDefOf.cs
@@ -2,6 +2,7 @@
 // last updated 03/21/2020  7:11 PM
 
 using RimWorld;
+
 #pragma warning disable 1591
 namespace Pawnmorph
 {

--- a/Source/Pawnmorphs/Esoteria/HediffCompProperties_Production.cs
+++ b/Source/Pawnmorphs/Esoteria/HediffCompProperties_Production.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using JetBrains.Annotations;
 using RimWorld;
 using Verse;
-using Verse.AI;
 
 namespace Pawnmorph
 {

--- a/Source/Pawnmorphs/Esoteria/HediffComp_AddSeverity.cs
+++ b/Source/Pawnmorphs/Esoteria/HediffComp_AddSeverity.cs
@@ -1,5 +1,4 @@
-﻿using Pawnmorph.Utilities;
-using Verse;
+﻿using Verse;
 
 namespace Pawnmorph
 {

--- a/Source/Pawnmorphs/Esoteria/HediffComp_Production.cs
+++ b/Source/Pawnmorphs/Esoteria/HediffComp_Production.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Linq;
 using System.Text;
-using AlienRace;
 using JetBrains.Annotations;
 using Pawnmorph.DebugUtils;
 using Pawnmorph.GraphicSys;
-using Pawnmorph.Hediffs;
 using Pawnmorph.Utilities;
 using RimWorld;
 using UnityEngine;

--- a/Source/Pawnmorphs/Esoteria/HediffComp_Production.cs
+++ b/Source/Pawnmorphs/Esoteria/HediffComp_Production.cs
@@ -41,15 +41,20 @@ namespace Pawnmorph
         private HediffComp_Staged _currentStage;
         private ThinkNode_JobGiver _jobGiverCached;
 
-
+        /// <summary>
+        /// Gets a value indicating whether this instance is dry (forbidden from producing).
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this instance is dry; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsDry => _isDry.Value;
+        
         /// <summary>
         /// Gets a value indicating whether this instance can produce.
         /// </summary>
         /// <value>
         ///   <c>true</c> if this instance can produce; otherwise, <c>false</c>.
         /// </value>
-        public bool IsDry => _isDry.Value;
-
         public bool CanProduce => _canProduce.Value;
 
         /// <summary>
@@ -433,6 +438,7 @@ namespace Pawnmorph
             return description;
         }
 
+        /// <inheritdoc />
         public string ToStringFull()
         {
             StringBuilder debugString = new StringBuilder();

--- a/Source/Pawnmorphs/Esoteria/HediffComp_Staged.cs
+++ b/Source/Pawnmorphs/Esoteria/HediffComp_Staged.cs
@@ -23,6 +23,9 @@ namespace Pawnmorph
         /// <summary>The thought to add when the resource is produced</summary>
         public ThoughtDef thought = null;
 
+        /// <summary>
+        /// 
+        /// </summary>
         public List<HediffGiver> hediffGivers;
 
         /// <summary>
@@ -35,6 +38,9 @@ namespace Pawnmorph
         /// </summary>
         public float? minSeverity;
 
+        /// <summary>
+        /// An additional factor for hunger rate
+        /// </summary>
         public float hungerRateFactor = 1f;
 
         /// <summary>

--- a/Source/Pawnmorphs/Esoteria/HediffComp_Staged.cs
+++ b/Source/Pawnmorphs/Esoteria/HediffComp_Staged.cs
@@ -24,7 +24,7 @@ namespace Pawnmorph
         public ThoughtDef thought = null;
 
         /// <summary>
-        /// 
+        /// The hediff givers on this stage, if any
         /// </summary>
         public List<HediffGiver> hediffGivers;
 

--- a/Source/Pawnmorphs/Esoteria/HediffComp_Staged.cs
+++ b/Source/Pawnmorphs/Esoteria/HediffComp_Staged.cs
@@ -1,5 +1,5 @@
-﻿using JetBrains.Annotations;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using JetBrains.Annotations;
 using RimWorld;
 using Verse;
 

--- a/Source/Pawnmorphs/Esoteria/HediffGiver_Esoteric_RandomList.cs
+++ b/Source/Pawnmorphs/Esoteria/HediffGiver_Esoteric_RandomList.cs
@@ -1,8 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using Pawnmorph.Utilities;
+﻿using System.Collections.Generic;
 using RimWorld;
 using Verse;
+
 #pragma warning disable 01591
 
 namespace Pawnmorph

--- a/Source/Pawnmorphs/Esoteria/HediffGiver_Mutation.cs
+++ b/Source/Pawnmorphs/Esoteria/HediffGiver_Mutation.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using JetBrains.Annotations;
 using Pawnmorph.DefExtensions;
 using Pawnmorph.Hediffs;
-using Pawnmorph.Utilities;
 using RimWorld;
 using UnityEngine;
 using Verse;

--- a/Source/Pawnmorphs/Esoteria/HediffGiver_PermanentFeral.cs
+++ b/Source/Pawnmorphs/Esoteria/HediffGiver_PermanentFeral.cs
@@ -1,8 +1,8 @@
 ﻿using System.Linq;
 using Pawnmorph.TfSys;
 using Pawnmorph.Thoughts;
-using Verse;
 using RimWorld;
+using Verse;
 
 namespace Pawnmorph
 {

--- a/Source/Pawnmorphs/Esoteria/Hediff_AddedMutation.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediff_AddedMutation.cs
@@ -127,6 +127,7 @@ namespace Pawnmorph
             }
         }
 
+        /// <inheritdoc />
         public override string DebugString()
         {
             string debugString = base.DebugString();
@@ -250,7 +251,7 @@ namespace Pawnmorph
         }
 
 
-
+        /// <inheritdoc />
         public override IEnumerable<Gizmo> GetGizmos()
         {
             foreach (Gizmo gizmo in base.GetGizmos()) yield return gizmo;
@@ -280,6 +281,7 @@ namespace Pawnmorph
             }
         }
 
+        /// <summary>
         ///     checks if this mutation blocks the addition of a new mutation at the given part
         /// </summary>
         /// <param name="otherMutation">The other mutation.</param>

--- a/Source/Pawnmorphs/Esoteria/Hediff_AddedMutation.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediff_AddedMutation.cs
@@ -2,11 +2,9 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using AlienRace;
 using JetBrains.Annotations;
 using Pawnmorph.GraphicSys;
 using Pawnmorph.Hediffs;
-using Pawnmorph.HPatches;
 using Pawnmorph.Utilities;
 using RimWorld;
 using UnityEngine;

--- a/Source/Pawnmorphs/Esoteria/Hediffs/CompProps_ImmunizableMutation.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/CompProps_ImmunizableMutation.cs
@@ -3,6 +3,7 @@
 
 using RimWorld;
 using Verse;
+
 #pragma warning disable 1591
 namespace Pawnmorph.Hediffs
 {

--- a/Source/Pawnmorphs/Esoteria/Hediffs/Comp_AcceleratedSeverity.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Comp_AcceleratedSeverity.cs
@@ -1,7 +1,6 @@
 ﻿// Comp_AcceleratedSeverity.cs modified by Iron Wolf for Pawnmorph on 11/04/2019 6:14 PM
 // last updated 11/04/2019  6:14 PM
 
-using System;
 using Pawnmorph.Utilities;
 using UnityEngine;
 using Verse;

--- a/Source/Pawnmorphs/Esoteria/Hediffs/Comp_CheckRace.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Comp_CheckRace.cs
@@ -1,11 +1,7 @@
 ﻿// Giver_CheckRace.cs modified by Iron Wolf for Pawnmorph on 08/03/2019 6:03 PM
 // last updated 08/03/2019  6:03 PM
 
-using System.Collections.Generic;
-using System.Linq;
-using Pawnmorph.Hybrids;
 using Pawnmorph.Utilities;
-using RimWorld;
 using Verse;
 
 namespace Pawnmorph.Hediffs

--- a/Source/Pawnmorphs/Esoteria/Hediffs/Comp_MutagenicInfecter.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Comp_MutagenicInfecter.cs
@@ -1,9 +1,6 @@
 ﻿// Comp_MutagenicInfecter.cs created by Iron Wolf for Pawnmorph on 02/07/2021 3:07 PM
 // last updated 02/07/2021  3:07 PM
 
-using System.Collections.Generic;
-using JetBrains.Annotations;
-using RimWorld;
 using Verse;
 
 namespace Pawnmorph.Hediffs

--- a/Source/Pawnmorphs/Esoteria/Hediffs/Comp_MutationSeverityAdjust.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Comp_MutationSeverityAdjust.cs
@@ -14,10 +14,11 @@ using Verse;
 namespace Pawnmorph.Hediffs
 {
     /// <summary>
-    ///     hediff comp that acts like severity per day but if affected by the 'Mutation Adaptability Stat'
-    ///     Replicates the behavior of HediffComp_SeverityPerDay instead of inheriting from it for performance reasons
+    /// Hediff comp that acts like severity per day but if affected by the 'Mutation Adaptability Stat'
+    /// Replicates the behavior of <see cref="HediffComp_SeverityPerDay"/> instead of inheriting from it for performance reasons
     /// </summary>
     /// <seealso cref="Pawnmorph.Utilities.HediffCompBase{T}" />
+    [UsedImplicitly]
     public class Comp_MutationSeverityAdjust : HediffComp, IStageChangeObserverComp
     {
         private const float EPSILON = 0.001f;
@@ -25,6 +26,9 @@ namespace Pawnmorph.Hediffs
 
         private float _offset; 
 
+        /// <summary>
+        /// An additional offset on the maximum severity, for when things such as adaption cream increase it
+        /// </summary>
         public float SeverityOffset
         {
             get => _offset;
@@ -310,7 +314,7 @@ namespace Pawnmorph.Hediffs
         private static float GenerateRandomReversionSpeed()
         {
             // Clamp between 0.81 and 1.3 to ensure mutations aren't disappearing too quickly or too slowly
-            // The absoulute minimum is 0.8, but making it slightly higher here to avoid mutations surviving reversion due to rounding errors
+            // The absolute minimum is 0.8, but making it slightly higher here to avoid mutations surviving reversion due to rounding errors
             return -Mathf.Clamp(RandUtilities.generateSkewNormalRandom(1.2f, 0.12f, -4f), 0.81f, 1.3f);
         }
     }

--- a/Source/Pawnmorphs/Esoteria/Hediffs/Composable/MutRate_Comp.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Composable/MutRate_Comp.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
 using Pawnmorph.Utilities;
-using RimWorld;
 using Verse;
 
 namespace Pawnmorph.Hediffs.Composable

--- a/Source/Pawnmorphs/Esoteria/Hediffs/Composable/MutRate_MutationsPerSeverityQuadratic.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Composable/MutRate_MutationsPerSeverityQuadratic.cs
@@ -2,7 +2,6 @@
 // last updated 09/05/2021  5:24 PM
 
 using JetBrains.Annotations;
-using UnityEngine;
 using Verse;
 
 namespace Pawnmorph.Hediffs.Composable

--- a/Source/Pawnmorphs/Esoteria/Hediffs/Composable/MutRate_MutationsPerSeverityQuadratic.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Composable/MutRate_MutationsPerSeverityQuadratic.cs
@@ -15,7 +15,7 @@ namespace Pawnmorph.Hediffs.Composable
     {
         
         [UsedImplicitly]
-        float a, b,c;
+        float a, b, c;
 
         /// <summary>
         /// Whether or not the mutation rate is affected by mutagen sensitivity

--- a/Source/Pawnmorphs/Esoteria/Hediffs/Composable/MutSpreadOrder.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Composable/MutSpreadOrder.cs
@@ -1,8 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Pawnmorph.Hediffs.Utility;
 using Pawnmorph.Utilities;
-using Pawnmorph.Utilities.Collections;
 using Verse;
 
 namespace Pawnmorph.Hediffs.Composable

--- a/Source/Pawnmorphs/Esoteria/Hediffs/Composable/TFCallback.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Composable/TFCallback.cs
@@ -1,5 +1,5 @@
-﻿using System.Linq;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using System.Linq;
 using JetBrains.Annotations;
 using Verse;
 

--- a/Source/Pawnmorphs/Esoteria/Hediffs/Composable/TFTypes.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Composable/TFTypes.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
-using Pawnmorph.Utilities;
 using Verse;
 
 namespace Pawnmorph.Hediffs.Composable

--- a/Source/Pawnmorphs/Esoteria/Hediffs/FullTransformationStage.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/FullTransformationStage.cs
@@ -1,12 +1,8 @@
 ﻿// FullTransformationStage.cs modified by Iron Wolf for Pawnmorph on 01/13/2020 5:26 PM
 // last updated 01/13/2020  5:26 PM
 
-using System;
 using System.Collections.Generic;
-using Pawnmorph.TfSys;
 using Pawnmorph.Utilities;
-using RimWorld;
-using UnityEngine;
 using Verse;
 
 namespace Pawnmorph.Hediffs

--- a/Source/Pawnmorphs/Esoteria/Hediffs/FullTransformationStageBase.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/FullTransformationStageBase.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using JetBrains.Annotations;
 using Pawnmorph.TfSys;
-using Pawnmorph.Utilities;
 using RimWorld;
 using UnityEngine;
 using Verse;

--- a/Source/Pawnmorphs/Esoteria/Hediffs/Giver_ChaomorphTf.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Giver_ChaomorphTf.cs
@@ -36,7 +36,8 @@ namespace Pawnmorph.Hediffs
         private readonly float changeChance = -1;
 
 
-        //for backwards compability, unused but don't remove for now 
+        //for backwards compability, unused but don't remove for now
+        [UsedImplicitly]
         private List<PawnKindDef> pawnkinds;
 
 

--- a/Source/Pawnmorphs/Esoteria/Hediffs/Giver_MutationCategoryGiver.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Giver_MutationCategoryGiver.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
-using Pawnmorph.Utilities;
 using RimWorld;
 using Verse;
 

--- a/Source/Pawnmorphs/Esoteria/Hediffs/Giver_MutationChaotic.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Giver_MutationChaotic.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using JetBrains.Annotations;
 using Pawnmorph.Utilities;
 using RimWorld;

--- a/Source/Pawnmorphs/Esoteria/Hediffs/Giver_MutationClass.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Giver_MutationClass.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using JetBrains.Annotations;
-using Pawnmorph.Utilities;
 using RimWorld;
 using Verse;
 

--- a/Source/Pawnmorphs/Esoteria/Hediffs/HediffComp_Composable.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/HediffComp_Composable.cs
@@ -10,9 +10,11 @@ using Verse;
 namespace Pawnmorph.Hediffs
 {
     /// <summary>
-    /// <see cref=""/>
+    /// A comp for composable mutagenic hediffs where the Hediff is responsible for deciding what kinds of mutations to apply.
+    /// Needed because hediff stages can't store state and so the state must be saved to the Hediff or one of its comps.
+    /// Meant to be used with <see cref="MutTypes_FromComp"/>
     /// </summary>
-    /// <seealso cref="Pawnmorph.Utilities.HediffCompBase{Pawnmorph.Hediffs.HediffCompProps_Composable}" />
+    /// <seealso cref="Pawnmorph.Utilities.HediffCompBase{HediffCompProps_Composable}" />
     public class HediffComp_Composable : HediffCompBase<HediffCompProps_Composable>, IMutRate
     {
 
@@ -54,7 +56,7 @@ namespace Pawnmorph.Hediffs
     /// <summary>
     /// properties for <see cref="HediffComp_Composable"/>
     /// </summary>
-    /// <seealso cref="Pawnmorph.Utilities.HediffCompPropertiesBase{Pawnmorph.Hediffs.HediffComp_Composable}" />
+    /// <seealso cref="Pawnmorph.Utilities.HediffCompPropertiesBase{HediffComp_Composable}" />
     public class HediffCompProps_Composable : HediffCompPropertiesBase<HediffComp_Composable>
     {
         

--- a/Source/Pawnmorphs/Esoteria/Hediffs/HediffStage_Mutation.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/HediffStage_Mutation.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using JetBrains.Annotations;

--- a/Source/Pawnmorphs/Esoteria/Hediffs/HediffStage_Transformation.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/HediffStage_Transformation.cs
@@ -1,10 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using JetBrains.Annotations;
 using Pawnmorph.Hediffs.Composable;
 using Verse;
-using System.Linq ;
 
 namespace Pawnmorph.Hediffs
 {

--- a/Source/Pawnmorphs/Esoteria/Hediffs/Hediff_Bullrush.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Hediff_Bullrush.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Verse;
+﻿using Verse;
 
 namespace Pawnmorph.Hediffs
 {

--- a/Source/Pawnmorphs/Esoteria/Hediffs/Hediff_Descriptive.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Hediff_Descriptive.cs
@@ -1,8 +1,7 @@
-﻿using JetBrains.Annotations;
-using RimWorld;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using JetBrains.Annotations;
 using Verse;
 
 namespace Pawnmorph.Hediffs

--- a/Source/Pawnmorphs/Esoteria/Hediffs/Hediff_StageChanges.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Hediff_StageChanges.cs
@@ -8,7 +8,7 @@ using Verse;
 namespace Pawnmorph.Hediffs
 {
     /// <summary>
-    /// An abstracty class for hediffs that need to do things on stage changes.
+    /// An abstract class for hediffs that need to do things on stage changes.
     /// Also implements the IDescriptiveHediff interface
     /// </summary>
     public abstract class Hediff_StageChanges : Hediff_Descriptive
@@ -18,6 +18,10 @@ namespace Pawnmorph.Hediffs
         private int cachedStageIndex = -1;
         [Unsaved] private HediffStage cachedStage;
 
+        /// <summary>
+        /// Whether the base Hediff tick is called.  Should be false for anything that doesn't need the vanilla tick behavior for
+        /// performance reasons.
+        /// </summary>
         protected bool TickBase = true;
 
         private List<IStageChangeObserverComp> observerComps;

--- a/Source/Pawnmorphs/Esoteria/Hediffs/Hediff_StageChanges.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Hediff_StageChanges.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
 using Pawnmorph.Utilities;

--- a/Source/Pawnmorphs/Esoteria/Hediffs/MorphHediffGenerator.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/MorphHediffGenerator.cs
@@ -8,7 +8,6 @@ using Pawnmorph.Composable.Hediffs;
 using Pawnmorph.DefExtensions;
 using Pawnmorph.Hediffs.Composable;
 using RimWorld;
-using UnityEngine.Analytics;
 using Verse;
 
 namespace Pawnmorph.Hediffs

--- a/Source/Pawnmorphs/Esoteria/Hediffs/MorphTf.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/MorphTf.cs
@@ -3,11 +3,8 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using JetBrains.Annotations;
 using Pawnmorph.Utilities;
 using RimWorld;
-using UnityEngine;
-using UnityEngine.Assertions.Must;
 using Verse;
 
 namespace Pawnmorph.Hediffs

--- a/Source/Pawnmorphs/Esoteria/Hediffs/MorphTransformationDefOf.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/MorphTransformationDefOf.cs
@@ -1,11 +1,9 @@
 ﻿// MorphDefs.cs modified by Iron Wolf for Pawnmorph on 07/31/2019 1:27 PM
 // last updated 07/31/2019  1:27 PM
 
-using System.Collections.Generic;
-using System.Linq;
-using Pawnmorph.Utilities;
 using RimWorld;
 using Verse;
+
 #pragma warning disable 1591
 namespace Pawnmorph.Hediffs
 {

--- a/Source/Pawnmorphs/Esoteria/Hediffs/MorphTransformationStage.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/MorphTransformationStage.cs
@@ -5,9 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
-using Pawnmorph.Utilities;
-using HarmonyLib;
-using Pawnmorph.DebugUtils;
 using Verse;
 
 namespace Pawnmorph.Hediffs

--- a/Source/Pawnmorphs/Esoteria/Hediffs/MutagenicBuildup.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/MutagenicBuildup.cs
@@ -1,6 +1,4 @@
-﻿using Pawnmorph.Utilities;
-using UnityEngine;
-using Verse;
+﻿using Verse;
 
 namespace Pawnmorph.Hediffs
 {

--- a/Source/Pawnmorphs/Esoteria/Hediffs/MutationDependency.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/MutationDependency.cs
@@ -2,7 +2,6 @@
 // last updated 08/09/2019  9:09 AM
 
 using System.Collections.Generic;
-using System.Linq;
 using Pawnmorph.Utilities;
 using Verse;
 

--- a/Source/Pawnmorphs/Esoteria/Hediffs/MutationRetrievers/Morph.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/MutationRetrievers/Morph.cs
@@ -2,7 +2,6 @@
 // last updated 10/24/2020  11:51 AM
 
 using System.Collections.Generic;
-using System.Linq;
 using Verse;
 
 namespace Pawnmorph.Hediffs.MutationRetrievers

--- a/Source/Pawnmorphs/Esoteria/Hediffs/MutationStage.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/MutationStage.cs
@@ -3,11 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
 using Pawnmorph.GraphicSys;
 using RimWorld;
-using RimWorld.IO;
 using Verse;
 
 namespace Pawnmorph.Hediffs

--- a/Source/Pawnmorphs/Esoteria/Hediffs/MutationStage.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/MutationStage.cs
@@ -77,6 +77,9 @@ namespace Pawnmorph.Hediffs
         [CanBeNull]
         public List<VerbToolOverride> verbOverrides;
 
+        /// <summary>
+        /// Any abilities added by the stage
+        /// </summary>
         [CanBeNull]
         public List<Abilities.MutationAbilityDef> abilities;
 
@@ -121,6 +124,10 @@ namespace Pawnmorph.Hediffs
 			RunBaseLogic = ShouldRunBaseLogic() ? true : RunBaseLogic;
 		}
 
+        /// <summary>
+        /// Called once when the hediff stage is first loaded, for any one-time initialization
+        /// </summary>
+        /// <param name="hediff"></param>
         public void OnLoad(Hediff hediff)
         {
             ApplyVerbOverrides(hediff);

--- a/Source/Pawnmorphs/Esoteria/Hediffs/ObsoletePart.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/ObsoletePart.cs
@@ -2,7 +2,6 @@
 // last updated 10/27/2019  8:52 AM
 
 using System;
-using Verse;
 
 namespace Pawnmorph.Hediffs
 {

--- a/Source/Pawnmorphs/Esoteria/Hediffs/RandomMorphFullTfStage.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/RandomMorphFullTfStage.cs
@@ -1,12 +1,10 @@
 ﻿// RandomMorphFullTfStage.cs modified by Iron Wolf for Pawnmorph on 01/25/2020 12:02 PM
 // last updated 01/25/2020  12:02 PM
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
 using Pawnmorph.Utilities;
-using RimWorld;
 using Verse;
 
 namespace Pawnmorph.Hediffs

--- a/Source/Pawnmorphs/Esoteria/Hediffs/RandomMorphTransformationStage.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/RandomMorphTransformationStage.cs
@@ -1,7 +1,6 @@
 ﻿// RandomMorphTransformationStage.cs modified by Iron Wolf for Pawnmorph on 01/25/2020 11:52 AM
 // last updated 01/25/2020  11:52 AM
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;

--- a/Source/Pawnmorphs/Esoteria/Hediffs/RemoveFromPartComp.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/RemoveFromPartComp.cs
@@ -1,10 +1,7 @@
 ﻿// RemoveFromPartComp.cs modified by Iron Wolf for Pawnmorph on 09/25/2019 5:42 PM
 // last updated 09/25/2019  5:42 PM
 
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using JetBrains.Annotations;
 using Pawnmorph.Utilities;
 using Verse;
 

--- a/Source/Pawnmorphs/Esoteria/Hediffs/SyringeRifleTf.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/SyringeRifleTf.cs
@@ -1,7 +1,6 @@
 ﻿// SyringeRifleTf.cs created by Iron Wolf for Pawnmorph on 05/17/2020 7:39 PM
 // last updated 05/17/2020  7:39 PM
 
-using System.Linq;
 using Pawnmorph.TfSys;
 using Pawnmorph.ThingComps;
 using Verse;

--- a/Source/Pawnmorphs/Esoteria/Hybrids/HThoughtDefOf.cs
+++ b/Source/Pawnmorphs/Esoteria/Hybrids/HThoughtDefOf.cs
@@ -2,6 +2,7 @@
 // last updated 08/03/2019  3:09 PM
 
 using RimWorld;
+
 #pragma warning disable 01591
 namespace Pawnmorph.Hybrids
 {

--- a/Source/Pawnmorphs/Esoteria/Hybrids/HybridRaceSettings.cs
+++ b/Source/Pawnmorphs/Esoteria/Hybrids/HybridRaceSettings.cs
@@ -3,13 +3,13 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using AlienRace;
 using JetBrains.Annotations;
 using Pawnmorph.Hediffs;
 using RimWorld;
 using UnityEngine;
 using Verse;
+
 #pragma warning disable 0612
 namespace Pawnmorph.Hybrids
 {

--- a/Source/Pawnmorphs/Esoteria/Hybrids/RaceGenerator.cs
+++ b/Source/Pawnmorphs/Esoteria/Hybrids/RaceGenerator.cs
@@ -6,12 +6,10 @@
 //#define TEST_BODY_SIZE 
 
 
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 using AlienRace;
 using JetBrains.Annotations;
 using Pawnmorph.Utilities;

--- a/Source/Pawnmorphs/Esoteria/Hybrids/RaceShiftUtilities.cs
+++ b/Source/Pawnmorphs/Esoteria/Hybrids/RaceShiftUtilities.cs
@@ -6,16 +6,13 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using AlienRace;
-using HarmonyLib;
 using JetBrains.Annotations;
 using Pawnmorph.DebugUtils;
 using Pawnmorph.GraphicSys;
 using Pawnmorph.Hediffs;
 using Pawnmorph.Utilities;
 using RimWorld;
-using UnityEngine;
 using Verse;
-using static Pawnmorph.DebugUtils.DebugLogUtils;
 
 namespace Pawnmorph.Hybrids
 {

--- a/Source/Pawnmorphs/Esoteria/IPMThingComp.cs
+++ b/Source/Pawnmorphs/Esoteria/IPMThingComp.cs
@@ -1,10 +1,6 @@
 ﻿// IPMThingComp.cs created by Iron Wolf for Pawnmorph on 05/17/2020 8:35 AM
 // last updated 05/17/2020  8:35 AM
 
-using System;
-using JetBrains.Annotations;
-using Verse;
-
 namespace Pawnmorph
 {
     /// <summary>

--- a/Source/Pawnmorphs/Esoteria/ITab_Pawn_Mutations.cs
+++ b/Source/Pawnmorphs/Esoteria/ITab_Pawn_Mutations.cs
@@ -2,11 +2,9 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using UnityEngine;
 using RimWorld;
+using UnityEngine;
 using Verse;
-using Pawnmorph.Utilities;
-using static Pawnmorph.DebugUtils.DebugLogUtils;
 
 namespace Pawnmorph
 {

--- a/Source/Pawnmorphs/Esoteria/ITabs/InjectorBills.cs
+++ b/Source/Pawnmorphs/Esoteria/ITabs/InjectorBills.cs
@@ -3,9 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using JetBrains.Annotations;
-using Pawnmorph.Chambers;
 using RimWorld;
 using UnityEngine;
 using Verse;

--- a/Source/Pawnmorphs/Esoteria/IWorkModifier.cs
+++ b/Source/Pawnmorphs/Esoteria/IWorkModifier.cs
@@ -4,7 +4,6 @@
 using JetBrains.Annotations;
 using Pawnmorph.Utilities;
 using Verse;
-using Verse.Noise;
 
 namespace Pawnmorph
 {

--- a/Source/Pawnmorphs/Esoteria/IncidentWorker/LiquidSlurry.cs
+++ b/Source/Pawnmorphs/Esoteria/IncidentWorker/LiquidSlurry.cs
@@ -1,13 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 using JetBrains.Annotations;
 using Pawnmorph.Utilities;
 using RimWorld;
 using UnityEngine;
 using Verse;
-using Verse.Noise;
 
 namespace Pawnmorph.IncidentWorkers
 {

--- a/Source/Pawnmorphs/Esoteria/IncidentWorker/MutagenicLeak.cs
+++ b/Source/Pawnmorphs/Esoteria/IncidentWorker/MutagenicLeak.cs
@@ -1,10 +1,10 @@
-﻿using System.Text;
+﻿using System.Collections.Generic;
 using System.Linq;
+using System.Text;
+using PipeSystem;
 using RimWorld;
 using UnityEngine;
 using Verse;
-using System.Collections.Generic;
-using PipeSystem;
 
 namespace Pawnmorph.IncidentWorkers
 {

--- a/Source/Pawnmorphs/Esoteria/IncidentWorker/SheepChef.cs
+++ b/Source/Pawnmorphs/Esoteria/IncidentWorker/SheepChef.cs
@@ -1,8 +1,6 @@
 ﻿// SheepChef.cs created by Iron Wolf for Pawnmorph on 01/05/2021 4:30 PM
 // last updated 01/05/2021  4:30 PM
 
-using System.Linq;
-using HarmonyLib;
 using JetBrains.Annotations;
 using Pawnmorph.Utilities;
 using RimWorld;

--- a/Source/Pawnmorphs/Esoteria/IncidentWorker_ChaomorphPasses.cs
+++ b/Source/Pawnmorphs/Esoteria/IncidentWorker_ChaomorphPasses.cs
@@ -1,7 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using RimWorld;
 using UnityEngine;
 using Verse;
-using RimWorld;
 
 namespace Pawnmorph
 {

--- a/Source/Pawnmorphs/Esoteria/IngestionOutcomeDoer_AddMorphTf.cs
+++ b/Source/Pawnmorphs/Esoteria/IngestionOutcomeDoer_AddMorphTf.cs
@@ -7,7 +7,6 @@ using JetBrains.Annotations;
 using Pawnmorph.Utilities;
 using RimWorld;
 using Verse;
-using Verse.Noise;
 
 namespace Pawnmorph
 {

--- a/Source/Pawnmorphs/Esoteria/IngestionOutcomeDoer_AddRandomAspect.cs
+++ b/Source/Pawnmorphs/Esoteria/IngestionOutcomeDoer_AddRandomAspect.cs
@@ -1,11 +1,9 @@
 ﻿// IngestionOutcomeDooer_Productive.cs modified by Iron Wolf for Pawnmorph on 10/05/2019 1:04 PM
 // last updated 10/05/2019  1:04 PM
 
+using System.Collections.Generic;
 using Pawnmorph.Aspects;
 using RimWorld;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Verse;
 using static Pawnmorph.Aspects.RandomGiver;
 

--- a/Source/Pawnmorphs/Esoteria/IngestionOutcomeDoer_BoostSeverity.cs
+++ b/Source/Pawnmorphs/Esoteria/IngestionOutcomeDoer_BoostSeverity.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using Pawnmorph.Utilities;
 using RimWorld;
 using Verse;
-using Verse.Noise;
 
 namespace Pawnmorph
 {

--- a/Source/Pawnmorphs/Esoteria/IngestionOutcomeDoer_CompleteTF.cs
+++ b/Source/Pawnmorphs/Esoteria/IngestionOutcomeDoer_CompleteTF.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using JetBrains.Annotations;
+﻿using JetBrains.Annotations;
 using Pawnmorph.Hediffs;
-using Pawnmorph.TfSys;
-using Pawnmorph.Utilities;
 using RimWorld;
 using Verse;
 

--- a/Source/Pawnmorphs/Esoteria/IngestionOutcomeDoer_GiveHediffAll.cs
+++ b/Source/Pawnmorphs/Esoteria/IngestionOutcomeDoer_GiveHediffAll.cs
@@ -1,5 +1,4 @@
 ﻿using System.Linq;
-using System.Text;
 using RimWorld;
 using Verse;
 

--- a/Source/Pawnmorphs/Esoteria/IngestionOutcomeDoer_MultipleTfBase.cs
+++ b/Source/Pawnmorphs/Esoteria/IngestionOutcomeDoer_MultipleTfBase.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using Pawnmorph.Hediffs;
 using RimWorld;
 using Verse;
 

--- a/Source/Pawnmorphs/Esoteria/InstinctUtilities.cs
+++ b/Source/Pawnmorphs/Esoteria/InstinctUtilities.cs
@@ -4,11 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using JetBrains.Annotations;
 using Pawnmorph.Utilities;
 using RimWorld;
-using UnityEngine;
 using Verse;
 
 namespace Pawnmorph

--- a/Source/Pawnmorphs/Esoteria/IntermittentMagicSprayer.cs
+++ b/Source/Pawnmorphs/Esoteria/IntermittentMagicSprayer.cs
@@ -1,7 +1,7 @@
 ﻿using System;
+using RimWorld;
 using UnityEngine;
 using Verse;
-using RimWorld;
 
 namespace Pawnmorph
 {

--- a/Source/Pawnmorphs/Esoteria/Jobs/Driver_DrainChemcyst.cs
+++ b/Source/Pawnmorphs/Esoteria/Jobs/Driver_DrainChemcyst.cs
@@ -1,6 +1,4 @@
-﻿using Verse;
-
-namespace Pawnmorph.Jobs
+﻿namespace Pawnmorph.Jobs
 {
     class Driver_DrainChemcyst : Driver_ProduceThing
     {

--- a/Source/Pawnmorphs/Esoteria/Jobs/Driver_LayEgg.cs
+++ b/Source/Pawnmorphs/Esoteria/Jobs/Driver_LayEgg.cs
@@ -1,7 +1,4 @@
-﻿using Verse;
-using System.Linq;
-
-namespace Pawnmorph.Jobs
+﻿namespace Pawnmorph.Jobs
 {
     /// <summary> Job driver to make humanoid pawns lay eggs using HediffComp_Production. </summary>
     public class Driver_LayEgg : Driver_ProduceThing

--- a/Source/Pawnmorphs/Esoteria/Jobs/Driver_MilkSelf.cs
+++ b/Source/Pawnmorphs/Esoteria/Jobs/Driver_MilkSelf.cs
@@ -1,10 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using JetBrains.Annotations;
-using Pawnmorph.Utilities;
-using Verse;
-
-namespace Pawnmorph.Jobs
+﻿namespace Pawnmorph.Jobs
 {
     /// <summary> Job driver to make humanoid pawns milk themselves using HediffComp_Production. </summary>
     public class Driver_MilkSelf : Driver_ProduceThing

--- a/Source/Pawnmorphs/Esoteria/Jobs/Driver_RecruitSapientFormerHuman.cs
+++ b/Source/Pawnmorphs/Esoteria/Jobs/Driver_RecruitSapientFormerHuman.cs
@@ -1,7 +1,6 @@
 ﻿// Driver_RecruitSapientFormerHuman.cs created by Iron Wolf for Pawnmorph on 03/15/2020 3:45 PM
 // last updated 03/15/2020  3:45 PM
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Pawnmorph.Utilities;

--- a/Source/Pawnmorphs/Esoteria/Jobs/Driver_ResurrectTf.cs
+++ b/Source/Pawnmorphs/Esoteria/Jobs/Driver_ResurrectTf.cs
@@ -7,7 +7,6 @@ using JetBrains.Annotations;
 using Pawnmorph.TfSys;
 using Pawnmorph.ThingComps;
 using RimWorld;
-using RimWorld.Planet;
 using Verse;
 using Verse.AI;
 

--- a/Source/Pawnmorphs/Esoteria/Jobs/Driver_ShaveSelf.cs
+++ b/Source/Pawnmorphs/Esoteria/Jobs/Driver_ShaveSelf.cs
@@ -1,7 +1,4 @@
-﻿using System.Linq;
-using Verse;
-
-namespace Pawnmorph.Jobs
+﻿namespace Pawnmorph.Jobs
 {
     class Driver_ShaveSelf : Driver_ProduceThing
     {

--- a/Source/Pawnmorphs/Esoteria/Jobs/Driver_TransformPrisoner.cs
+++ b/Source/Pawnmorphs/Esoteria/Jobs/Driver_TransformPrisoner.cs
@@ -1,10 +1,8 @@
 ﻿// Driver_TransformPrisoner.cs created by Iron Wolf for Pawnmorph on 10/20/2020 6:58 AM
 // last updated 10/20/2020  6:58 AM
 
-using System;
 using System.Collections.Generic;
 using Pawnmorph.Chambers;
-using RimWorld;
 using Verse;
 using Verse.AI;
 

--- a/Source/Pawnmorphs/Esoteria/Jobs/Driver_UseGenome.cs
+++ b/Source/Pawnmorphs/Esoteria/Jobs/Driver_UseGenome.cs
@@ -4,15 +4,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using Pawnmorph.Chambers;
-using Pawnmorph.DebugUtils;
 using Pawnmorph.Genebank.Model;
 using Pawnmorph.Hediffs;
 using Pawnmorph.ThingComps;
-using Pawnmorph.Utilities;
 using RimWorld;
 using Verse;
 using Verse.AI;
-using Verse.Sound;
 
 namespace Pawnmorph.Jobs
 {

--- a/Source/Pawnmorphs/Esoteria/Jobs/Giver_Producer.cs
+++ b/Source/Pawnmorphs/Esoteria/Jobs/Giver_Producer.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Verse.AI;
+﻿using Verse.AI;
 
 namespace Pawnmorph.Jobs
 {

--- a/Source/Pawnmorphs/Esoteria/Joy/Giver_TerrainProduction.cs
+++ b/Source/Pawnmorphs/Esoteria/Joy/Giver_TerrainProduction.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using Pawnmorph.DefExtensions;
 using Pawnmorph.Hediffs;
 using RimWorld;
-using UnityEngine;
 using Verse;
 using Verse.AI;
 

--- a/Source/Pawnmorphs/Esoteria/MorphCategoryDef.cs
+++ b/Source/Pawnmorphs/Esoteria/MorphCategoryDef.cs
@@ -2,7 +2,6 @@
 // last updated 09/15/2019  9:09 PM
 
 using System.Collections.Generic;
-using System.Linq;
 using JetBrains.Annotations;
 using Pawnmorph.Hediffs;
 using Verse;

--- a/Source/Pawnmorphs/Esoteria/MorphCategoryDefOf.cs
+++ b/Source/Pawnmorphs/Esoteria/MorphCategoryDefOf.cs
@@ -1,8 +1,8 @@
 ﻿// MorphCategoryDefOf.cs created by Iron Wolf for Pawnmorph on 09/15/2019 9:13 PM
 // last updated 09/15/2019  9:13 PM
 
-using JetBrains.Annotations;
 using RimWorld;
+
 #pragma warning disable 1591
 namespace Pawnmorph
 {

--- a/Source/Pawnmorphs/Esoteria/MorphDef.cs
+++ b/Source/Pawnmorphs/Esoteria/MorphDef.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using HarmonyLib;
 using JetBrains.Annotations;
 using Pawnmorph.Hediffs;
 using Pawnmorph.Hybrids;

--- a/Source/Pawnmorphs/Esoteria/MorphDefOfs.cs
+++ b/Source/Pawnmorphs/Esoteria/MorphDefOfs.cs
@@ -2,6 +2,7 @@
 // last updated 08/02/2019  2:46 PM
 
 using RimWorld;
+
 #pragma warning disable 1591
 namespace Pawnmorph
 {

--- a/Source/Pawnmorphs/Esoteria/MorphGroupDefOf.cs
+++ b/Source/Pawnmorphs/Esoteria/MorphGroupDefOf.cs
@@ -2,6 +2,7 @@
 // last updated 09/09/2019  7:33 PM
 
 using RimWorld;
+
 #pragma warning disable 1591
 namespace Pawnmorph
 {

--- a/Source/Pawnmorphs/Esoteria/MorphPawnKindExtension.cs
+++ b/Source/Pawnmorphs/Esoteria/MorphPawnKindExtension.cs
@@ -1,7 +1,6 @@
 ﻿// MorphPawnKindExtension.cs created by Iron Wolf for Pawnmorph on 09/15/2019 9:43 PM
 // last updated 09/15/2019  9:43 PM
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -10,7 +9,6 @@ using JetBrains.Annotations;
 using Pawnmorph.DebugUtils;
 using Pawnmorph.Hediffs;
 using Pawnmorph.Utilities;
-using RimWorld;
 using Verse;
 
 namespace Pawnmorph

--- a/Source/Pawnmorphs/Esoteria/MorphTracker.cs
+++ b/Source/Pawnmorphs/Esoteria/MorphTracker.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using JetBrains.Annotations;
 using Pawnmorph.Hybrids;
 using UnityEngine;

--- a/Source/Pawnmorphs/Esoteria/MorphTrader.cs
+++ b/Source/Pawnmorphs/Esoteria/MorphTrader.cs
@@ -1,13 +1,11 @@
-﻿using RimWorld;
-using RimWorld.Planet;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using JetBrains.Annotations;
-using Verse;
-using Pawnmorph.Utilities;
-using UnityEngine;
 using Pawnmorph.FormerHumans;
+using RimWorld;
+using RimWorld.Planet;
+using Verse;
 
 namespace Pawnmorph
 {

--- a/Source/Pawnmorphs/Esoteria/MorphUtilities.cs
+++ b/Source/Pawnmorphs/Esoteria/MorphUtilities.cs
@@ -4,15 +4,14 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using HarmonyLib;
 using JetBrains.Annotations;
+using Pawnmorph.DefExtensions;
 using Pawnmorph.Hediffs;
 using Pawnmorph.Hybrids;
 using Pawnmorph.Utilities;
 using RimWorld;
 using Verse;
-using HarmonyLib;
-using HugsLib.Logs;
-using Pawnmorph.DefExtensions;
 using static Pawnmorph.PMHistoryEventArgsNames;
 
 namespace Pawnmorph

--- a/Source/Pawnmorphs/Esoteria/MutagenDefOf.cs
+++ b/Source/Pawnmorphs/Esoteria/MutagenDefOf.cs
@@ -3,6 +3,7 @@
 
 using JetBrains.Annotations;
 using RimWorld;
+
 #pragma warning disable 1591
 namespace Pawnmorph
 {

--- a/Source/Pawnmorphs/Esoteria/Mutagen_JobDefOf.cs
+++ b/Source/Pawnmorphs/Esoteria/Mutagen_JobDefOf.cs
@@ -3,6 +3,7 @@
 
 using RimWorld;
 using Verse;
+
 #pragma warning disable 1591
 namespace Pawnmorph
 {

--- a/Source/Pawnmorphs/Esoteria/MutagenicBuildupUtilities.cs
+++ b/Source/Pawnmorphs/Esoteria/MutagenicBuildupUtilities.cs
@@ -2,7 +2,6 @@
 // last updated 03/25/2020  7:20 PM
 
 using System;
-using System.Linq;
 using JetBrains.Annotations;
 using Pawnmorph.Damage;
 using Pawnmorph.DefExtensions;

--- a/Source/Pawnmorphs/Esoteria/MutagenicStone.cs
+++ b/Source/Pawnmorphs/Esoteria/MutagenicStone.cs
@@ -1,9 +1,8 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
-using Verse;
-using RimWorld;
 using Pawnmorph.Hediffs;
 using Pawnmorph.Utilities;
+using RimWorld;
+using Verse;
 
 namespace Pawnmorph
 {

--- a/Source/Pawnmorphs/Esoteria/MutationLogEntry.cs
+++ b/Source/Pawnmorphs/Esoteria/MutationLogEntry.cs
@@ -65,6 +65,7 @@ namespace Pawnmorph
         /// </summary>
         /// <param name="pawn">The pawn.</param>
         /// <param name="mutationDef">The mutation definition.</param>
+        /// <param name="mutagenCause">The cause for this mutation (optional)</param>
         /// <param name="mutatedParts">The mutated parts.</param>
         public MutationLogEntry(Pawn pawn, HediffDef mutationDef, [CanBeNull] MutagenDef mutagenCause, 
                                 IEnumerable<BodyPartDef> mutatedParts)

--- a/Source/Pawnmorphs/Esoteria/MutationLogEntry.cs
+++ b/Source/Pawnmorphs/Esoteria/MutationLogEntry.cs
@@ -6,12 +6,10 @@ using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
 using Pawnmorph.Hediffs;
-using Pawnmorph.Utilities;
 using RimWorld;
 using UnityEngine;
 using Verse;
 using Verse.Grammar;
-using Verse.Noise;
 using static Pawnmorph.DebugUtils.DebugLogUtils;
 
 namespace Pawnmorph

--- a/Source/Pawnmorphs/Esoteria/MutationRules/Worker_Hellhound.cs
+++ b/Source/Pawnmorphs/Esoteria/MutationRules/Worker_Hellhound.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
 using Pawnmorph.Hediffs;
-using RimWorld;
 using Verse;
 
 namespace Pawnmorph.MutationRules

--- a/Source/Pawnmorphs/Esoteria/MutationRules/Worker_RemoveConditionalHediffs.cs
+++ b/Source/Pawnmorphs/Esoteria/MutationRules/Worker_RemoveConditionalHediffs.cs
@@ -1,7 +1,6 @@
 ﻿// Worker_Hellhound.cs created by Iron Wolf for Pawnmorph on 07/29/2020 8:54 PM
 // last updated 07/29/2020  8:54 PM
 
-using System;
 using JetBrains.Annotations;
 using Pawnmorph.Utilities;
 using Verse;

--- a/Source/Pawnmorphs/Esoteria/MutationStagePatch.cs
+++ b/Source/Pawnmorphs/Esoteria/MutationStagePatch.cs
@@ -1,11 +1,8 @@
-﻿using JetBrains.Annotations;
-using RimWorld;
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using JetBrains.Annotations;
+using RimWorld;
 using Verse;
 
 namespace Pawnmorph.Hediffs

--- a/Source/Pawnmorphs/Esoteria/MutationUtilities.cs
+++ b/Source/Pawnmorphs/Esoteria/MutationUtilities.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using AlienRace;
@@ -11,13 +10,12 @@ using HarmonyLib;
 using JetBrains.Annotations;
 using Pawnmorph.DebugUtils;
 using Pawnmorph.DefExtensions;
-using static Pawnmorph.DebugUtils.DebugLogUtils;
 using Pawnmorph.Hediffs;
 using Pawnmorph.UserInterface;
 using Pawnmorph.Utilities;
 using RimWorld;
-using UnityEngine;
 using Verse;
+using static Pawnmorph.DebugUtils.DebugLogUtils;
 
 
 namespace Pawnmorph

--- a/Source/Pawnmorphs/Esoteria/MutationsDefOf.cs
+++ b/Source/Pawnmorphs/Esoteria/MutationsDefOf.cs
@@ -2,7 +2,7 @@
 // last updated 09/22/2019  8:36 AM
 
 using RimWorld;
-using Verse;
+
 #pragma warning disable 1591 
 namespace Pawnmorph
 {

--- a/Source/Pawnmorphs/Esoteria/Need_Control.cs
+++ b/Source/Pawnmorphs/Esoteria/Need_Control.cs
@@ -130,6 +130,9 @@ namespace Pawnmorph
         /// </value>
         public float SeekerLevel => _seekerLevel;
 
+        /// <summary>
+        /// The races that this need is enabled for
+        /// </summary>
         [NotNull]
         public static HashSet<ThingDef> EnabledRaces
         {

--- a/Source/Pawnmorphs/Esoteria/PMBackstoryDefOf.cs
+++ b/Source/Pawnmorphs/Esoteria/PMBackstoryDefOf.cs
@@ -1,7 +1,6 @@
 ﻿// PMBackstoryDefOf.cs created by Iron Wolf for Pawnmorph on 01/05/2021 4:49 PM
 // last updated 01/05/2021  4:49 PM
 
-using AlienRace;
 using JetBrains.Annotations;
 using RimWorld;
 

--- a/Source/Pawnmorphs/Esoteria/PMDesignationDefOf.cs
+++ b/Source/Pawnmorphs/Esoteria/PMDesignationDefOf.cs
@@ -4,6 +4,7 @@
 using JetBrains.Annotations;
 using RimWorld;
 using Verse;
+
 // ReSharper disable NotNullMemberIsNotInitialized
 
 #pragma warning disable 1591

--- a/Source/Pawnmorphs/Esoteria/PMEffecterDefOf.cs
+++ b/Source/Pawnmorphs/Esoteria/PMEffecterDefOf.cs
@@ -14,6 +14,9 @@ namespace Pawnmorph
     {
         static PMEffecterDefOf() {  DefOfHelper.EnsureInitializedInCtor(typeof(PMEffecterDefOf));}
 
+        /// <summary>
+        /// The EffectorDef for cooking
+        /// </summary>
         public static EffecterDef Cook; 
     }
 

--- a/Source/Pawnmorphs/Esoteria/PMHistoryEventDef.cs
+++ b/Source/Pawnmorphs/Esoteria/PMHistoryEventDef.cs
@@ -1,6 +1,5 @@
 ﻿using JetBrains.Annotations;
 using RimWorld;
-using Verse;
 
 namespace Pawnmorph
 {

--- a/Source/Pawnmorphs/Esoteria/PMImplicitDefGenerator.cs
+++ b/Source/Pawnmorphs/Esoteria/PMImplicitDefGenerator.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
-using System.Text;
 using JetBrains.Annotations;
 using Pawnmorph.Chambers;
 using Pawnmorph.Hediffs;

--- a/Source/Pawnmorphs/Esoteria/PMIncidentDefOf.cs
+++ b/Source/Pawnmorphs/Esoteria/PMIncidentDefOf.cs
@@ -2,6 +2,7 @@
 // last updated 08/29/2019  3:34 PM
 
 using RimWorld;
+
 #pragma warning disable 1591
 namespace Pawnmorph
 {

--- a/Source/Pawnmorphs/Esoteria/PMInteractionDefOf.cs
+++ b/Source/Pawnmorphs/Esoteria/PMInteractionDefOf.cs
@@ -3,6 +3,7 @@
 
 using JetBrains.Annotations;
 using RimWorld;
+
 // ReSharper disable NotNullMemberIsNotInitialized
 
 #pragma warning disable 1591

--- a/Source/Pawnmorphs/Esoteria/PMJobDefOf.cs
+++ b/Source/Pawnmorphs/Esoteria/PMJobDefOf.cs
@@ -4,6 +4,7 @@
 using JetBrains.Annotations;
 using RimWorld;
 using Verse;
+
 #pragma warning disable 1591
 namespace Pawnmorph
 {

--- a/Source/Pawnmorphs/Esoteria/PMPrisonerInteractionModeDefOf.cs
+++ b/Source/Pawnmorphs/Esoteria/PMPrisonerInteractionModeDefOf.cs
@@ -2,7 +2,6 @@
 // last updated 10/20/2020  7:04 AM
 
 using RimWorld;
-using Verse;
 
 namespace Pawnmorph
 {

--- a/Source/Pawnmorphs/Esoteria/PMRulePackDefOf.cs
+++ b/Source/Pawnmorphs/Esoteria/PMRulePackDefOf.cs
@@ -3,6 +3,7 @@
 
 using RimWorld;
 using Verse;
+
 #pragma warning disable 1591
 namespace Pawnmorph
 {

--- a/Source/Pawnmorphs/Esoteria/PMStatDefOf.cs
+++ b/Source/Pawnmorphs/Esoteria/PMStatDefOf.cs
@@ -1,7 +1,6 @@
 ﻿// PMStatDefOf.cs modified by Iron Wolf for Pawnmorph on 12/01/2019 9:01 AM
 // last updated 12/01/2019  9:01 AM
 
-using System.Security.Policy;
 using JetBrains.Annotations;
 using RimWorld;
 

--- a/Source/Pawnmorphs/Esoteria/PMStyleDefOf.cs
+++ b/Source/Pawnmorphs/Esoteria/PMStyleDefOf.cs
@@ -1,7 +1,6 @@
 ﻿// BackstoryDefOf.cs modified by Iron Wolf for Pawnmorph on 11/29/2019 7:35 AM
 // last updated 11/29/2019  7:35 AM
 
-using AlienRace;
 using JetBrains.Annotations;
 using RimWorld;
 

--- a/Source/Pawnmorphs/Esoteria/PMThingDefOf.cs
+++ b/Source/Pawnmorphs/Esoteria/PMThingDefOf.cs
@@ -3,6 +3,7 @@
 
 using RimWorld;
 using Verse;
+
 #pragma warning disable 1591
 namespace Pawnmorph
 {

--- a/Source/Pawnmorphs/Esoteria/PMThingUtilities.cs
+++ b/Source/Pawnmorphs/Esoteria/PMThingUtilities.cs
@@ -46,7 +46,6 @@ namespace Pawnmorph
         {
             if (thing == null) throw new ArgumentNullException(nameof(thing));
             return thing.Map ?? thing.MapHeld; 
-            return thing.holdingOwner == null ? thing.Map : thing.MapHeld;
         }
     }
 }

--- a/Source/Pawnmorphs/Esoteria/PMThoughtDefOf.cs
+++ b/Source/Pawnmorphs/Esoteria/PMThoughtDefOf.cs
@@ -1,8 +1,8 @@
 ﻿// PMThoughtDefOf.cs modified by Iron Wolf for Pawnmorph on 09/28/2019 8:35 AM
 // last updated 09/28/2019  8:35 AM
 
-using System;
 using RimWorld;
+
 #pragma warning disable 1591
 namespace Pawnmorph
 {

--- a/Source/Pawnmorphs/Esoteria/PMTraitDefOf.cs
+++ b/Source/Pawnmorphs/Esoteria/PMTraitDefOf.cs
@@ -2,6 +2,7 @@
 // last updated 09/16/2019  12:48 PM
 
 using RimWorld;
+
 #pragma warning disable 1591
 namespace Pawnmorph
 {

--- a/Source/Pawnmorphs/Esoteria/PartAddress.cs
+++ b/Source/Pawnmorphs/Esoteria/PartAddress.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Xml;
 using JetBrains.Annotations;
-using RimWorld;
 using Verse;
 
 namespace Pawnmorph

--- a/Source/Pawnmorphs/Esoteria/PatchOperations/DebugAdd.cs
+++ b/Source/Pawnmorphs/Esoteria/PatchOperations/DebugAdd.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Xml;
 using JetBrains.Annotations;
 using Verse;
+
 #pragma warning disable CS0649
 namespace Pawnmorph.PatchOperations
 {

--- a/Source/Pawnmorphs/Esoteria/PawnMorphInstance.cs
+++ b/Source/Pawnmorphs/Esoteria/PawnMorphInstance.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Verse;
+
 #pragma warning disable 01591
 namespace Pawnmorph
 {

--- a/Source/Pawnmorphs/Esoteria/PawnMorphInstanceMerged.cs
+++ b/Source/Pawnmorphs/Esoteria/PawnMorphInstanceMerged.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Verse;
+
 #pragma warning disable 01591
 
 namespace Pawnmorph

--- a/Source/Pawnmorphs/Esoteria/PawnTransferUtilities.cs
+++ b/Source/Pawnmorphs/Esoteria/PawnTransferUtilities.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Security.Cryptography;
 using JetBrains.Annotations;
 using Pawnmorph.DefExtensions;
 using Pawnmorph.Thoughts;

--- a/Source/Pawnmorphs/Esoteria/PawnmorphGameComp.cs
+++ b/Source/Pawnmorphs/Esoteria/PawnmorphGameComp.cs
@@ -13,7 +13,6 @@ using Pawnmorph.TfSys;
 using Pawnmorph.Utilities;
 using RimWorld;
 using RimWorld.Planet;
-using UnityEngine;
 using Verse;
 
 namespace Pawnmorph

--- a/Source/Pawnmorphs/Esoteria/PawnmorphMPCompat.cs
+++ b/Source/Pawnmorphs/Esoteria/PawnmorphMPCompat.cs
@@ -1,11 +1,9 @@
 ﻿using System.Reflection;
-
-using Verse;
 using HarmonyLib;
 using Multiplayer.API;
-
 using Pawnmorph;
 using Pawnmorph.Hediffs;
+using Verse;
 
 namespace PawnMorpher
 {

--- a/Source/Pawnmorphs/Esoteria/PawnmorphPatches.cs
+++ b/Source/Pawnmorphs/Esoteria/PawnmorphPatches.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;

--- a/Source/Pawnmorphs/Esoteria/PawnmorpherMod.cs
+++ b/Source/Pawnmorphs/Esoteria/PawnmorpherMod.cs
@@ -1,6 +1,5 @@
-﻿using Pawnmorph.DebugUtils;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
+using Pawnmorph.DebugUtils;
 using UnityEngine;
 using Verse;
 

--- a/Source/Pawnmorphs/Esoteria/PawnmorpherModInit.cs
+++ b/Source/Pawnmorphs/Esoteria/PawnmorpherModInit.cs
@@ -1,21 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Text;
 using AlienRace;
 using JetBrains.Annotations;
-using Pawnmorph.Chambers;
 using Pawnmorph.DebugUtils;
 using Pawnmorph.GraphicSys;
 using Pawnmorph.Hediffs;
-using Verse;
-using RimWorld;
 using Pawnmorph.Hybrids;
 using Pawnmorph.Utilities;
+using RimWorld;
 using UnityEngine;
-
+using Verse;
 //just a typedef to shorten long type name 
 using HediffGraphic = AlienRace.AlienPartGenerator.ExtendedHediffGraphic; 
 

--- a/Source/Pawnmorphs/Esoteria/PawnmorpherSettings.cs
+++ b/Source/Pawnmorphs/Esoteria/PawnmorpherSettings.cs
@@ -1,5 +1,5 @@
-﻿using Pawnmorph.DebugUtils;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using Pawnmorph.DebugUtils;
 using Verse;
 
 namespace Pawnmorph

--- a/Source/Pawnmorphs/Esoteria/PreceptComps/SelfTookMemoryThought_MemeOverride.cs
+++ b/Source/Pawnmorphs/Esoteria/PreceptComps/SelfTookMemoryThought_MemeOverride.cs
@@ -140,7 +140,8 @@ namespace Pawnmorph.PreceptComps
             }
 
             /// <summary>
-            ///     Performs an explicit conversion from <see cref="MemeThoughtEntry" /> to <see cref="(T1, T2)" />.
+            ///     Performs an explicit conversion from <see cref="MemeThoughtEntry" /> to
+            ///     <see cref="ValueTuple{MemeDef, ThoughtDef}" />.
             /// </summary>
             /// <param name="entry">The entry.</param>
             /// <returns>

--- a/Source/Pawnmorphs/Esoteria/PreceptComps/VeneratedAnimalMemory.cs
+++ b/Source/Pawnmorphs/Esoteria/PreceptComps/VeneratedAnimalMemory.cs
@@ -2,10 +2,8 @@
 // last updated 07/22/2021  7:05 AM
 
 using System.Collections.Generic;
-using System.Linq;
 using JetBrains.Annotations;
 using Pawnmorph.Thoughts.Precept;
-using Pawnmorph.Utilities;
 using RimWorld;
 using Verse;
 

--- a/Source/Pawnmorphs/Esoteria/PreceptComps/VeneratedMutation.cs
+++ b/Source/Pawnmorphs/Esoteria/PreceptComps/VeneratedMutation.cs
@@ -2,7 +2,6 @@
 // last updated 07/25/2021  4:35 PM
 
 using System.Linq;
-using Pawnmorph.Utilities;
 using RimWorld;
 using Verse;
 

--- a/Source/Pawnmorphs/Esoteria/PreceptComps/VeneratedMutation.cs
+++ b/Source/Pawnmorphs/Esoteria/PreceptComps/VeneratedMutation.cs
@@ -24,7 +24,6 @@ namespace Pawnmorph.PreceptComps
         /// </returns>
         protected override ThingDef GetAnimal(in HistoryEvent historyEvent, Ideo ideo)
         {
-            ThingDef animal = null;
             var mut = historyEvent.GetArg<Hediff_AddedMutation>(PMHistoryEventArgsNames.MUTATION);
 
 

--- a/Source/Pawnmorphs/Esoteria/Properties/AssemblyInfo.cs
+++ b/Source/Pawnmorphs/Esoteria/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/Source/Pawnmorphs/Esoteria/RaceMutationSettingsExtension.cs
+++ b/Source/Pawnmorphs/Esoteria/RaceMutationSettingsExtension.cs
@@ -7,7 +7,6 @@ using System.Text;
 using JetBrains.Annotations;
 using Pawnmorph.Hediffs;
 using Pawnmorph.Utilities;
-using RimWorld;
 using Verse;
 
 namespace Pawnmorph

--- a/Source/Pawnmorphs/Esoteria/RecipeWorkers/TagAnimal.cs
+++ b/Source/Pawnmorphs/Esoteria/RecipeWorkers/TagAnimal.cs
@@ -1,12 +1,11 @@
 ﻿// TagAnimal.cs created by Iron Wolf for Pawnmorph on 07/20/2021 6:37 PM
 // last updated 07/20/2021  6:37 PM
 
-using RimWorld;
 using System.Collections.Generic;
-using System.Linq;
 using Pawnmorph.Chambers;
-using Verse;
 using Pawnmorph.Genebank.Model;
+using RimWorld;
+using Verse;
 
 namespace Pawnmorph.RecipeWorkers
 {

--- a/Source/Pawnmorphs/Esoteria/Rituals/AttachableOutcomeEffectWorkers/AddRandomVeneratedMutation.cs
+++ b/Source/Pawnmorphs/Esoteria/Rituals/AttachableOutcomeEffectWorkers/AddRandomVeneratedMutation.cs
@@ -126,6 +126,7 @@ namespace Pawnmorph.Rituals.AttachableOutcomeEffectWorkers
         /// <param name="target">The target.</param>
         /// <param name="jobRitual">The job ritual.</param>
         /// <param name="outcome">The outcome.</param>
+        /// <param name="chosenAnimal">The venerated animal that was chosen</param>
         /// <returns></returns>
         [NotNull]
         protected virtual IEnumerable<MutationDef> GetMutationsToAdd([NotNull] Pawn target, [NotNull] LordJob_Ritual jobRitual,

--- a/Source/Pawnmorphs/Esoteria/SapienceStates/MergedPawn.cs
+++ b/Source/Pawnmorphs/Esoteria/SapienceStates/MergedPawn.cs
@@ -1,7 +1,6 @@
 ﻿// MergedPawn.cs created by Iron Wolf for Pawnmorph on 05/08/2020 10:33 AM
 // last updated 05/08/2020  10:33 AM
 
-using Pawnmorph.Hediffs;
 using Verse;
 
 namespace Pawnmorph.SapienceStates

--- a/Source/Pawnmorphs/Esoteria/ScenarioParts/ScenPart_ForcedAspect.cs
+++ b/Source/Pawnmorphs/Esoteria/ScenarioParts/ScenPart_ForcedAspect.cs
@@ -1,8 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using RimWorld;
 using UnityEngine;
 using Verse;
-using RimWorld;
+
 #pragma warning disable 1591
 
 namespace Pawnmorph.ScenarioParts

--- a/Source/Pawnmorphs/Esoteria/ScenarioParts/ScenPart_ForcedSapience.cs
+++ b/Source/Pawnmorphs/Esoteria/ScenarioParts/ScenPart_ForcedSapience.cs
@@ -1,8 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using RimWorld;
 using UnityEngine;
 using Verse;
-using RimWorld;
+
 #pragma warning disable 1591
 
 namespace Pawnmorph.ScenarioParts

--- a/Source/Pawnmorphs/Esoteria/SimplePawnColorSet.cs
+++ b/Source/Pawnmorphs/Esoteria/SimplePawnColorSet.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using UnityEngine;
+﻿using UnityEngine;
 using Verse;
 
 namespace Pawnmorph

--- a/Source/Pawnmorphs/Esoteria/SkyFallerDefOf.cs
+++ b/Source/Pawnmorphs/Esoteria/SkyFallerDefOf.cs
@@ -1,9 +1,4 @@
 ﻿using RimWorld;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Verse;
 
 namespace Pawnmorph

--- a/Source/Pawnmorphs/Esoteria/Social/Worker_FormerHuman.cs
+++ b/Source/Pawnmorphs/Esoteria/Social/Worker_FormerHuman.cs
@@ -6,7 +6,6 @@ using JetBrains.Annotations;
 using Pawnmorph.DefExtensions;
 using Pawnmorph.Utilities;
 using RimWorld;
-using UnityEngine;
 using Verse;
 
 namespace Pawnmorph.Social

--- a/Source/Pawnmorphs/Esoteria/StockGenerators/GenomeGenerator.cs
+++ b/Source/Pawnmorphs/Esoteria/StockGenerators/GenomeGenerator.cs
@@ -3,12 +3,10 @@
 
 using System.Collections.Generic;
 using JetBrains.Annotations;
-using Pawnmorph.Hediffs;
 using Pawnmorph.ThingComps;
 using Pawnmorph.Utilities;
 using RimWorld;
 using Verse;
-using Verse.Noise;
 
 namespace Pawnmorph.StockGenerators
 {

--- a/Source/Pawnmorphs/Esoteria/TaleDefOf.cs
+++ b/Source/Pawnmorphs/Esoteria/TaleDefOf.cs
@@ -2,6 +2,7 @@
 // last updated 08/04/2019  7:00 PM
 
 using RimWorld;
+
 #pragma warning disable 1591
 namespace Pawnmorph
 {

--- a/Source/Pawnmorphs/Esoteria/TfHediffDefOf.cs
+++ b/Source/Pawnmorphs/Esoteria/TfHediffDefOf.cs
@@ -4,6 +4,7 @@
 using JetBrains.Annotations;
 using RimWorld;
 using Verse;
+
 #pragma warning disable 1591
 namespace Pawnmorph
 {

--- a/Source/Pawnmorphs/Esoteria/TfRelationDefOf.cs
+++ b/Source/Pawnmorphs/Esoteria/TfRelationDefOf.cs
@@ -2,6 +2,7 @@
 // last updated 08/17/2019  11:00 AM
 
 using RimWorld;
+
 #pragma warning disable 1591
 namespace Pawnmorph
 {

--- a/Source/Pawnmorphs/Esoteria/TfSys/MergeMutagen.cs
+++ b/Source/Pawnmorphs/Esoteria/TfSys/MergeMutagen.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using Pawnmorph.Thoughts;
-using Pawnmorph.Utilities;
 using RimWorld;
 using Verse;
 

--- a/Source/Pawnmorphs/Esoteria/TfSys/SimpleMechaniteMutagen.cs
+++ b/Source/Pawnmorphs/Esoteria/TfSys/SimpleMechaniteMutagen.cs
@@ -10,7 +10,6 @@ using Pawnmorph.Thoughts;
 using Pawnmorph.Utilities;
 using RimWorld;
 using RimWorld.Planet;
-using UnityEngine;
 using Verse;
 
 namespace Pawnmorph.TfSys

--- a/Source/Pawnmorphs/Esoteria/TfSys/TransformationRequest.cs
+++ b/Source/Pawnmorphs/Esoteria/TfSys/TransformationRequest.cs
@@ -1,10 +1,8 @@
 ﻿// TransformationRequest.cs modified by Iron Wolf for Pawnmorph on 08/18/2019 8:55 AM
 // last updated 08/18/2019  8:55 AM
 
-using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using AlienRace;
 using JetBrains.Annotations;
 using Pawnmorph.Utilities;
 using RimWorld;

--- a/Source/Pawnmorphs/Esoteria/ThingComps/AddAspectEffectProps.cs
+++ b/Source/Pawnmorphs/Esoteria/ThingComps/AddAspectEffectProps.cs
@@ -2,7 +2,6 @@
 // last updated 07/30/2021  7:01 AM
 
 using System;
-using System.CodeDom;
 using System.Collections.Generic;
 using RimWorld;
 using Verse;

--- a/Source/Pawnmorphs/Esoteria/ThingComps/AlwaysMergedPawn.cs
+++ b/Source/Pawnmorphs/Esoteria/ThingComps/AlwaysMergedPawn.cs
@@ -8,7 +8,6 @@ using Pawnmorph.DebugUtils;
 using Pawnmorph.FormerHumans;
 using Pawnmorph.TfSys;
 using RimWorld;
-using RimWorld.Planet;
 using Verse;
 
 namespace Pawnmorph.ThingComps

--- a/Source/Pawnmorphs/Esoteria/ThingComps/AnimalSelectorComp.cs
+++ b/Source/Pawnmorphs/Esoteria/ThingComps/AnimalSelectorComp.cs
@@ -119,6 +119,7 @@ namespace Pawnmorph.ThingComps
 
         private Gizmo[] _cachedGizmoArr;
 
+        /// <inheritdoc />
         public override void Initialize(CompProperties props)
         {
             base.Initialize(props);
@@ -150,6 +151,9 @@ namespace Pawnmorph.ThingComps
 
         Command_Action Gizmo => _cachedGizmo;
 
+        /// <summary>
+        /// Resets the selected animal
+        /// </summary>
         public void ResetSelection()
         {
             _cachedGizmo.defaultLabel = Props.labelKey.Translate();

--- a/Source/Pawnmorphs/Esoteria/ThingComps/DatabaseStorage.cs
+++ b/Source/Pawnmorphs/Esoteria/ThingComps/DatabaseStorage.cs
@@ -21,6 +21,7 @@ namespace Pawnmorph.ThingComps
 
         private ChamberDatabase Database => Find.World.GetComponent<ChamberDatabase>();
 
+        /// <inheritdoc />
         public override void ReceiveCompSignal(string signal)
         {
             if (signal == CompPowerTrader.PowerTurnedOnSignal && _powered == false)

--- a/Source/Pawnmorphs/Esoteria/ThingComps/DatabaseStorage.cs
+++ b/Source/Pawnmorphs/Esoteria/ThingComps/DatabaseStorage.cs
@@ -1,7 +1,6 @@
 ﻿// DatabaseStorageComp.cs created by Iron Wolf for Pawnmorph on 08/03/2020 4:57 PM
 // last updated 08/03/2020  4:57 PM
 
-using System.Diagnostics;
 using System.Text;
 using Pawnmorph.Chambers;
 using RimWorld;

--- a/Source/Pawnmorphs/Esoteria/ThingComps/DrawStoredPawnComp.cs
+++ b/Source/Pawnmorphs/Esoteria/ThingComps/DrawStoredPawnComp.cs
@@ -1,8 +1,7 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
+using RimWorld;
 using UnityEngine;
 using Verse;
-using RimWorld;
 
 namespace Pawnmorph.ThingComps
 {

--- a/Source/Pawnmorphs/Esoteria/ThingComps/DrawStoredPawnProperties.cs
+++ b/Source/Pawnmorphs/Esoteria/ThingComps/DrawStoredPawnProperties.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
+using RimWorld;
 using UnityEngine;
 using Verse;
-using RimWorld;
 
 namespace Pawnmorph.ThingComps
 {

--- a/Source/Pawnmorphs/Esoteria/ThingComps/MutationGenomeStorage.cs
+++ b/Source/Pawnmorphs/Esoteria/ThingComps/MutationGenomeStorage.cs
@@ -2,10 +2,8 @@
 // last updated 08/07/2020  1:43 PM
 
 using System.Collections.Generic;
-using System.Linq;
 using JetBrains.Annotations;
 using Pawnmorph.Chambers;
-using Pawnmorph.Hediffs;
 using Pawnmorph.Utilities;
 using RimWorld;
 using Verse;

--- a/Source/Pawnmorphs/Esoteria/ThingComps/ResurrectorTargetProperties.cs
+++ b/Source/Pawnmorphs/Esoteria/ThingComps/ResurrectorTargetProperties.cs
@@ -5,11 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
-using Pawnmorph.Chambers;
 using Pawnmorph.DefExtensions;
 using Pawnmorph.Hybrids;
 using Pawnmorph.Utilities;
-using RimWorld;
 using Verse;
 
 namespace Pawnmorph.ThingComps

--- a/Source/Pawnmorphs/Esoteria/Things/Chaothrumbo.cs
+++ b/Source/Pawnmorphs/Esoteria/Things/Chaothrumbo.cs
@@ -1,7 +1,6 @@
 ﻿// Chaothrumbo.cs created by Iron Wolf for Pawnmorph on 06/26/2021 10:09 AM
 // last updated 06/26/2021  10:09 AM
 
-using System;
 using Pawnmorph.Thoughts;
 using RimWorld;
 using Verse;

--- a/Source/Pawnmorphs/Esoteria/Things/ExpandedPlant.cs
+++ b/Source/Pawnmorphs/Esoteria/Things/ExpandedPlant.cs
@@ -1,8 +1,6 @@
 ﻿// ExpandedPlant.cs created by Iron Wolf for Pawnmorph on 07/25/2021 6:39 PM
 // last updated 07/25/2021  6:39 PM
 
-using System.Collections.Generic;
-using System.Reflection;
 using System.Text;
 using JetBrains.Annotations;
 using Pawnmorph.DefExtensions;

--- a/Source/Pawnmorphs/Esoteria/Things/InjectorGenerator.cs
+++ b/Source/Pawnmorphs/Esoteria/Things/InjectorGenerator.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using JetBrains.Annotations;
 using Pawnmorph.Utilities;
 using RimWorld;

--- a/Source/Pawnmorphs/Esoteria/ThinkNodes/ConditionalOfFormerHuman.cs
+++ b/Source/Pawnmorphs/Esoteria/ThinkNodes/ConditionalOfFormerHuman.cs
@@ -4,7 +4,6 @@
 using Pawnmorph.Utilities;
 using Verse;
 using Verse.AI;
-using Verse.Noise;
 
 namespace Pawnmorph.ThinkNodes
 {

--- a/Source/Pawnmorphs/Esoteria/ThoughtWorker_HasEsotericBodyPart.cs
+++ b/Source/Pawnmorphs/Esoteria/ThoughtWorker_HasEsotericBodyPart.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
-using Verse;
 using RimWorld;
+using Verse;
 
 namespace Pawnmorph
 {

--- a/Source/Pawnmorphs/Esoteria/Thoughts/FormerHumanPalsWorker.cs
+++ b/Source/Pawnmorphs/Esoteria/Thoughts/FormerHumanPalsWorker.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 using Pawnmorph.DefExtensions;
-using Pawnmorph.Utilities;
 using RimWorld;
 using Verse;
 

--- a/Source/Pawnmorphs/Esoteria/Thoughts/FormerHumanSituationalWorkerBase.cs
+++ b/Source/Pawnmorphs/Esoteria/Thoughts/FormerHumanSituationalWorkerBase.cs
@@ -1,7 +1,6 @@
 ﻿// FormerHumanSituationalWorkerBase.cs modified by Iron Wolf for Pawnmorph on 01/21/2020 8:46 PM
 // last updated 01/21/2020  8:46 PM
 
-using JetBrains.Annotations;
 using RimWorld;
 using UnityEngine;
 

--- a/Source/Pawnmorphs/Esoteria/Thoughts/ReactionsHelper.cs
+++ b/Source/Pawnmorphs/Esoteria/Thoughts/ReactionsHelper.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
-using Pawnmorph.Utilities;
 using RimWorld;
 using UnityEngine;
 using Verse;

--- a/Source/Pawnmorphs/Esoteria/Thoughts/SapienceMemory.cs
+++ b/Source/Pawnmorphs/Esoteria/Thoughts/SapienceMemory.cs
@@ -3,7 +3,6 @@
 
 using RimWorld;
 using UnityEngine;
-using Verse;
 
 namespace Pawnmorph.Thoughts
 {

--- a/Source/Pawnmorphs/Esoteria/Thoughts/ThoughtDefOfs.cs
+++ b/Source/Pawnmorphs/Esoteria/Thoughts/ThoughtDefOfs.cs
@@ -2,6 +2,7 @@
 // last updated 07/31/2019  4:39 PM
 
 using RimWorld;
+
 #pragma warning disable 1591
 namespace Pawnmorph.Thoughts
 {

--- a/Source/Pawnmorphs/Esoteria/Thoughts/ThoughtLabels.cs
+++ b/Source/Pawnmorphs/Esoteria/Thoughts/ThoughtLabels.cs
@@ -1,9 +1,6 @@
 ﻿// PMThoughtLabels.cs created by Iron Wolf for Pawnmorph on 07/21/2021 5:52 PM
 // last updated 07/21/2021  5:52 PM
 
-using JetBrains.Annotations;
-using Verse;
-
 namespace Pawnmorph.Thoughts
 {
     /// <summary>

--- a/Source/Pawnmorphs/Esoteria/Thoughts/Thought_EtherMemory.cs
+++ b/Source/Pawnmorphs/Esoteria/Thoughts/Thought_EtherMemory.cs
@@ -4,7 +4,6 @@
 using JetBrains.Annotations;
 using RimWorld;
 using UnityEngine;
-using Verse;
 
 namespace Pawnmorph.Thoughts
 {

--- a/Source/Pawnmorphs/Esoteria/Thoughts/Worker_BeastMaster.cs
+++ b/Source/Pawnmorphs/Esoteria/Thoughts/Worker_BeastMaster.cs
@@ -31,6 +31,7 @@ namespace Pawnmorph.Thoughts
             return false;
         }
 
+        /// <inheritdoc />
         protected override bool AnimalMasterCheck(Pawn p, Pawn animal)
         {
             return base.AnimalMasterCheck(p,animal) && animal.IsFormerHuman();

--- a/Source/Pawnmorphs/Esoteria/Thoughts/Worker_FurryAppreciation.cs
+++ b/Source/Pawnmorphs/Esoteria/Thoughts/Worker_FurryAppreciation.cs
@@ -1,8 +1,6 @@
 ﻿// Worker_FurryAppreciation.cs created by Iron Wolf for Pawnmorph on 09/18/2019 2:07 PM
 // last updated 09/18/2019  2:07 PM
 
-using System.Linq;
-using System.Text;
 using RimWorld;
 using UnityEngine;
 using Verse;

--- a/Source/Pawnmorphs/Esoteria/Thoughts/Worker_HasMutations.cs
+++ b/Source/Pawnmorphs/Esoteria/Thoughts/Worker_HasMutations.cs
@@ -1,12 +1,9 @@
 ﻿// Worker_HasMutations.cs created by Iron Wolf for Pawnmorph on 09/18/2019 2:14 PM
 // last updated 09/18/2019  2:14 PM
 
-using System.Collections.Generic;
 using System.Linq;
 using Pawnmorph.DefExtensions;
 using Pawnmorph.GraphicSys;
-using Pawnmorph.Hediffs;
-using Pawnmorph.Hybrids;
 using Pawnmorph.Utilities;
 using RimWorld;
 using UnityEngine;

--- a/Source/Pawnmorphs/Esoteria/Thoughts/Worker_MorphFrustrated.cs
+++ b/Source/Pawnmorphs/Esoteria/Thoughts/Worker_MorphFrustrated.cs
@@ -1,7 +1,6 @@
 ﻿// Worker_MorphFrustraited.cs modified by Iron Wolf for Pawnmorph on 01/05/2020 3:45 PM
 // last updated 01/05/2020  3:45 PM
 
-using System.Linq;
 using Pawnmorph.Utilities;
 using RimWorld;
 using Verse;

--- a/Source/Pawnmorphs/Esoteria/TransformPawn.cs
+++ b/Source/Pawnmorphs/Esoteria/TransformPawn.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Verse;
 using Pawnmorph;
+using Verse;
 
 namespace EtherGun
 {

--- a/Source/Pawnmorphs/Esoteria/TransformerUtility.cs
+++ b/Source/Pawnmorphs/Esoteria/TransformerUtility.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Security.Policy;
-using AlienRace;
 using JetBrains.Annotations;
 using Pawnmorph.DebugUtils;
 using Pawnmorph.Hediffs;
@@ -10,11 +8,10 @@ using Pawnmorph.Hybrids;
 using Pawnmorph.TfSys;
 using Pawnmorph.Thoughts;
 using Pawnmorph.Utilities;
-using UnityEngine;
 using RimWorld;
 using RimWorld.Planet;
+using UnityEngine;
 using Verse;
-using Verse.AI;
 using Verse.AI.Group;
 
 namespace Pawnmorph

--- a/Source/Pawnmorphs/Esoteria/UserInterface/Dialog_PartPicker.cs
+++ b/Source/Pawnmorphs/Esoteria/UserInterface/Dialog_PartPicker.cs
@@ -1,24 +1,18 @@
-﻿using AlienRace;
-using Pawnmorph.Hediffs;
-using RimWorld;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using AlienRace;
 using JetBrains.Annotations;
 using Pawnmorph.Chambers;
-using Pawnmorph.Utilities;
+using Pawnmorph.Genebank.Model;
+using Pawnmorph.GraphicSys;
+using Pawnmorph.Hediffs;
+using Pawnmorph.UserInterface.PartPicker;
+using RimWorld;
 using UnityEngine;
 using Verse;
 using Verse.Sound;
-using Pawnmorph.GraphicSys;
-using Pawnmorph.Hediffs.MutationRetrievers;
-using UnityEngine.UIElements.Experimental;
-using Pawnmorph.UserInterface.PartPicker;
-using HarmonyLib;
-using UnityEngine.UIElements;
-using Pawnmorph.ThingComps;
-using Pawnmorph.Genebank.Model;
 
 namespace Pawnmorph.UserInterface
 {

--- a/Source/Pawnmorphs/Esoteria/UserInterface/Dialog_Popup.cs
+++ b/Source/Pawnmorphs/Esoteria/UserInterface/Dialog_Popup.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using UnityEngine;
 using Verse;
 

--- a/Source/Pawnmorphs/Esoteria/UserInterface/Dialog_Textbox.cs
+++ b/Source/Pawnmorphs/Esoteria/UserInterface/Dialog_Textbox.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using UnityEngine;
 using Verse;
 

--- a/Source/Pawnmorphs/Esoteria/UserInterface/FilterListBox.cs
+++ b/Source/Pawnmorphs/Esoteria/UserInterface/FilterListBox.cs
@@ -1,9 +1,5 @@
-﻿using Pawnmorph.Utilities.Collections;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System;
+using Pawnmorph.Utilities.Collections;
 using UnityEngine;
 using Verse;
 

--- a/Source/Pawnmorphs/Esoteria/UserInterface/Genebank/GeneRowItem.cs
+++ b/Source/Pawnmorphs/Esoteria/UserInterface/Genebank/GeneRowItem.cs
@@ -1,13 +1,7 @@
-﻿using Pawnmorph.Chambers;
+﻿using System.Collections.Generic;
+using Pawnmorph.Chambers;
 using Pawnmorph.Genebank.Model;
-using Pawnmorph.Hediffs;
-using Pawnmorph.UserInterface.PartPicker;
 using Pawnmorph.UserInterface.TableBox;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Verse;
 
 namespace Pawnmorph.UserInterface.Genebank

--- a/Source/Pawnmorphs/Esoteria/UserInterface/Genebank/GenebankTab.cs
+++ b/Source/Pawnmorphs/Esoteria/UserInterface/Genebank/GenebankTab.cs
@@ -1,12 +1,7 @@
-﻿using JetBrains.Annotations;
+﻿using System.Collections.Generic;
 using Pawnmorph.Chambers;
 using Pawnmorph.Genebank.Model;
 using Pawnmorph.UserInterface.TableBox;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using UnityEngine;
 using Verse;
 

--- a/Source/Pawnmorphs/Esoteria/UserInterface/Genebank/Tabs/AnimalsTab.cs
+++ b/Source/Pawnmorphs/Esoteria/UserInterface/Genebank/Tabs/AnimalsTab.cs
@@ -1,16 +1,12 @@
-﻿using Pawnmorph.Chambers;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Pawnmorph.Chambers;
 using Pawnmorph.Genebank.Model;
 using Pawnmorph.Hediffs;
 using Pawnmorph.UserInterface.Preview;
 using Pawnmorph.UserInterface.TableBox;
 using RimWorld;
-using RimWorld.BaseGen;
-using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using UnityEngine;
 using Verse;
 

--- a/Source/Pawnmorphs/Esoteria/UserInterface/Genebank/Tabs/MutationsTab.cs
+++ b/Source/Pawnmorphs/Esoteria/UserInterface/Genebank/Tabs/MutationsTab.cs
@@ -1,18 +1,15 @@
-﻿using Pawnmorph.Abilities;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Pawnmorph.Abilities;
 using Pawnmorph.Chambers;
 using Pawnmorph.Genebank.Model;
 using Pawnmorph.Hediffs;
-using Pawnmorph.Hediffs.MutationRetrievers;
 using Pawnmorph.UserInterface.Preview;
 using Pawnmorph.UserInterface.TableBox;
 using Pawnmorph.Utilities;
 using RimWorld;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Security.Cryptography.Xml;
-using System.Text;
-using System.Threading.Tasks;
 using UnityEngine;
 using Verse;
 

--- a/Source/Pawnmorphs/Esoteria/UserInterface/Genebank/Tabs/TemplatesTab.cs
+++ b/Source/Pawnmorphs/Esoteria/UserInterface/Genebank/Tabs/TemplatesTab.cs
@@ -1,16 +1,14 @@
-﻿using Pawnmorph.Chambers;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Pawnmorph.Chambers;
 using Pawnmorph.Genebank.Model;
 using Pawnmorph.Hediffs;
-using Pawnmorph.Hediffs.MutationRetrievers;
 using Pawnmorph.UserInterface.PartPicker;
 using Pawnmorph.UserInterface.Preview;
 using Pawnmorph.UserInterface.TableBox;
 using RimWorld;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using UnityEngine;
 using Verse;
 

--- a/Source/Pawnmorphs/Esoteria/UserInterface/MainTabWindow_ChamberDatabase.cs
+++ b/Source/Pawnmorphs/Esoteria/UserInterface/MainTabWindow_ChamberDatabase.cs
@@ -1,12 +1,6 @@
 ﻿// MainTabWindow_ChamberDatabase.cs created by Iron Wolf for Pawnmorph on 08/26/2020 2:36 PM
 // last updated 08/26/2020  2:36 PM
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-using JetBrains.Annotations;
-using Pawnmorph.Chambers;
-using Pawnmorph.Hediffs;
 using Pawnmorph.UserInterface;
 using RimWorld;
 using UnityEngine;

--- a/Source/Pawnmorphs/Esoteria/UserInterface/MainTabWindow_ChamberDatabase.cs
+++ b/Source/Pawnmorphs/Esoteria/UserInterface/MainTabWindow_ChamberDatabase.cs
@@ -20,7 +20,7 @@ namespace Pawnmorph
     /// <seealso cref="RimWorld.MainTabWindow" />
     public partial class MainTabWindow_ChamberDatabase : MainTabWindow
     {
-
+        /// <inheritdoc />
         public override void PostOpen()
         {
             base.PostOpen();
@@ -31,6 +31,7 @@ namespace Pawnmorph
             this.Close();
         }
 
+        /// <inheritdoc />
         public override void DoWindowContents(Rect inRect)
         {
 

--- a/Source/Pawnmorphs/Esoteria/UserInterface/PartPicker/AddedMutations.cs
+++ b/Source/Pawnmorphs/Esoteria/UserInterface/PartPicker/AddedMutations.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
 using Pawnmorph.Hediffs;
-using RimWorld;
 using Verse;
 
 namespace Pawnmorph.UserInterface

--- a/Source/Pawnmorphs/Esoteria/UserInterface/PartPicker/MutationTemplate.cs
+++ b/Source/Pawnmorphs/Esoteria/UserInterface/PartPicker/MutationTemplate.cs
@@ -1,10 +1,8 @@
-﻿using Pawnmorph.Hediffs;
-using RimWorld;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
+using Pawnmorph.Hediffs;
 using Verse;
 
 namespace Pawnmorph.UserInterface.PartPicker

--- a/Source/Pawnmorphs/Esoteria/UserInterface/PartPicker/MutationTemplate.cs
+++ b/Source/Pawnmorphs/Esoteria/UserInterface/PartPicker/MutationTemplate.cs
@@ -83,6 +83,10 @@ namespace Pawnmorph.UserInterface.PartPicker
 
 		}
 
+		/// <summary>
+		/// Returns a string describing all the mutations in this template  
+		/// </summary>
+		/// <returns>A string describing the template</returns>
 		public string Serialize()
 		{
 			// MutationDef, Part name, severity, halted.

--- a/Source/Pawnmorphs/Esoteria/UserInterface/PartPicker/MutationTemplateData.cs
+++ b/Source/Pawnmorphs/Esoteria/UserInterface/PartPicker/MutationTemplateData.cs
@@ -21,9 +21,24 @@ namespace Pawnmorph.UserInterface.PartPicker
 		private float _severity;
 		private bool _halted;
 
+		/// <summary>
+		/// The saved mutation def
+		/// </summary>
 		public MutationDef MutationDef => _mutationDef;
+		
+		/// <summary>
+		/// The name of the body part the mutation is attached to.
+		/// </summary>
 		public string PartLabelCap => _partLabelCap;
+		
+		/// <summary>
+		/// The severity of the mutation
+		/// </summary>
 		public float Severity => _severity;
+		
+		/// <summary>
+		/// Whether the mutation is halted or not
+		/// </summary>
 		public bool Halted => _halted;
 
 		/// <summary>

--- a/Source/Pawnmorphs/Esoteria/UserInterface/PartPicker/MutationTemplateData.cs
+++ b/Source/Pawnmorphs/Esoteria/UserInterface/PartPicker/MutationTemplateData.cs
@@ -1,11 +1,4 @@
 ﻿using Pawnmorph.Hediffs;
-using Pawnmorph.Hediffs.MutationRetrievers;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using UnityEngine;
 using Verse;
 
 namespace Pawnmorph.UserInterface.PartPicker

--- a/Source/Pawnmorphs/Esoteria/UserInterface/Preview/HumanlikePreview.cs
+++ b/Source/Pawnmorphs/Esoteria/UserInterface/Preview/HumanlikePreview.cs
@@ -1,12 +1,9 @@
-﻿using AlienRace;
-using Pawnmorph.Hediffs;
-using Pawnmorph.Hediffs.MutationRetrievers;
-using RimWorld;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using AlienRace;
+using Pawnmorph.Hediffs;
+using RimWorld;
 using UnityEngine;
 using Verse;
 

--- a/Source/Pawnmorphs/Esoteria/UserInterface/Preview/PawnPreview.cs
+++ b/Source/Pawnmorphs/Esoteria/UserInterface/Preview/PawnPreview.cs
@@ -1,14 +1,7 @@
-﻿using Pawnmorph.GraphicSys;
+﻿using System;
 using Pawnmorph.Utilities;
 using RimWorld;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using UnityEngine;
 using Verse;
-using Verse.AI;
 
 namespace Pawnmorph.UserInterface.Preview
 {

--- a/Source/Pawnmorphs/Esoteria/UserInterface/Preview/Preview.cs
+++ b/Source/Pawnmorphs/Esoteria/UserInterface/Preview/Preview.cs
@@ -1,15 +1,5 @@
-﻿using AlienRace;
-using Pawnmorph.GraphicSys;
-using Pawnmorph.Hediffs;
-using RimWorld;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.Remoting.Channels;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System;
 using UnityEngine;
-using UnityEngine.UIElements;
 using Verse;
 
 namespace Pawnmorph.UserInterface.Preview

--- a/Source/Pawnmorphs/Esoteria/UserInterface/Preview/ThingPreview.cs
+++ b/Source/Pawnmorphs/Esoteria/UserInterface/Preview/ThingPreview.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using UnityEngine;
+﻿using UnityEngine;
 using Verse;
 
 namespace Pawnmorph.UserInterface.Preview

--- a/Source/Pawnmorphs/Esoteria/UserInterface/Settings/Dialog_AnimalAssociations.cs
+++ b/Source/Pawnmorphs/Esoteria/UserInterface/Settings/Dialog_AnimalAssociations.cs
@@ -1,12 +1,8 @@
-﻿using HugsLib.Utils;
-using Pawnmorph.Chambers;
-using Pawnmorph.Utilities.Collections;
-using System;
-using System.Collections;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Pawnmorph.Chambers;
+using Pawnmorph.Utilities.Collections;
 using UnityEngine;
 using Verse;
 using Verse.Sound;

--- a/Source/Pawnmorphs/Esoteria/UserInterface/Settings/Dialog_OptionalPatches.cs
+++ b/Source/Pawnmorphs/Esoteria/UserInterface/Settings/Dialog_OptionalPatches.cs
@@ -1,10 +1,8 @@
-﻿using Pawnmorph.HPatches.Optional;
-using Pawnmorph.Utilities.Collections;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Pawnmorph.HPatches.Optional;
+using Pawnmorph.Utilities.Collections;
 using UnityEngine;
 using Verse;
 using Verse.Sound;

--- a/Source/Pawnmorphs/Esoteria/UserInterface/Settings/Dialog_RaceReplacements.cs
+++ b/Source/Pawnmorphs/Esoteria/UserInterface/Settings/Dialog_RaceReplacements.cs
@@ -1,11 +1,7 @@
-﻿using HugsLib.Utils;
-using Pawnmorph.Utilities.Collections;
-using System;
-using System.Collections;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Pawnmorph.Utilities.Collections;
 using UnityEngine;
 using Verse;
 using Verse.Sound;

--- a/Source/Pawnmorphs/Esoteria/UserInterface/Settings/Dialog_VisibleRaceSelection.cs
+++ b/Source/Pawnmorphs/Esoteria/UserInterface/Settings/Dialog_VisibleRaceSelection.cs
@@ -1,9 +1,7 @@
-﻿using Pawnmorph.Utilities.Collections;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Pawnmorph.Utilities.Collections;
 using UnityEngine;
 using Verse;
 using Verse.Sound;

--- a/Source/Pawnmorphs/Esoteria/UserInterface/TableBox/ITableRow.cs
+++ b/Source/Pawnmorphs/Esoteria/UserInterface/TableBox/ITableRow.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Pawnmorph.UserInterface.TableBox
+﻿namespace Pawnmorph.UserInterface.TableBox
 {
     internal interface ITableRow
     {

--- a/Source/Pawnmorphs/Esoteria/UserInterface/TableBox/Table.cs
+++ b/Source/Pawnmorphs/Esoteria/UserInterface/TableBox/Table.cs
@@ -1,12 +1,7 @@
-﻿using Pawnmorph.Utilities.Collections;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Data.Common;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Pawnmorph.Utilities.Collections;
 using UnityEngine;
-using UnityEngine.UIElements;
 using Verse;
 
 namespace Pawnmorph.UserInterface.TableBox

--- a/Source/Pawnmorphs/Esoteria/UserInterface/TableBox/TableColumn.cs
+++ b/Source/Pawnmorphs/Esoteria/UserInterface/TableBox/TableColumn.cs
@@ -1,13 +1,6 @@
-﻿using Pawnmorph.Utilities.Collections;
-using RimWorld;
-using Steamworks;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System;
+using Pawnmorph.Utilities.Collections;
 using UnityEngine;
-using Verse;
 
 namespace Pawnmorph.UserInterface.TableBox
 {

--- a/Source/Pawnmorphs/Esoteria/UserInterface/Window_Genebank.cs
+++ b/Source/Pawnmorphs/Esoteria/UserInterface/Window_Genebank.cs
@@ -1,16 +1,9 @@
-﻿using Pawnmorph.Chambers;
-using Pawnmorph.Hediffs;
-using Pawnmorph.Hediffs.MutationRetrievers;
+﻿using System;
+using System.Collections.Generic;
+using Pawnmorph.Chambers;
 using Pawnmorph.UserInterface.Genebank;
 using Pawnmorph.UserInterface.Genebank.Tabs;
-using Pawnmorph.UserInterface.Preview;
 using Pawnmorph.UserInterface.TableBox;
-using RimWorld;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using UnityEngine;
 using Verse;
 

--- a/Source/Pawnmorphs/Esoteria/Utilities/Collections/ExposableList.cs
+++ b/Source/Pawnmorphs/Esoteria/Utilities/Collections/ExposableList.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Verse;
 
 namespace Pawnmorph.Utilities.Collections

--- a/Source/Pawnmorphs/Esoteria/Utilities/Collections/FilteredList.cs
+++ b/Source/Pawnmorphs/Esoteria/Utilities/Collections/FilteredList.cs
@@ -1,12 +1,7 @@
-﻿using Mono.Cecil;
-using System;
-using System.Collections;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Verse;
 
 namespace Pawnmorph.Utilities.Collections
 {

--- a/Source/Pawnmorphs/Esoteria/Utilities/CompCacher.cs
+++ b/Source/Pawnmorphs/Esoteria/Utilities/CompCacher.cs
@@ -134,7 +134,7 @@ namespace Pawnmorph.Utilities
             {
                 GenCompCacher.ClearAllCompCaches(); //clear any pawns from a previous world 
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 Log.Error($"Pawnmorpher is unable to clear all comp caches on world initialization!");
             }

--- a/Source/Pawnmorphs/Esoteria/Utilities/HashGiverUtils.cs
+++ b/Source/Pawnmorphs/Esoteria/Utilities/HashGiverUtils.cs
@@ -1,13 +1,6 @@
-﻿using HarmonyLib;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Configuration;
-using System.Data;
-using System.Linq;
-using System.Reflection;
-using System.Security.Cryptography;
-using System.Text;
-using System.Threading.Tasks;
+using HarmonyLib;
 using Verse;
 
 namespace Pawnmorph.Utilities

--- a/Source/Pawnmorphs/Esoteria/Utilities/ListedBackstoryDef.cs
+++ b/Source/Pawnmorphs/Esoteria/Utilities/ListedBackstoryDef.cs
@@ -7,12 +7,19 @@ using Verse;
 
 namespace Pawnmorph
 {
+    /// <summary>
+    /// A backstory def that can explicitly allow a list of multiple work types 
+    /// </summary>
     public class ListedBackstoryDef : AlienRace.AlienBackstoryDef
     {
 
+        /// <summary>
+        /// The list of allowed WorkTags
+        /// </summary>
         public List<WorkTags> workAllowsList = new List<WorkTags>();
 
 
+        /// <inheritdoc />
         public override void ResolveReferences()
         {
             if (workAllowsList.Count > 0)

--- a/Source/Pawnmorphs/Esoteria/Utilities/ListedBackstoryDef.cs
+++ b/Source/Pawnmorphs/Esoteria/Utilities/ListedBackstoryDef.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 using Verse;
 
 namespace Pawnmorph

--- a/Source/Pawnmorphs/Esoteria/Utilities/PatchUtilities.cs
+++ b/Source/Pawnmorphs/Esoteria/Utilities/PatchUtilities.cs
@@ -37,7 +37,6 @@ namespace Pawnmorph.Utilities
             Type fhUtilType = typeof(FormerHumanUtilities);
             Type racePropType = typeof(RaceProperties);
             const BindingFlags publicInstance = BindingFlags.Public | BindingFlags.Instance;
-            const BindingFlags allFlags = publicInstance | BindingFlags.NonPublic | BindingFlags.Static;
 
             IsAnimalMethod = fhUtilType.GetMethod(nameof(FormerHumanUtilities.IsAnimal), new[] {typeof(Pawn)});
 

--- a/Source/Pawnmorphs/Esoteria/Utilities/PawnGeneratorUtility.cs
+++ b/Source/Pawnmorphs/Esoteria/Utilities/PawnGeneratorUtility.cs
@@ -1,9 +1,4 @@
 ﻿using RimWorld;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Verse;
 
 namespace Pawnmorph.Utilities

--- a/Source/Pawnmorphs/Esoteria/Utilities/RandUtilities.cs
+++ b/Source/Pawnmorphs/Esoteria/Utilities/RandUtilities.cs
@@ -1,6 +1,6 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
 using Verse;
-using System;
 
 namespace Pawnmorph.Utilities
 {

--- a/Source/Pawnmorphs/Esoteria/Utilities/StatsUtility.cs
+++ b/Source/Pawnmorphs/Esoteria/Utilities/StatsUtility.cs
@@ -1,10 +1,5 @@
-﻿using RimWorld;
-using RimWorld.Planet;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using RimWorld;
 using Verse;
 
 namespace Pawnmorph.Utilities

--- a/Source/Pawnmorphs/Esoteria/Utilities/TimedCache.cs
+++ b/Source/Pawnmorphs/Esoteria/Utilities/TimedCache.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Verse;
 
 namespace Pawnmorph.Utilities

--- a/Source/Pawnmorphs/Esoteria/Verbs/Tag.cs
+++ b/Source/Pawnmorphs/Esoteria/Verbs/Tag.cs
@@ -1,7 +1,6 @@
 ﻿// Tag.cs created by Iron Wolf for Pawnmorph on 08/13/2020 5:18 PM
 // last updated 08/13/2020  5:18 PM
 
-using Pawnmorph.Chambers;
 using RimWorld;
 using UnityEngine;
 using Verse;

--- a/Source/Pawnmorphs/Esoteria/Work/Giver_RecruitSapientAnimal.cs
+++ b/Source/Pawnmorphs/Esoteria/Work/Giver_RecruitSapientAnimal.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using RimWorld;
-using UnityEngine;
 using Verse;
 using Verse.AI;
 

--- a/Source/Pawnmorphs/Esoteria/Work/Giver_WorkAtSequencer.cs
+++ b/Source/Pawnmorphs/Esoteria/Work/Giver_WorkAtSequencer.cs
@@ -1,7 +1,6 @@
 ﻿// Giver_WorkAtSequencer.cs created by Iron Wolf for Pawnmorph on 11/14/2020 8:54 AM
 // last updated 11/14/2020  8:54 AM
 
-using System.Collections.Generic;
 using Pawnmorph.ThingComps;
 using RimWorld;
 using Verse;


### PR DESCRIPTION
I fixed a number of low-hanging compiler warnings to reduce the warning spam on building the project.  This doesn't fix all of them by far, but it's a lot easier to see the important warnings now.

I recommend looking at the individual commits to see the changes, as one of them involved sorting and optimizing the using directives in every file.

Changes:
 - Added missing XML docs for public methods.  Most were set to inherit the existing docs, but I added some manual docs for a few cases as best as I understood them.  I'd appreciate double-checking the documentation I added to ensure it's correct.
 - Removed or annotated a number of unused variables.  The removed variables were all local variables and so were safe to remove.  Any properties that are set via XML were given the [UsedImplicitly] tag if they were missing it instead.
 - Replaced a single obsolete method call that presumably got missed in all the warning spam
 - Sorted the using directives and removed unused usings in the entire project.  This was done with Rider's Optimize Import tool, and I manually confirmed that the project still compiled successfully after running it.