### PR TITLE
Limit head replacement to explicitly removed heads

### DIFF
--- a/Source/Pawnmorphs/Esoteria/HPatches/GamePatches.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/GamePatches.cs
@@ -1,32 +1,44 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using HarmonyLib;
+using JetBrains.Annotations;
 using RimWorld;
 using Verse;
 
 namespace Pawnmorph.HPatches
 {
 	[HarmonyPatch(typeof(Game))]
+	[UsedImplicitly]
 	internal static class GamePatches
 	{
-
+		private static readonly Dictionary<string, string> HeadReplacements = new()
+		{
+			{ "Male_NarrowNormal", "Male_AverageNormal" },
+			{ "Male_NarrowPointy", "Male_AveragePointy" },
+			{ "Male_NarrowWide", "Male_AverageWide" },
+			{ "Female_NarrowNormal", "Female_AverageNormal" },
+			{ "Female_NarrowPointy", "Female_AveragePointy" },
+			{ "Female_NarrowWide", "Female_AverageWide" }
+		};
 
 		[HarmonyPatch(nameof(Game.LoadGame)), HarmonyPostfix]
+		[UsedImplicitly]
 		private static void LoadGamePostFix()
 		{
 			FixMissingNarrowHeads();
 		}
 		private static void FixMissingNarrowHeads()
 		{
-			HeadTypeDef[] narrowHeads = DefDatabase<HeadTypeDef>.AllDefs.Where(x => x.defName.Contains("Narrow")).ToArray();
-			Dictionary<HeadTypeDef, HeadTypeDef> headmap = narrowHeads.ToDictionary(x => x, x => DefDatabase<HeadTypeDef>.GetNamed(x.defName.Replace("Narrow", "Average")));
+			Dictionary<HeadTypeDef, HeadTypeDef> headMap =
+				HeadReplacements.ToDictionary(pair => DefDatabase<HeadTypeDef>.GetNamed(pair.Key),
+				                              pair => DefDatabase<HeadTypeDef>.GetNamed(pair.Value));
 
 			foreach (Pawn pawn in PawnsFinder.All_AliveOrDead)
 			{
 				Pawn_StoryTracker story = pawn.story;
 				if (story?.headType != null)
 				{
-					if (headmap.TryGetValue(story.headType, out HeadTypeDef headTypeDef))
+					if (headMap.TryGetValue(story.headType, out HeadTypeDef headTypeDef))
 						story.headType = headTypeDef;
 				}
 			}


### PR DESCRIPTION
This patch was causing errors and missing heads when various race mods were installed.  The issue is that the patch was hitting any head with the word "narrow" in it (e.g. AG_SlugFace_Narrow), and a number of mods don't use the same naming scheme as vanilla so the replaced heads were null.

I could have just not replaced the head if the replacement def type didn't exist, but I figured we shouldn't be replacing alien heads anyway since they don't usually show PM mutations