### PR TITLE
Performance improvements

### DIFF
--- a/Source/Pawnmorphs/Esoteria/Hediff_AddedMutation.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediff_AddedMutation.cs
@@ -419,7 +419,7 @@ namespace Pawnmorph
         }
 
         /// <summary>
-        ///     Posts the tick.
+        ///     Called after Tick().  The base class ticks Comps here.
         /// </summary>
         public override void PostTick()
         {

--- a/Source/Pawnmorphs/Esoteria/Hediff_AddedMutation.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediff_AddedMutation.cs
@@ -209,9 +209,6 @@ namespace Pawnmorph
         /// </summary>
         public override void Tick()
         {
-            // We don't use any of the vanilla functionality so there is no reason to propagate the tick further down
-            TickBase = Def.RunBaseLogic || (CurrentMutationStage?.RunBaseLogic ?? false);
-
             base.Tick();
 
             // Use a for loop here because this is a hot path and creating enumerators is causing too much overhead
@@ -234,6 +231,11 @@ namespace Pawnmorph
         {
             if (newStage is MutationStage mStage)
             {
+                
+                // We don't normally use any of the vanilla functionality so there is no reason to propagate the tick further down
+                // unless the hediff specifically requests it
+                TickBase = Def.RunBaseLogic || mStage.RunBaseLogic;
+                
                 GenerateAbilities(mStage);
 
                 //check for aspect skips 

--- a/Source/Pawnmorphs/Esoteria/Hediff_AddedMutation.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediff_AddedMutation.cs
@@ -214,10 +214,10 @@ namespace Pawnmorph
 
             base.Tick();
 
-            foreach (Abilities.MutationAbility ability in abilities)
-            {
-                ability.Tick();
-            }
+            // Use a for loop here because this is a hot path and creating enumerators is causing too much overhead
+            // ReSharper disable once ForCanBeConvertedToForeach
+            for (var i = 0; i < abilities.Count; i++)
+                abilities[i].Tick();
 
             if (shouldRemove == false && pawn.IsHashIntervalTick(10))
             {

--- a/Source/Pawnmorphs/Esoteria/Hediffs/Hediff_MutagenicBase.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Hediff_MutagenicBase.cs
@@ -551,7 +551,8 @@ namespace Pawnmorph.Hediffs
             set
             {
                 // Severity changes can potentially queue up mutations
-                if (CurStageIndex != -1 && CurStage is HediffStage_Mutation mutStage)
+                // Note that CurStage can be null if this hediff does not have stages, but the 'is' will return false in that case
+                if (CurStage is HediffStage_Mutation mutStage)
                 {
                     float diff = value - base.Severity;
                     int mutations = mutStage.mutationRate?.GetMutationsPerSeverity(this, diff) ?? 0;

--- a/Source/Pawnmorphs/Esoteria/Hediffs/Hediff_StageChanges.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Hediff_StageChanges.cs
@@ -85,7 +85,8 @@ namespace Pawnmorph.Hediffs
                 ageTicks++;
 
             // As long as we're within these bounds, the stage hasn't changed yet
-            if (Severity <= minStageSeverity || Severity >= maxStageSeverity)
+            float sev = Severity;
+            if (sev <= minStageSeverity || sev >= maxStageSeverity)
             {
                 int newStageIndex = base.CurStageIndex; // Make sure to get the actual index from the base
                 var oldStage = cachedStage;

--- a/Source/Pawnmorphs/Esoteria/Hediffs/Hediff_StageChanges.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Hediff_StageChanges.cs
@@ -19,14 +19,6 @@ namespace Pawnmorph.Hediffs
         // If the severity is within these bounds, we are still in the same stage.  Otherwise we've had a stage change.
         [Unsaved] private float minStageSeverity = float.NegativeInfinity;
         [Unsaved] private float maxStageSeverity = float.PositiveInfinity;
-
-        [Unsaved] private bool? _hasStages;
-        
-        /// <summary>
-        /// Whether or not this hediff has stages.  Is usually going to be true, but in rare cases a hediff may inherit from this
-        /// class yet have no stages.
-        /// </summary>
-        public bool HasStages => _hasStages ??= def?.stages != null;
         
 
         /// <summary>

--- a/Source/Pawnmorphs/Esoteria/Hediffs/MutationDef.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/MutationDef.cs
@@ -163,7 +163,7 @@ namespace Pawnmorph.Hediffs
         /// The cached mutation stages.
         /// </value>
         [NotNull]
-        public IReadOnlyList<MutationStage> CachedMutationStages => _cachedMutationStages ?? Array.Empty<MutationStage>();
+        public IReadOnlyList<MutationStage> CachedMutationStages => _cachedMutationStages ??= Array.Empty<MutationStage>();
 
         /// <summary>
         ///     returns a full, detailed, representation of the object in string form


### PR DESCRIPTION
Mutation hediffs were being a bit slow again.  I went through and cleaned up a lot of the caching to minimize what's going in in `.Tick()` directly or indirectly.  It still chugs quite a bit if you have a ton of hediffs, but at the moment the bottleneck is now vanilla's HediffWithComps.PostTick() rather than anything we're doing.

Before:
![image](https://user-images.githubusercontent.com/6283552/216592894-010a686e-d30c-4594-871e-18c0b9d0242e.png)


After:
![image](https://user-images.githubusercontent.com/6283552/216591541-357ecccf-472d-447b-9301-3a2aaa51eeea.png)
