### PR TITLE
Issue 774 - paragon aspect not working

### DIFF
--- a/Source/Pawnmorphs/Esoteria/DebugUtils/PMDebugActions.cs
+++ b/Source/Pawnmorphs/Esoteria/DebugUtils/PMDebugActions.cs
@@ -694,7 +694,13 @@ namespace Pawnmorph.DebugUtils
             Log.Message(initialComp.GetDebugStr());
         }
 
-        private static void AddAspectAtStage(AspectDef def, Pawn p, int i)
+		[DebugAction("Pawnmorpher", "Get pawn stats cache", actionType = DebugActionType.ToolMapForPawns, allowedGameStates = AllowedGameStates.PlayingOnMap)]
+		private static void GetPawnCachedStats(Pawn pawn)
+		{
+			Log.Message(StatsUtility.GetPawnDebugString(pawn));
+		}
+
+		private static void AddAspectAtStage(AspectDef def, Pawn p, int i)
         {
             p.GetAspectTracker()?.Add(def, i);
         }

--- a/Source/Pawnmorphs/Esoteria/Hediffs/Comp_MutationSeverityAdjust.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Comp_MutationSeverityAdjust.cs
@@ -284,7 +284,7 @@ namespace Pawnmorph.Hediffs
             stringBuilder.Append(base.CompDebugString());
             if (!Pawn.Dead)
             {
-                stringBuilder.Append($"severity/day: {SeverityChangePerDay().ToString("F3")}");
+                stringBuilder.Append($"severity/day: {SeverityChangePerDay().ToString("F3")}, effective max: {EffectiveMax:F3}");
 
                 if (_halted)
                     stringBuilder.Append(" (halted)");

--- a/Source/Pawnmorphs/Esoteria/Hediffs/Comp_MutationSeverityAdjust.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Comp_MutationSeverityAdjust.cs
@@ -24,7 +24,7 @@ namespace Pawnmorph.Hediffs
         private const float EPSILON = 0.001f;
         private bool _halted;
 
-        private float _offset; 
+        private float _offset;
 
         /// <summary>
         /// An additional offset on the maximum severity, for when things such as adaption cream increase it
@@ -102,7 +102,7 @@ namespace Pawnmorph.Hediffs
         /// <value>
         ///     <c>true</c> if [comp should remove]; otherwise, <c>false</c>.
         /// </value>
-        public override bool CompShouldRemove => ShouldRemove.Value;
+        public override bool CompShouldRemove => ShouldRemove.GetValue(300);
 
         /// <summary>
         ///     Gets the change per day.
@@ -135,10 +135,8 @@ namespace Pawnmorph.Hediffs
 
         // These values only get recalculated every so often because of how expensive they are to calculate
         //TODO make some sort of unified caching system for stat lookups, easy way to cause lots of lag 
-        private readonly Cached<float> StatAdjust;
-        private readonly Cached<float> MutationAdaptability;
-        private readonly Cached<bool> IsReverting;
-        private readonly Cached<bool> ShouldRemove;
+        private readonly TimedCache<bool> IsReverting;
+        private readonly TimedCache<bool> ShouldRemove;
 
         // The speed at which this particular mutation will revert, in severity-per-day.
         // Only generated once so that it doesn't fluctuate during reversion
@@ -149,10 +147,8 @@ namespace Pawnmorph.Hediffs
         /// </summary>
         public Comp_MutationSeverityAdjust()
         {
-            StatAdjust = new Cached<float>(() => Pawn.GetStatValue(PMStatDefOf.MutagenSensitivity));
-            MutationAdaptability = new Cached<float>(() => Pawn.GetStatValue(PMStatDefOf.MutationAdaptability));
-            IsReverting = new Cached<bool>(() => Pawn.health?.hediffSet?.HasHediff(MorphTransformationDefOf.PM_Reverting) == true);
-            ShouldRemove = new Cached<bool>(() => IsReverting.Value && parent.Severity <= 0);
+            IsReverting = new TimedCache<bool>(() => Pawn.health?.hediffSet?.HasHediff(MorphTransformationDefOf.PM_Reverting) == true);
+            ShouldRemove = new TimedCache<bool>(() => IsReverting.GetValue(300) && parent.Severity <= 0);
 
             RandReversionSpeed = new Lazy<float>(GenerateRandomReversionSpeed);
         }
@@ -185,10 +181,10 @@ namespace Pawnmorph.Hediffs
         {
             if (Pawn.IsHashIntervalTick(200))
             {
-                StatAdjust.Recalculate();
-                MutationAdaptability.Recalculate();
-                IsReverting.Recalculate();
-                ShouldRemove.Recalculate();
+                //StatAdjust.Recalculate();
+                //MutationAdaptability.Recalculate();
+                //IsReverting.Recalculate();
+                //ShouldRemove.Recalculate();
 
                 severityAdjustment += SeverityChangePerDay() / 300f; // 60000 / 200
             }
@@ -208,10 +204,10 @@ namespace Pawnmorph.Hediffs
         /// </summary>
         public void RecalcAdjustSpeed()
         {
-            StatAdjust.Recalculate();
-            MutationAdaptability.Recalculate();
-            IsReverting.Recalculate();
-            ShouldRemove.Recalculate();
+            //StatAdjust.Recalculate();
+            //MutationAdaptability.Recalculate();
+            //IsReverting.Recalculate();
+            //ShouldRemove.Recalculate();
         }
 
         /// <summary>
@@ -229,7 +225,7 @@ namespace Pawnmorph.Hediffs
         /// <returns></returns>
         public virtual float SeverityChangePerDay()
         {
-            if (IsReverting.Value)
+            if (IsReverting.GetValue(300))
             {
                 return RandReversionSpeed.Value;
             }
@@ -244,17 +240,17 @@ namespace Pawnmorph.Hediffs
             if (parent.Severity < minSeverity) sevPerDay = Mathf.Max(0, sevPerDay);
 
 
-            return sevPerDay * Mathf.Max(StatAdjust.Value, 0); //take the mutagen sensitivity stat into account 
+            return sevPerDay * Mathf.Max(StatsUtility.GetStat(Pawn, PMStatDefOf.MutagenSensitivity, 300) ?? 1, 0); //take the mutagen sensitivity stat into account 
         }
 
 
-        internal float EffectiveMax => Mathf.Max(MutationAdaptability.Value, 1) + SeverityOffset;
+        internal float EffectiveMax => Mathf.Max(StatsUtility.GetStat(Pawn, PMStatDefOf.MutationAdaptability, 300) ?? 0, 1) + SeverityOffset;
 
         private void CheckIfHalted()
         {
             if (parent.CurStage is MutationStage mStage)
             {
-                float stopChance = mStage.stopChance * GetChanceMult() * Pawn.GetStatValue(PMStatDefOf.MutationHaltChance);
+                float stopChance = mStage.stopChance * GetChanceMult() * StatsUtility.GetStat(Pawn, PMStatDefOf.MutationHaltChance, 300) ?? 0;
 
                 if (stopChance < 0.01f) return;
                 if (Rand.Value < stopChance) Halted = true;
@@ -272,7 +268,7 @@ namespace Pawnmorph.Hediffs
 
         private float GetChanceMult()
         {
-            float sVal = MutationAdaptability.Value;
+            float sVal = StatsUtility.GetStat(Pawn, PMStatDefOf.MutationAdaptability, 300) ?? 0;
 
             float r = MutationUtilities.MaxMutationAdaptabilityValue - MutationUtilities.MinMutationAdaptabilityValue;
             sVal = Mathf.Abs(MutationUtilities.AverageMutationAdaptabilityValue - sVal)

--- a/Source/Pawnmorphs/Esoteria/Hediffs/Comp_MutationSeverityAdjust.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Comp_MutationSeverityAdjust.cs
@@ -181,11 +181,6 @@ namespace Pawnmorph.Hediffs
         {
             if (Pawn.IsHashIntervalTick(200))
             {
-                //StatAdjust.Recalculate();
-                //MutationAdaptability.Recalculate();
-                //IsReverting.Recalculate();
-                //ShouldRemove.Recalculate();
-
                 severityAdjustment += SeverityChangePerDay() / 300f; // 60000 / 200
             }
         }
@@ -204,11 +199,9 @@ namespace Pawnmorph.Hediffs
         /// </summary>
         public void RecalcAdjustSpeed()
         {
-            //StatAdjust.Recalculate();
-            //MutationAdaptability.Recalculate();
-            //IsReverting.Recalculate();
-            //ShouldRemove.Recalculate();
-        }
+            IsReverting.QueueUpdate();
+            ShouldRemove.QueueUpdate();
+		}
 
         /// <summary>
         ///     restarts adjustment for this mutation if it was halted

--- a/Source/Pawnmorphs/Esoteria/Hediffs/Comp_MutationSeverityAdjust.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Comp_MutationSeverityAdjust.cs
@@ -291,7 +291,10 @@ namespace Pawnmorph.Hediffs
             stringBuilder.Append(base.CompDebugString());
             if (!Pawn.Dead)
             {
-                stringBuilder.AppendLine("severity/day: " + SeverityChangePerDay().ToString("F3"));
+                stringBuilder.Append($"severity/day: {SeverityChangePerDay().ToString("F3")}");
+
+                if (_halted)
+                    stringBuilder.Append(" (halted)");
             }
             return stringBuilder.ToString().TrimEndNewlines();
         }

--- a/Source/Pawnmorphs/Esoteria/Utilities/StatsUtility.cs
+++ b/Source/Pawnmorphs/Esoteria/Utilities/StatsUtility.cs
@@ -77,7 +77,7 @@ namespace Pawnmorph.Utilities
         /// <param name="pawn">The pawn.</param>
         /// <param name="statDef">The stat definition.</param>
         /// <param name="maxAge">Max amount of ticks since stat was last updated.</param>
-        /// <returns></returns>
+        /// <returns>Null if no value is cached and pawn isn't spawned because GetStatValueForPawn throws error in that case.</returns>
         public static float? GetStat(Pawn pawn, StatDef statDef, int maxAge)
         {
             ulong lookupID = (ulong)pawn.thingIDNumber << 32 | statDef.index;

--- a/Source/Pawnmorphs/Esoteria/Utilities/TimedCache.cs
+++ b/Source/Pawnmorphs/Esoteria/Utilities/TimedCache.cs
@@ -27,7 +27,7 @@ namespace Pawnmorph.Utilities
             if (_requestedUpdate == false)
             {
                 // If stat is older than age limit, recalculate.
-                if (_tickManager.TicksGame - Timestamp > maxAge)
+                if (_tickManager.TicksGame - _timestamp > maxAge)
                 {
                     QueueUpdate();
                 }


### PR DESCRIPTION
Paragon aspect did not work because stat cache in Ticker component did not get refreshed.
Seems PostTick method was not getting called?

Moved caches be time based instead of HashTick, and moved stats to use centralized StatsUtility cache.

The problem with IsHashIntervalTick is that it can only be used in a method guaranteed to run every tick, otherwise you may just so happen to never hit the exact tick that counts as hash tick for the pawn.

Now I just say that we can accept up to 300 ticks delay in responsiveness from gaining aspect. (5 seconds at 60tps)

StatsUtility returns null if not not cached and pawn isn't spawned because GetStatValue in that case errors. Coult potentially be changed to return StatDef.defaultBaseValue instead in those cases.

Fixes #774