### PR TITLE
Options to black list individual animals from being potential picks during full random transformations.

### DIFF
--- a/Languages/English/Keyed/Settings.xml
+++ b/Languages/English/Keyed/Settings.xml
@@ -37,4 +37,7 @@
 	<PMAnimalAssociationsButton>Associate animals.</PMAnimalAssociationsButton>
 	<PMAnimalAssociationsHeader>Associate animals.</PMAnimalAssociationsHeader>
 	<PMAnimalAssociationsText>Associate additional animals with morphs that will act as both additional outcomes, source of sequencing morph mutations and unlocking the injector.</PMAnimalAssociationsText>
+	<PMBlacklistFormerHumansButton>Former human animals</PMBlacklistFormerHumansButton>
+	<PMBlacklistFormerHumansHeader>Can be former humans</PMBlacklistFormerHumansHeader>
+	<PMBlacklistFormerHumansText>Enable or disable individual animals from being selectable by the game for completely transformation.\nOnly animals not associated with a morph type can be disabled.</PMBlacklistFormerHumansText>
 </LanguageData>

--- a/Source/Pawnmorphs/Esoteria/Pawnmorph.csproj
+++ b/Source/Pawnmorphs/Esoteria/Pawnmorph.csproj
@@ -895,6 +895,7 @@
     <Compile Include="UserInterface\Settings\Dialog_OptionalPatches.cs" />
     <Compile Include="UserInterface\Settings\Dialog_AnimalAssociations.cs" />
     <Compile Include="UserInterface\Settings\Dialog_RaceReplacements.cs" />
+    <Compile Include="UserInterface\Settings\Dialog_BlacklistAnimal.cs" />
     <Compile Include="UserInterface\Settings\Dialog_VisibleRaceSelection.cs" />
     <Compile Include="UserInterface\TableBox\ITableRow.cs" />
     <Compile Include="UserInterface\TableBox\Table.cs" />

--- a/Source/Pawnmorphs/Esoteria/PawnmorpherMod.cs
+++ b/Source/Pawnmorphs/Esoteria/PawnmorpherMod.cs
@@ -69,8 +69,10 @@ namespace Pawnmorph
             if (checkBoxSection.ButtonText("PMAnimalAssociationsButton".Translate()))
                 ShowAnimalAssociations();
 
+			if (checkBoxSection.ButtonText("PMBlacklistFormerHumansButton".Translate()))
+				ShowAnimalBlacklist();
 
-            listingStandard.EndSection(checkBoxSection);
+			listingStandard.EndSection(checkBoxSection);
 
 
             listingStandard.Label($"{"transformChanceSliderLabel".Translate()}: {settings.transformChance.ToString("F1")}%");
@@ -146,12 +148,22 @@ namespace Pawnmorph
             Find.WindowStack.Add(animalAssociations);
         }
 
-        /// <summary>
-        /// Override SettingsCategory to show up in the list of settings. <br />
-        /// Using .Translate() is optional, but does allow for localisation.
-        /// </summary>
-        /// <returns> The (translated) mod name. </returns>
-        public override string SettingsCategory()
+
+		private void ShowAnimalBlacklist()
+		{
+			if (settings.animalBlacklist == null)
+				settings.animalBlacklist = new List<string>();
+
+			UserInterface.Settings.Dialog_BlacklistAnimal animalAssociations = new UserInterface.Settings.Dialog_BlacklistAnimal(settings.animalBlacklist);
+			Find.WindowStack.Add(animalAssociations);
+		}
+
+		/// <summary>
+		/// Override SettingsCategory to show up in the list of settings. <br />
+		/// Using .Translate() is optional, but does allow for localisation.
+		/// </summary>
+		/// <returns> The (translated) mod name. </returns>
+		public override string SettingsCategory()
         {
             return "PawnmorpherModName".Translate();
         }

--- a/Source/Pawnmorphs/Esoteria/PawnmorpherModInit.cs
+++ b/Source/Pawnmorphs/Esoteria/PawnmorpherModInit.cs
@@ -6,6 +6,7 @@ using System.Text;
 using AlienRace;
 using JetBrains.Annotations;
 using Pawnmorph.DebugUtils;
+using Pawnmorph.DefExtensions;
 using Pawnmorph.GraphicSys;
 using Pawnmorph.Hediffs;
 using Pawnmorph.Hybrids;
