### PR TITLE
Remove an unnecessary min-age limit from the race shifting utility

### DIFF
--- a/Source/Pawnmorphs/Esoteria/FormerHumanUtilities.cs
+++ b/Source/Pawnmorphs/Esoteria/FormerHumanUtilities.cs
@@ -33,6 +33,7 @@ namespace Pawnmorph
 
         /// <summary>
         /// The minimum biological age for a former human's human form
+        /// TODO - Support children if biotech is installed
         /// </summary>
         public const float MIN_FORMER_HUMAN_AGE = 17f;
 

--- a/Source/Pawnmorphs/Esoteria/Hybrids/RaceShiftUtilities.cs
+++ b/Source/Pawnmorphs/Esoteria/Hybrids/RaceShiftUtilities.cs
@@ -213,8 +213,6 @@ namespace Pawnmorph.Hybrids
 
             float currentConvertedAge = TransformerUtility.ConvertAge(pawn, race.race);
 
-            currentConvertedAge = Math.Max(currentConvertedAge, FormerHumanUtilities.MIN_FORMER_HUMAN_AGE);
-
             pawn.def = race;
             pawn.ageTracker.AgeBiologicalTicks = (long)currentConvertedAge * TimeMetrics.TICKS_PER_YEAR; // 3600000f ticks per year.;
 

--- a/Source/Pawnmorphs/Esoteria/TransformerUtility.cs
+++ b/Source/Pawnmorphs/Esoteria/TransformerUtility.cs
@@ -440,13 +440,12 @@ namespace Pawnmorph
         /// <param name="animal"> The animal. </param>
         public static PawnGenerationRequest GenerateRandomPawnFromAnimal(Pawn animal)
         {
-            var convertedAge = Mathf.Max(ConvertAge(animal, ThingDefOf.Human.race),17);
+            var convertedAge = Mathf.Max(ConvertAge(animal, ThingDefOf.Human.race),FormerHumanUtilities.MIN_FORMER_HUMAN_AGE);
             var gender = animal.gender;
             if (Rand.RangeInclusive(0, 100) <= 50)
             {
                 switch (gender)
                 {
-                    
                     case Gender.Male:
                         gender = Gender.Female; 
                         break;


### PR DESCRIPTION
Fixes #751 for real this time
There was an unneeded minimum age in the race shift utilities that always made race-shifted pawns at least 17.  That was only meant to be used when generating former humans and doesn't make any sense for morph races (which could potentially have a lower max age than 17, among other things).

The age limit for generated former humans should probably be rethought now that biotech adds kids, but that can be saved for a future PR.