@@ -44,6 +45,7 @@ namespace Pawnmorph
                 InjectGraphics(); 
                 NotifySettingsChanged();
                 GenerateImplicitRaces();
+                BanlistFormerHumanAnimals();
                 PatchExplicitRaces();
                 AddMutationsToWhitelistedRaces();
                 EnableDisableOptionalPatches();
@@ -85,6 +87,31 @@ namespace Pawnmorph
                 throw new ModInitializationException($"while initializing Pawnmorpher caught exception {e.GetType().Name}",e);
             }
         }
+
+        private static void BanlistFormerHumanAnimals()
+        {
+            if (PawnmorpherMod.Settings.animalBlacklist == null)
+                return;
+
+			foreach (string animalDef in PawnmorpherMod.Settings.animalBlacklist)
+			{
+                ThingDef animal = DefDatabase<ThingDef>.GetNamed(animalDef, false);
+                if (animal == null)
+                    continue;
+
+				FormerHumanSettings formerHumanConfig = animal.GetModExtension<FormerHumanSettings>();
+				if (formerHumanConfig == null)
+				{
+					formerHumanConfig = new FormerHumanSettings();
+					if (animal.modExtensions == null)
+						animal.modExtensions = new List<DefModExtension>();
+
+					animal.modExtensions.Add(formerHumanConfig);
+				}
+
+				formerHumanConfig.neverFormerHuman = true;
+			}
+		}
 
         private static void EnableDisableOptionalPatches()
         {

--- a/Source/Pawnmorphs/Esoteria/PawnmorpherSettings.cs
+++ b/Source/Pawnmorphs/Esoteria/PawnmorpherSettings.cs
@@ -87,10 +87,15 @@ namespace Pawnmorph
         /// </summary>
         public Dictionary<string, string> animalAssociations;
 
-        /// <summary>
-        /// Dictionary of optional patches explicitly enabled or disabled.
-        /// </summary>
-        public Dictionary<string, bool> optionalPatches;
+		/// <summary>
+		/// List of blacklisted animal types.
+		/// </summary>
+		public List<string> animalBlacklist;
+
+		/// <summary>
+		/// Dictionary of optional patches explicitly enabled or disabled.
+		/// </summary>
+		public Dictionary<string, bool> optionalPatches;
 
         /// <summary> The part that writes our settings to file. Note that saving is by ref. </summary>
         public override void ExposeData()
@@ -115,8 +120,9 @@ namespace Pawnmorph
             Scribe_Collections.Look(ref raceReplacements, nameof(raceReplacements));
             Scribe_Collections.Look(ref optionalPatches, nameof(optionalPatches));
             Scribe_Collections.Look(ref animalAssociations, nameof(animalAssociations));
+			Scribe_Collections.Look(ref animalBlacklist, nameof(animalBlacklist));
 
-            if (Scribe.mode == LoadSaveMode.PostLoadInit)
+			if (Scribe.mode == LoadSaveMode.PostLoadInit)
             {
                 if (formerChance > 1) formerChance /= 100f; 
             }

--- a/Source/Pawnmorphs/Esoteria/UserInterface/FilterListBox.cs
+++ b/Source/Pawnmorphs/Esoteria/UserInterface/FilterListBox.cs
@@ -42,9 +42,10 @@ namespace Pawnmorph.UserInterface
 
             Text.Font = GameFont.Tiny;
             Listing_Standard lineListing = new Listing_Standard();
-            float lineHeight = 30f + lineListing.verticalSpacing;
+            float lineHeight = Text.LineHeight + lineListing.verticalSpacing; // + 30f;
 
-            Rect listbox = new Rect(0, 0, inRect.width - 20, (_filteredList.Filtered.Count + 1) * lineHeight);
+
+			Rect listbox = new Rect(0, 0, inRect.width - 20, (_filteredList.Filtered.Count + 1) * lineHeight);
             Widgets.BeginScrollView(new Rect(x, curY, inRect.width, height), ref _scrollPosition, listbox);
 
 

--- a/Source/Pawnmorphs/Esoteria/UserInterface/Settings/Dialog_BlacklistAnimal.cs
+++ b/Source/Pawnmorphs/Esoteria/UserInterface/Settings/Dialog_BlacklistAnimal.cs
@@ -10,102 +10,102 @@ using Verse.Sound;
 
 namespace Pawnmorph.UserInterface.Settings
 {
-    internal class Dialog_BlacklistAnimal : Window
-    {
-        private static string HEADER_TEXT = "PMBlacklistFormerHumansHeader".Translate();
-        private static string DESCRIPTION_TEXT = "PMBlacklistFormerHumansText".Translate();
+	internal class Dialog_BlacklistAnimal : Window
+	{
+		private static string HEADER_TEXT = "PMBlacklistFormerHumansHeader".Translate();
+		private static string DESCRIPTION_TEXT = "PMBlacklistFormerHumansText".Translate();
 		private static string APPLY_BUTTON_TEXT = "ApplyButtonText".Translate();
-        private static string RESET_BUTTON_TEXT = "ResetButtonText".Translate();
-        private static string CANCEL_BUTTON_TEXT = "CancelButtonText".Translate();
-        private static string FAILED_PARSING_TEXT = "PMFailedToParse".Translate();
+		private static string RESET_BUTTON_TEXT = "ResetButtonText".Translate();
+		private static string CANCEL_BUTTON_TEXT = "CancelButtonText".Translate();
+		private static string FAILED_PARSING_TEXT = "PMFailedToParse".Translate();
 		private static Vector2 APPLY_BUTTON_SIZE = new Vector2(120f, 40f);
-        private static Vector2 RESET_BUTTON_SIZE = new Vector2(120f, 40f);
-        private static Vector2 CANCEL_BUTTON_SIZE = new Vector2(120f, 40f);
+		private static Vector2 RESET_BUTTON_SIZE = new Vector2(120f, 40f);
+		private static Vector2 CANCEL_BUTTON_SIZE = new Vector2(120f, 40f);
 		private static Vector2 RAW_BUTTON_SIZE = new Vector2(28, 28f);
 		private const float SPACER_SIZE = 17f;
 
-        private Dictionary<ThingDef, bool> _blacklistedAnimalDictonary;
-        List<string> _settingsReference;
-        FilterListBox<ThingDef> _animalListBox;
+		private Dictionary<ThingDef, bool> _blacklistedAnimalDictonary;
+		List<string> _settingsReference;
+		FilterListBox<ThingDef> _animalListBox;
 
-        public Dialog_BlacklistAnimal(List<string> settingsReference)
-        {
-            _settingsReference = settingsReference;
-            _blacklistedAnimalDictonary = new Dictionary<ThingDef, bool>();
-        }
+		public Dialog_BlacklistAnimal(List<string> settingsReference)
+		{
+			_settingsReference = settingsReference;
+			_blacklistedAnimalDictonary = new Dictionary<ThingDef, bool>();
+		}
 
-        public override void PostOpen()
-        {
-            base.PostOpen();
-            RefreshList();
-        }
+		public override void PostOpen()
+		{
+			base.PostOpen();
+			RefreshList();
+		}
 
-        private void RefreshList()
-        {
-            // Get all animal ThingDefs that are not dryads.
-            IEnumerable<ThingDef> animals = DefDatabase<ThingDef>.AllDefsListForReading.Where(x => x.race?.Animal == true && x.race?.Dryad != true);
-            animals = animals.Except(MorphDef.AllDefs.SelectMany(x => x.AllAssociatedAnimals));
+		private void RefreshList()
+		{
+			// Get all animal ThingDefs that are not dryads.
+			IEnumerable<ThingDef> animals = DefDatabase<ThingDef>.AllDefsListForReading.Where(x => x.race?.Animal == true && x.race?.Dryad != true);
+			animals = animals.Except(MorphDef.AllDefs.SelectMany(x => x.AllAssociatedAnimals));
 
-            _blacklistedAnimalDictonary = animals.ToDictionary(x => x, x => _settingsReference.Contains(x.defName) == false);
+			_blacklistedAnimalDictonary = animals.ToDictionary(x => x, x => _settingsReference.Contains(x.defName) == false);
 			
 
 			var filterList = new ListFilter<ThingDef>(animals, (animal, filterText) => animal.LabelCap.ToString().ToLower().Contains(filterText));
-            _animalListBox = new FilterListBox<ThingDef>(filterList);
-        }
+			_animalListBox = new FilterListBox<ThingDef>(filterList);
+		}
 
 
-        public override void DoWindowContents(Rect inRect)
-        {
-            float curY = 0;
-            Text.Font = GameFont.Medium;
-            Widgets.Label(new Rect(0, curY, inRect.width, Text.LineHeight), HEADER_TEXT);
+		public override void DoWindowContents(Rect inRect)
+		{
+			float curY = 0;
+			Text.Font = GameFont.Medium;
+			Widgets.Label(new Rect(0, curY, inRect.width, Text.LineHeight), HEADER_TEXT);
 
-            curY += Text.LineHeight;
+			curY += Text.LineHeight;
 
-            Text.Font = GameFont.Small;
-            Rect descriptionRect = new Rect(0, curY, inRect.width, 60);
-            Widgets.Label(descriptionRect, DESCRIPTION_TEXT);
+			Text.Font = GameFont.Small;
+			Rect descriptionRect = new Rect(0, curY, inRect.width, 60);
+			Widgets.Label(descriptionRect, DESCRIPTION_TEXT);
 
-            curY += descriptionRect.height;
+			curY += descriptionRect.height;
 			curY += 35;
 
 			float totalHeight = inRect.height - curY - Math.Max(APPLY_BUTTON_SIZE.y, Math.Max(RESET_BUTTON_SIZE.y, CANCEL_BUTTON_SIZE.y)) - SPACER_SIZE;
-            _animalListBox.Draw(inRect, 0, curY, totalHeight, (item, listing) =>
-            {
-                bool current = _blacklistedAnimalDictonary.TryGetValue(item, false);
-                listing.CheckboxLabeled(item.LabelCap, ref current, item.modContentPack.ModMetaData.Name);
-                _blacklistedAnimalDictonary[item] = current;
-            });
+			_animalListBox.Draw(inRect, 0, curY, totalHeight, (item, listing) =>
+			{
+				bool current = _blacklistedAnimalDictonary.TryGetValue(item, false);
+				listing.CheckboxLabeled(item.LabelCap, ref current, item.modContentPack.ModMetaData.Name);
+				_blacklistedAnimalDictonary[item] = current;
+			});
 
-            // Draw the apply, reset and cancel buttons.
+			// Draw the apply, reset and cancel buttons.
 			if (Widgets.ButtonImage(new Rect(5, inRect.height - 33, RAW_BUTTON_SIZE.x, RAW_BUTTON_SIZE.y), TexButton.Rename))
 			{
 				ShowRawInput();
 			}
 
-            float buttonVertPos = inRect.height - Math.Max(APPLY_BUTTON_SIZE.y, Math.Max(RESET_BUTTON_SIZE.y, CANCEL_BUTTON_SIZE.y));
-            float applyHorPos = inRect.width / 2 - APPLY_BUTTON_SIZE.x - RESET_BUTTON_SIZE.x / 2 - SPACER_SIZE;
-            float resetHorPos = inRect.width / 2 - RESET_BUTTON_SIZE.x / 2;
-            float cancelHorPos = inRect.width / 2 + RESET_BUTTON_SIZE.x / 2 + SPACER_SIZE;
+			float buttonVertPos = inRect.height - Math.Max(APPLY_BUTTON_SIZE.y, Math.Max(RESET_BUTTON_SIZE.y, CANCEL_BUTTON_SIZE.y));
+			float applyHorPos = inRect.width / 2 - APPLY_BUTTON_SIZE.x - RESET_BUTTON_SIZE.x / 2 - SPACER_SIZE;
+			float resetHorPos = inRect.width / 2 - RESET_BUTTON_SIZE.x / 2;
+			float cancelHorPos = inRect.width / 2 + RESET_BUTTON_SIZE.x / 2 + SPACER_SIZE;
 			if (Widgets.ButtonText(new Rect(applyHorPos, buttonVertPos, APPLY_BUTTON_SIZE.x, APPLY_BUTTON_SIZE.y), APPLY_BUTTON_TEXT))
-            {
-                OnAcceptKeyPressed();
-            }
-            if (Widgets.ButtonText(new Rect(resetHorPos, buttonVertPos, RESET_BUTTON_SIZE.x, RESET_BUTTON_SIZE.y), RESET_BUTTON_TEXT))
-            {
-                RimWorld.SoundDefOf.Checkbox_TurnedOff.PlayOneShotOnCamera(null);
-                RefreshList();
-            }
-            if (Widgets.ButtonText(new Rect(cancelHorPos, buttonVertPos, CANCEL_BUTTON_SIZE.x, CANCEL_BUTTON_SIZE.y), CANCEL_BUTTON_TEXT))
-            {
-                OnCancelKeyPressed();
-            }
-        }
+			{
+				OnAcceptKeyPressed();
+			}
+			if (Widgets.ButtonText(new Rect(resetHorPos, buttonVertPos, RESET_BUTTON_SIZE.x, RESET_BUTTON_SIZE.y), RESET_BUTTON_TEXT))
+			{
+				RimWorld.SoundDefOf.Checkbox_TurnedOff.PlayOneShotOnCamera(null);
+				RefreshList();
+			}
+			if (Widgets.ButtonText(new Rect(cancelHorPos, buttonVertPos, CANCEL_BUTTON_SIZE.x, CANCEL_BUTTON_SIZE.y), CANCEL_BUTTON_TEXT))
+			{
+				OnCancelKeyPressed();
+			}
+		}
 
 
 		private void ShowRawInput()
 		{
-            List<string> exportCollection = new List<string>();
+			List<string> exportCollection = new List<string>();
 			exportCollection.AddRange(_blacklistedAnimalDictonary.Where(x => x.Value == false).Select(x => x.Key.defName).ToList());
 			exportCollection = exportCollection.Distinct().ToList();
 
@@ -116,9 +116,9 @@ namespace Pawnmorph.UserInterface.Settings
 			{
 				try
 				{
-                    _settingsReference.Clear();
+					_settingsReference.Clear();
 					_settingsReference.AddRange(value.Split(',').Where(x => String.IsNullOrWhiteSpace(x) == false).Distinct());
-                    RefreshList();
+					RefreshList();
 				}
 				catch (Exception)
 				{
@@ -130,48 +130,48 @@ namespace Pawnmorph.UserInterface.Settings
 		}
 
 		private void ApplyChanges()
-        {
-            // We want to persist any definitions assigned for defnames that could not be loaded into the game at present time.
-            // Like animals from currently disabled mods.
-            // Take the old list, add all disabled animals (this will cause duplicates) and then apply distinct.
+		{
+			// We want to persist any definitions assigned for defnames that could not be loaded into the game at present time.
+			// Like animals from currently disabled mods.
+			// Take the old list, add all disabled animals (this will cause duplicates) and then apply distinct.
 			_settingsReference.AddRange(_blacklistedAnimalDictonary.Where(x => x.Value == false).Select(x => x.Key.defName).ToList());
-            _settingsReference = _settingsReference.Distinct().ToList();
+			_settingsReference = _settingsReference.Distinct().ToList();
 
-            foreach (var animal in _blacklistedAnimalDictonary)
-            {
-                FormerHumanSettings formerHumanConfig = animal.Key.GetModExtension<FormerHumanSettings>();
+			foreach (var animal in _blacklistedAnimalDictonary)
+			{
+				FormerHumanSettings formerHumanConfig = animal.Key.GetModExtension<FormerHumanSettings>();
 
-                if (animal.Value == false)
+				if (animal.Value == false)
 				{
 					if (formerHumanConfig == null)
 					{
 						formerHumanConfig = new FormerHumanSettings();
-                        if (animal.Key.modExtensions == null)
-                            animal.Key.modExtensions = new List<DefModExtension>();
+						if (animal.Key.modExtensions == null)
+							animal.Key.modExtensions = new List<DefModExtension>();
 
 						animal.Key.modExtensions.Add(formerHumanConfig);
 					}
 
 					formerHumanConfig.neverFormerHuman = true;
 				} 
-                else if (formerHumanConfig != null)
-                {
-                    // Enable animal as valid former human
-                    formerHumanConfig.neverFormerHuman = false;
-                }
+				else if (formerHumanConfig != null)
+				{
+					// Enable animal as valid former human
+					formerHumanConfig.neverFormerHuman = false;
+				}
 			}
 		}
 
-        public override void OnCancelKeyPressed()
-        {
-            base.OnCancelKeyPressed();
-        }
+		public override void OnCancelKeyPressed()
+		{
+			base.OnCancelKeyPressed();
+		}
 
-        public override void OnAcceptKeyPressed()
-        {
-            ApplyChanges();
+		public override void OnAcceptKeyPressed()
+		{
+			ApplyChanges();
 
-            base.OnAcceptKeyPressed();
-        }
-    }
+			base.OnAcceptKeyPressed();
+		}
+	}
 }

--- a/Source/Pawnmorphs/Esoteria/UserInterface/Settings/Dialog_BlacklistAnimal.cs
+++ b/Source/Pawnmorphs/Esoteria/UserInterface/Settings/Dialog_BlacklistAnimal.cs
@@ -1,0 +1,177 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Pawnmorph.Chambers;
+using Pawnmorph.DefExtensions;
+using Pawnmorph.Utilities.Collections;
+using UnityEngine;
+using Verse;
+using Verse.Sound;
+
+namespace Pawnmorph.UserInterface.Settings
+{
+    internal class Dialog_BlacklistAnimal : Window
+    {
+        private static string HEADER_TEXT = "PMBlacklistFormerHumansHeader".Translate();
+        private static string DESCRIPTION_TEXT = "PMBlacklistFormerHumansText".Translate();
+		private static string APPLY_BUTTON_TEXT = "ApplyButtonText".Translate();
+        private static string RESET_BUTTON_TEXT = "ResetButtonText".Translate();
+        private static string CANCEL_BUTTON_TEXT = "CancelButtonText".Translate();
+        private static string FAILED_PARSING_TEXT = "PMFailedToParse".Translate();
+		private static Vector2 APPLY_BUTTON_SIZE = new Vector2(120f, 40f);
+        private static Vector2 RESET_BUTTON_SIZE = new Vector2(120f, 40f);
+        private static Vector2 CANCEL_BUTTON_SIZE = new Vector2(120f, 40f);
+		private static Vector2 RAW_BUTTON_SIZE = new Vector2(28, 28f);
+		private const float SPACER_SIZE = 17f;
+
+        private Dictionary<ThingDef, bool> _blacklistedAnimalDictonary;
+        List<string> _settingsReference;
+        FilterListBox<ThingDef> _animalListBox;
+
+        public Dialog_BlacklistAnimal(List<string> settingsReference)
+        {
+            _settingsReference = settingsReference;
+            _blacklistedAnimalDictonary = new Dictionary<ThingDef, bool>();
+        }
+
+        public override void PostOpen()
+        {
+            base.PostOpen();
+            RefreshList();
+        }
+
+        private void RefreshList()
+        {
+            // Get all animal ThingDefs that are not dryads.
+            IEnumerable<ThingDef> animals = DefDatabase<ThingDef>.AllDefsListForReading.Where(x => x.race?.Animal == true && x.race?.Dryad != true);
+            animals = animals.Except(MorphDef.AllDefs.SelectMany(x => x.AllAssociatedAnimals));
+
+            _blacklistedAnimalDictonary = animals.ToDictionary(x => x, x => _settingsReference.Contains(x.defName) == false);
+			
+
+			var filterList = new ListFilter<ThingDef>(animals, (animal, filterText) => animal.LabelCap.ToString().ToLower().Contains(filterText));
+            _animalListBox = new FilterListBox<ThingDef>(filterList);
+        }
+
+
+        public override void DoWindowContents(Rect inRect)
+        {
+            float curY = 0;
+            Text.Font = GameFont.Medium;
+            Widgets.Label(new Rect(0, curY, inRect.width, Text.LineHeight), HEADER_TEXT);
+
+            curY += Text.LineHeight;
+
+            Text.Font = GameFont.Small;
+            Rect descriptionRect = new Rect(0, curY, inRect.width, 60);
+            Widgets.Label(descriptionRect, DESCRIPTION_TEXT);
+
+            curY += descriptionRect.height;
+			curY += 35;
+
+			float totalHeight = inRect.height - curY - Math.Max(APPLY_BUTTON_SIZE.y, Math.Max(RESET_BUTTON_SIZE.y, CANCEL_BUTTON_SIZE.y)) - SPACER_SIZE;
+            _animalListBox.Draw(inRect, 0, curY, totalHeight, (item, listing) =>
+            {
+                bool current = _blacklistedAnimalDictonary.TryGetValue(item, false);
+                listing.CheckboxLabeled(item.LabelCap, ref current, item.modContentPack.ModMetaData.Name);
+                _blacklistedAnimalDictonary[item] = current;
+            });
+
+            // Draw the apply, reset and cancel buttons.
+			if (Widgets.ButtonImage(new Rect(5, inRect.height - 33, RAW_BUTTON_SIZE.x, RAW_BUTTON_SIZE.y), TexButton.Rename))
+			{
+				ShowRawInput();
+			}
+
+            float buttonVertPos = inRect.height - Math.Max(APPLY_BUTTON_SIZE.y, Math.Max(RESET_BUTTON_SIZE.y, CANCEL_BUTTON_SIZE.y));
+            float applyHorPos = inRect.width / 2 - APPLY_BUTTON_SIZE.x - RESET_BUTTON_SIZE.x / 2 - SPACER_SIZE;
+            float resetHorPos = inRect.width / 2 - RESET_BUTTON_SIZE.x / 2;
+            float cancelHorPos = inRect.width / 2 + RESET_BUTTON_SIZE.x / 2 + SPACER_SIZE;
+			if (Widgets.ButtonText(new Rect(applyHorPos, buttonVertPos, APPLY_BUTTON_SIZE.x, APPLY_BUTTON_SIZE.y), APPLY_BUTTON_TEXT))
+            {
+                OnAcceptKeyPressed();
+            }
+            if (Widgets.ButtonText(new Rect(resetHorPos, buttonVertPos, RESET_BUTTON_SIZE.x, RESET_BUTTON_SIZE.y), RESET_BUTTON_TEXT))
+            {
+                RimWorld.SoundDefOf.Checkbox_TurnedOff.PlayOneShotOnCamera(null);
+                RefreshList();
+            }
+            if (Widgets.ButtonText(new Rect(cancelHorPos, buttonVertPos, CANCEL_BUTTON_SIZE.x, CANCEL_BUTTON_SIZE.y), CANCEL_BUTTON_TEXT))
+            {
+                OnCancelKeyPressed();
+            }
+        }
+
+
+		private void ShowRawInput()
+		{
+            List<string> exportCollection = new List<string>();
+			exportCollection.AddRange(_blacklistedAnimalDictonary.Where(x => x.Value == false).Select(x => x.Key.defName).ToList());
+			exportCollection = exportCollection.Distinct().ToList();
+
+			string stringValue = string.Join(",", exportCollection);
+			Dialog_Textbox textBox = new Dialog_Textbox(stringValue, true, new Vector2(300, 100));
+
+			textBox.ApplyAction = (value) =>
+			{
+				try
+				{
+                    _settingsReference.Clear();
+					_settingsReference.AddRange(value.Split(',').Where(x => String.IsNullOrWhiteSpace(x) == false).Distinct());
+                    RefreshList();
+				}
+				catch (Exception)
+				{
+					Find.WindowStack.Add(new Dialog_Popup(FAILED_PARSING_TEXT, new Vector2(300, 100)));
+				}
+			};
+
+			Find.WindowStack.Add(textBox);
+		}
+
+		private void ApplyChanges()
+        {
+            // We want to persist any definitions assigned for defnames that could not be loaded into the game at present time.
+            // Like animals from currently disabled mods.
+            // Take the old list, add all disabled animals (this will cause duplicates) and then apply distinct.
+			_settingsReference.AddRange(_blacklistedAnimalDictonary.Where(x => x.Value == false).Select(x => x.Key.defName).ToList());
+            _settingsReference = _settingsReference.Distinct().ToList();
+
+            foreach (var animal in _blacklistedAnimalDictonary)
+            {
+                FormerHumanSettings formerHumanConfig = animal.Key.GetModExtension<FormerHumanSettings>();
+
+                if (animal.Value == false)
+				{
+					if (formerHumanConfig == null)
+					{
+						formerHumanConfig = new FormerHumanSettings();
+                        if (animal.Key.modExtensions == null)
+                            animal.Key.modExtensions = new List<DefModExtension>();
+
+						animal.Key.modExtensions.Add(formerHumanConfig);
+					}
+
+					formerHumanConfig.neverFormerHuman = true;
+				} 
+                else if (formerHumanConfig != null)
+                {
+                    // Enable animal as valid former human
+                    formerHumanConfig.neverFormerHuman = false;
+                }
+			}
+		}
+
+        public override void OnCancelKeyPressed()
+        {
+            base.OnCancelKeyPressed();
+        }
+
+        public override void OnAcceptKeyPressed()
+        {
+            ApplyChanges();
+
+            base.OnAcceptKeyPressed();
+        }
+    }
+}


### PR DESCRIPTION
Added yet another options window to allow users to manually disable specific types of animals from being a potential result in a completely random transformation.
Does not require restart.