### PR TITLE
Former human update

### DIFF
--- a/Languages/English/Keyed/Settings.xml
+++ b/Languages/English/Keyed/Settings.xml
@@ -20,7 +20,7 @@
 	<maxMutationThoughtsSliderLabel>How many mutation related thoughts will show up at once</maxMutationThoughtsSliderLabel>
 	<friendlyManhunterTfChance>Chance for friendly pawns to go manhunter when transformed</friendlyManhunterTfChance>
 	<manhunterTfChance>Chance for pawns to go manhunter when transformed</manhunterTfChance>
-	<hostileKeepFactionTfChance>Chance for hostile pawns to keept their faction when transformed</hostileKeepFactionTfChance>
+	<hostileKeepFactionTfChance>Chance for pawns of other factions to keept their faction when transformed</hostileKeepFactionTfChance>
 	<PMInjectorsRequireTagging>Injectors Require Tagging</PMInjectorsRequireTagging>
 	<PMInjectorsRequireTaggingTooltip>If true, tagging animals is required to make injectors.</PMInjectorsRequireTaggingTooltip>
 	<PMEnableMutationVisualsButton>Show mutations on races.</PMEnableMutationVisualsButton>

--- a/Languages/English/Keyed/Settings.xml
+++ b/Languages/English/Keyed/Settings.xml
@@ -40,4 +40,10 @@
 	<PMBlacklistFormerHumansButton>Former human animals</PMBlacklistFormerHumansButton>
 	<PMBlacklistFormerHumansHeader>Can be former humans</PMBlacklistFormerHumansHeader>
 	<PMBlacklistFormerHumansText>Enable or disable individual animals from being selectable by the game for completely transformation.\nOnly animals not associated with a morph type can be disabled.</PMBlacklistFormerHumansText>
+	<PMBlacklistFormerHumansEnabled>Enabled</PMBlacklistFormerHumansEnabled>
+	<PMBlacklistFormerHumansRestricted>Restricted</PMBlacklistFormerHumansRestricted>
+	<PMBlacklistFormerHumansDisabled>Disabled</PMBlacklistFormerHumansDisabled>
+	<PMBlacklistFormerHumansEnabledDescription></PMBlacklistFormerHumansEnabledDescription>
+	<PMBlacklistFormerHumansRestrictedDescription></PMBlacklistFormerHumansRestrictedDescription>
+	<PMBlacklistFormerHumansDisabledDescription></PMBlacklistFormerHumansDisabledDescription>
 </LanguageData>

--- a/Languages/English/Keyed/Settings.xml
+++ b/Languages/English/Keyed/Settings.xml
@@ -45,6 +45,7 @@
 	<PMBlacklistFormerHumansRestricted>Restricted</PMBlacklistFormerHumansRestricted>
 	<PMBlacklistFormerHumansDisabled>Disabled</PMBlacklistFormerHumansDisabled>
 	<PMBlacklistFormerHumansEnabledDescription>Can freely appear as former human in game.</PMBlacklistFormerHumansEnabledDescription>
-	<PMBlacklistFormerHumansRestrictedDescription>Can only appear as former human at random in game.</PMBlacklistFormerHumansRestrictedDescription>
-	<PMBlacklistFormerHumansDisabledDescription>Cannot appear as former human in game at all.</PMBlacklistFormerHumansDisabledDescription>
+	<PMBlacklistFormerHumansRestrictedDescription>Can exist as former human but not spawn at random.</PMBlacklistFormerHumansRestrictedDescription>
+	<PMBlacklistFormerHumansDisabledDescription>Cannot exist as former human at all.</PMBlacklistFormerHumansDisabledDescription>
+	<PMBlacklistFormerHumansAddedBy>Added by {0}</PMBlacklistFormerHumansAddedBy>
 </LanguageData>

--- a/Languages/English/Keyed/Settings.xml
+++ b/Languages/English/Keyed/Settings.xml
@@ -20,6 +20,7 @@
 	<maxMutationThoughtsSliderLabel>How many mutation related thoughts will show up at once</maxMutationThoughtsSliderLabel>
 	<friendlyManhunterTfChance>Chance for friendly pawns to go manhunter when transformed</friendlyManhunterTfChance>
 	<manhunterTfChance>Chance for pawns to go manhunter when transformed</manhunterTfChance>
+	<hostileKeepFactionTfChance>Chance for hostile pawns to keept their faction when transformed</hostileKeepFactionTfChance>
 	<PMInjectorsRequireTagging>Injectors Require Tagging</PMInjectorsRequireTagging>
 	<PMInjectorsRequireTaggingTooltip>If true, tagging animals is required to make injectors.</PMInjectorsRequireTaggingTooltip>
 	<PMEnableMutationVisualsButton>Show mutations on races.</PMEnableMutationVisualsButton>

--- a/Languages/English/Keyed/Settings.xml
+++ b/Languages/English/Keyed/Settings.xml
@@ -40,11 +40,11 @@
 	<PMAnimalAssociationsText>Associate additional animals with morphs that will act as both additional outcomes, source of sequencing morph mutations and unlocking the injector.</PMAnimalAssociationsText>
 	<PMBlacklistFormerHumansButton>Former human animals</PMBlacklistFormerHumansButton>
 	<PMBlacklistFormerHumansHeader>Can be former humans</PMBlacklistFormerHumansHeader>
-	<PMBlacklistFormerHumansText>Enable or disable individual animals from being selectable by the game for completely transformation.\nOnly animals not associated with a morph type can be disabled.</PMBlacklistFormerHumansText>
+	<PMBlacklistFormerHumansText>Enable, restrict or disable animals from randomly appearing as former humans in game.\nAnimals associated with morphs can only be restricted.</PMBlacklistFormerHumansText>
 	<PMBlacklistFormerHumansEnabled>Enabled</PMBlacklistFormerHumansEnabled>
 	<PMBlacklistFormerHumansRestricted>Restricted</PMBlacklistFormerHumansRestricted>
 	<PMBlacklistFormerHumansDisabled>Disabled</PMBlacklistFormerHumansDisabled>
-	<PMBlacklistFormerHumansEnabledDescription></PMBlacklistFormerHumansEnabledDescription>
-	<PMBlacklistFormerHumansRestrictedDescription></PMBlacklistFormerHumansRestrictedDescription>
-	<PMBlacklistFormerHumansDisabledDescription></PMBlacklistFormerHumansDisabledDescription>
+	<PMBlacklistFormerHumansEnabledDescription>Can freely appear as former human in game.</PMBlacklistFormerHumansEnabledDescription>
+	<PMBlacklistFormerHumansRestrictedDescription>Can only appear as former human at random in game.</PMBlacklistFormerHumansRestrictedDescription>
+	<PMBlacklistFormerHumansDisabledDescription>Cannot appear as former human in game at all.</PMBlacklistFormerHumansDisabledDescription>
 </LanguageData>

--- a/Source/Pawnmorphs/Esoteria/FormerHumanUtilities.cs
+++ b/Source/Pawnmorphs/Esoteria/FormerHumanUtilities.cs
@@ -154,7 +154,7 @@ namespace Pawnmorph
                 return false;
 
             // XML Patched as not valid former human.
-            if (pawnKind.GetModExtension<FormerHumanSettings>()?.neverFormerHuman == false)
+            if (pawnKind.GetModExtension<FormerHumanSettings>()?.neverFormerHuman == true)
                 return false;
 
             // If restricted is not allowed, then filter away special chaomorphs.

--- a/Source/Pawnmorphs/Esoteria/FormerHumanUtilities.cs
+++ b/Source/Pawnmorphs/Esoteria/FormerHumanUtilities.cs
@@ -9,6 +9,7 @@ using JetBrains.Annotations;
 using Pawnmorph.DefExtensions;
 using Pawnmorph.FormerHumans;
 using Pawnmorph.Hediffs;
+using Pawnmorph.Hybrids;
 using Pawnmorph.TfSys;
 using Pawnmorph.ThingComps;
 using Pawnmorph.Utilities;
@@ -176,8 +177,17 @@ namespace Pawnmorph
                 if (allowRestricted == false && restriction == FormerHumanRestrictions.Restricted)
                     return false;
 
-				if (allowDisabled == false && restriction == FormerHumanRestrictions.Disabled)
-					return false;
+
+                if (restriction == FormerHumanRestrictions.Disabled)
+                {
+                    // If animal is disabled but has a related morph, then count as restricted.
+                    // They could have disabled the animal and then added a sub-mod which needs it for a morph.
+                    if (allowRestricted && pawnKind.GetMorphOfRace() != null)
+                        return true;
+
+                    if (allowDisabled == false)
+                        return false;
+                }
 			}
 
             return true;

--- a/Source/Pawnmorphs/Esoteria/FormerHumanUtilities.cs
+++ b/Source/Pawnmorphs/Esoteria/FormerHumanUtilities.cs
@@ -1564,7 +1564,11 @@ namespace Pawnmorph
 
 			var defaultConfig = new Dictionary<string, FormerHumanRestrictions>()
             {
+                // Genetic Rim
+                ["GR_ArchotechCentipede"] = FormerHumanRestrictions.Disabled,
 
+                // Alpha Animals
+                ["AA_Gallatross"] = FormerHumanRestrictions.Restricted,
             };
 
             foreach (var animal in AnimalClassDefOf.Powerful.GetAssociatedAnimals())

--- a/Source/Pawnmorphs/Esoteria/FormerHumans/FormerHumanRestrictions.cs
+++ b/Source/Pawnmorphs/Esoteria/FormerHumans/FormerHumanRestrictions.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Pawnmorph.FormerHumans
+{
+	public enum FormerHumanRestrictions : byte
+	{
+		/// <summary>
+		/// This animal type is a valid former human and can be spawned randomly without restrictions.
+		/// </summary>
+		Enabled = 0,
+
+		/// <summary>
+		/// This animal type is a valid former human but cannot be spawned randomly.
+		/// </summary>
+		Restricted = 1,
+
+		/// <summary>
+		/// This animal type is not a valid former human.
+		/// </summary>
+		Disabled = 2,
+	}
+}

--- a/Source/Pawnmorphs/Esoteria/FormerHumans/FormerHumanRestrictions.cs
+++ b/Source/Pawnmorphs/Esoteria/FormerHumans/FormerHumanRestrictions.cs
@@ -6,6 +6,9 @@ using System.Threading.Tasks;
 
 namespace Pawnmorph.FormerHumans
 {
+	/// <summary>
+	/// Used to describe if an animal can be appear as a former human.
+	/// </summary>
 	public enum FormerHumanRestrictions : byte
 	{
 		/// <summary>

--- a/Source/Pawnmorphs/Esoteria/Genebank/DatabaseUtilities.cs
+++ b/Source/Pawnmorphs/Esoteria/Genebank/DatabaseUtilities.cs
@@ -268,11 +268,8 @@ namespace Pawnmorph.Chambers
         public static bool IsValidAnimal([NotNull] this ThingDef inst)
         {
             if (inst == null) throw new ArgumentNullException(nameof(inst));
-            if (inst.race?.Animal != true) return false; //use != because inst.race?.Animal can be true,false or null
-            if (inst.race?.Dryad == true) return false; //Dryads seem to be animals, but we do not allow them (yet?).
-
-            var ext = inst.GetModExtension<FormerHumanSettings>();
-            if (ext?.neverFormerHuman == true) return false;
+            if (inst.IsValidFormerHuman() == false)
+                return false;
 
             var chaoExt = inst.GetModExtension<ChaomorphExtension>();
 

--- a/Source/Pawnmorphs/Esoteria/Need_Control.cs
+++ b/Source/Pawnmorphs/Esoteria/Need_Control.cs
@@ -139,25 +139,23 @@ namespace Pawnmorph
             get
             {
                 if (_enabledRaces == null)
-                {
-                    _enabledRaces = new HashSet<ThingDef>();
-                    foreach (ThingDef race in DefDatabase<ThingDef>.AllDefs.Where(t => t.race?.Humanlike == true))
-                    {
-                        if (!DefDatabase<MutagenDef>.AllDefs.Any(m => m.CanTransform(race))) continue;
-                        _enabledRaces.Add(race);
-                    }
-
-                    foreach (ThingDef thingDef in DefDatabase<ThingDef>.AllDefs.Where(t => t.race?.Animal == true))
-                    {
-                        var fhSettings = thingDef.GetModExtension<FormerHumanSettings>(); 
-                        if(fhSettings?.neverFormerHuman == true) continue;
-                        _enabledRaces.Add(thingDef); 
-                    }
-                }
+					InvalidateRaceCache();
 
                 return _enabledRaces;
             }
         }
+
+        public static void InvalidateRaceCache()
+		{
+			_enabledRaces = new HashSet<ThingDef>();
+			foreach (ThingDef race in DefDatabase<ThingDef>.AllDefs.Where(t => t.race?.Humanlike == true))
+			{
+				if (!DefDatabase<MutagenDef>.AllDefs.Any(m => m.CanTransform(race))) continue;
+				_enabledRaces.Add(race);
+			}
+
+			_enabledRaces.AddRange(DefDatabase<ThingDef>.AllDefs.Where(x => x.IsValidFormerHuman()));
+		}
 
         /// <summary>
         ///     Adds the instinct change to this need

--- a/Source/Pawnmorphs/Esoteria/Pawnmorph.csproj
+++ b/Source/Pawnmorphs/Esoteria/Pawnmorph.csproj
@@ -318,6 +318,7 @@
     <Compile Include="Abilities\MutationAbilityState.cs" />
     <Compile Include="Abilities\MutationAbilityType.cs" />
     <Compile Include="Abilities\TerrifyingRoar.cs" />
+    <Compile Include="FormerHumans\FormerHumanRestrictions.cs" />
     <Compile Include="Genebank\Model\AnimalGenebankEntry.cs" />
     <Compile Include="Genebank\GenebankEntry.cs" />
     <Compile Include="Genebank\IGenebankEntry.cs" />

--- a/Source/Pawnmorphs/Esoteria/PawnmorpherMod.cs
+++ b/Source/Pawnmorphs/Esoteria/PawnmorpherMod.cs
@@ -151,9 +151,6 @@ namespace Pawnmorph
 
 		private void ShowAnimalBlacklist()
 		{
-			if (settings.animalBlacklist == null)
-				settings.animalBlacklist = new List<string>();
-
 			UserInterface.Settings.Dialog_BlacklistAnimal animalAssociations = new UserInterface.Settings.Dialog_BlacklistAnimal(settings.animalBlacklist);
 			Find.WindowStack.Add(animalAssociations);
 		}

--- a/Source/Pawnmorphs/Esoteria/PawnmorpherMod.cs
+++ b/Source/Pawnmorphs/Esoteria/PawnmorpherMod.cs
@@ -96,8 +96,11 @@ namespace Pawnmorph
 
             }
 
+			listingStandard
+			   .Label($"{nameof(PawnmorpherSettings.hostileKeepFactionTfChance).Translate()}: {settings.hostileKeepFactionTfChance.ToStringByStyle(ToStringStyle.PercentOne)}");
+			settings.hostileKeepFactionTfChance = listingStandard.Slider(settings.hostileKeepFactionTfChance, 0, 1f);
 
-            if (Prefs.DevMode)
+			if (Prefs.DevMode)
             {
                 listingStandard.Label($"logging level:{settings.logLevel}");
                 float f = (float) ((int) settings.logLevel);

--- a/Source/Pawnmorphs/Esoteria/PawnmorpherModInit.cs
+++ b/Source/Pawnmorphs/Esoteria/PawnmorpherModInit.cs
@@ -45,12 +45,12 @@ namespace Pawnmorph
                 InjectGraphics(); 
                 NotifySettingsChanged();
                 GenerateImplicitRaces();
-                BanlistFormerHumanAnimals();
                 PatchExplicitRaces();
                 AddMutationsToWhitelistedRaces();
                 EnableDisableOptionalPatches();
                 CheckForObsoletedComponents();
-                try
+
+				try
                 {
 
 
@@ -87,31 +87,6 @@ namespace Pawnmorph
                 throw new ModInitializationException($"while initializing Pawnmorpher caught exception {e.GetType().Name}",e);
             }
         }
-
-        private static void BanlistFormerHumanAnimals()
-        {
-            if (PawnmorpherMod.Settings.animalBlacklist == null)
-                return;
-
-			foreach (string animalDef in PawnmorpherMod.Settings.animalBlacklist)
-			{
-                ThingDef animal = DefDatabase<ThingDef>.GetNamed(animalDef, false);
-                if (animal == null)
-                    continue;
-
-				FormerHumanSettings formerHumanConfig = animal.GetModExtension<FormerHumanSettings>();
-				if (formerHumanConfig == null)
-				{
-					formerHumanConfig = new FormerHumanSettings();
-					if (animal.modExtensions == null)
-						animal.modExtensions = new List<DefModExtension>();
-
-					animal.modExtensions.Add(formerHumanConfig);
-				}
-
-				formerHumanConfig.neverFormerHuman = true;
-			}
-		}
 
         private static void EnableDisableOptionalPatches()
         {

--- a/Source/Pawnmorphs/Esoteria/PawnmorpherSettings.cs
+++ b/Source/Pawnmorphs/Esoteria/PawnmorpherSettings.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Pawnmorph.DebugUtils;
+using Pawnmorph.FormerHumans;
 using UnityEngine;
 using Verse;
 
@@ -91,7 +92,7 @@ namespace Pawnmorph
 		/// <summary>
 		/// List of blacklisted animal types.
 		/// </summary>
-		public List<string> animalBlacklist;
+		public Dictionary<string, FormerHumanRestrictions> animalBlacklist;
 
 		/// <summary>
 		/// Dictionary of optional patches explicitly enabled or disabled.
@@ -148,7 +149,9 @@ namespace Pawnmorph
 
 			if (Scribe.mode == LoadSaveMode.PostLoadInit)
             {
-                if (formerChance > 1) formerChance /= 100f; 
+                animalBlacklist = null;
+
+				if (formerChance > 1) formerChance /= 100f; 
             }
 
             base.ExposeData();

--- a/Source/Pawnmorphs/Esoteria/PawnmorpherSettings.cs
+++ b/Source/Pawnmorphs/Esoteria/PawnmorpherSettings.cs
@@ -149,8 +149,6 @@ namespace Pawnmorph
 
 			if (Scribe.mode == LoadSaveMode.PostLoadInit)
             {
-                animalBlacklist = null;
-
 				if (formerChance > 1) formerChance /= 100f; 
             }
 

--- a/Source/Pawnmorphs/Esoteria/PawnmorpherSettings.cs
+++ b/Source/Pawnmorphs/Esoteria/PawnmorpherSettings.cs
@@ -64,15 +64,21 @@ namespace Pawnmorph
         /// the chance an tf'd enemy or neutral pawn will go manhunter 
         /// </summary>
         public float manhunterTfChance = 0;
+
         /// <summary>
         /// The chance a friendly pawn will go manhunter when tf'd 
         /// </summary>
-        public float friendlyManhunterTfChance = 0; 
+        public float friendlyManhunterTfChance = 0;
 
         /// <summary>
-        /// The current log level
+        /// The chance a hostile will keep their faction when tf'd
         /// </summary>
-        public LogLevel logLevel = LogLevel.Warnings;
+		public float hostileKeepFactionTfChance = 0f;
+
+		/// <summary>
+		/// The current log level
+		/// </summary>
+		public LogLevel logLevel = LogLevel.Warnings;
 
         /// <summary>
         /// List of races whitelisted to have visible mutations.
@@ -135,6 +141,8 @@ namespace Pawnmorph
             Scribe_Values.Look(ref friendlyManhunterTfChance, nameof(friendlyManhunterTfChance));
             Scribe_Values.Look(ref chamberDatabaseIgnoreStorageLimit, nameof(chamberDatabaseIgnoreStorageLimit));
             Scribe_Values.Look(ref hazardousChaobulbs, nameof(hazardousChaobulbs), true);
+			Scribe_Values.Look(ref hostileKeepFactionTfChance, nameof(hostileKeepFactionTfChance));
+
 
 
 			Scribe_Values.Look(ref GenebankWindowSize, nameof(GenebankWindowSize));

--- a/Source/Pawnmorphs/Esoteria/TfSys/SimpleMechaniteMutagen.cs
+++ b/Source/Pawnmorphs/Esoteria/TfSys/SimpleMechaniteMutagen.cs
@@ -246,6 +246,8 @@ namespace Pawnmorph.TfSys
                 faction = request.forcedFaction;
             else if (original.IsColonist)
                 faction = original.Faction;
+            else if (Rand.Chance(PawnmorpherMod.Settings.hostileKeepFactionTfChance))
+                faction = original.Faction;
             else
                 faction = null;
             return faction;

--- a/Source/Pawnmorphs/Esoteria/ThingComps/Comp_CanBeFormerHuman.cs
+++ b/Source/Pawnmorphs/Esoteria/ThingComps/Comp_CanBeFormerHuman.cs
@@ -1,5 +1,4 @@
-﻿using Pawnmorph.DefExtensions;
-using Pawnmorph.FormerHumans;
+﻿using Pawnmorph.FormerHumans;
 using RimWorld;
 using Verse;
 using Verse.AI;
@@ -68,7 +67,7 @@ namespace Pawnmorph.ThingComps
             if (!PawnmorpherMod.Settings.enableWildFormers)
                 return false;
 
-            if (parent.def.GetModExtension<FormerHumanSettings>()?.neverFormerHuman == true)
+            if (parent.def.IsValidFormerHuman() == false)
                 return false;
 
             // Don't make animals belonging to any faction former humans

--- a/Source/Pawnmorphs/Esoteria/ThingComps/Comp_CanBeFormerHuman.cs
+++ b/Source/Pawnmorphs/Esoteria/ThingComps/Comp_CanBeFormerHuman.cs
@@ -1,5 +1,7 @@
 ﻿using Pawnmorph.FormerHumans;
+using Pawnmorph.Utilities;
 using RimWorld;
+using UnityEngine;
 using Verse;
 using Verse.AI;
 
@@ -46,8 +48,8 @@ namespace Pawnmorph.ThingComps
                     bool isManhunter = Pawn.MentalStateDef == MentalStateDefOf.Manhunter
                                     || Pawn.MentalStateDef == MentalStateDefOf.ManhunterPermanent;
 
-                    float sapience = Rand.Value;
-                    FormerHumanUtilities.MakeAnimalSapient(Pawn, sapience, !isManhunter);
+                    float sapience = RandUtilities.generateBetaRandom(1.5f, 4.5f);
+					FormerHumanUtilities.MakeAnimalSapient(Pawn, sapience, !isManhunter);
                     if (isManhunter)
                         // TODO this will only ever fire once, even if the pawn shows up again later
                         RelatedFormerHumanUtilities.WildNotifyIfRelated(Pawn);

--- a/Source/Pawnmorphs/Esoteria/ThingComps/Comp_CanBeFormerHuman.cs
+++ b/Source/Pawnmorphs/Esoteria/ThingComps/Comp_CanBeFormerHuman.cs
@@ -48,6 +48,9 @@ namespace Pawnmorph.ThingComps
                     bool isManhunter = Pawn.MentalStateDef == MentalStateDefOf.Manhunter
                                     || Pawn.MentalStateDef == MentalStateDefOf.ManhunterPermanent;
 
+                    // Strong bias towards feral sapience for former humans spawned "in the wild".
+                    // Reasoning: They have spent so much time wandering and living in the wild
+                    // before they encounter your colony that their grip on sapience is much more likely than not slipping.
                     float sapience = RandUtilities.generateBetaRandom(1.5f, 4.5f);
 					FormerHumanUtilities.MakeAnimalSapient(Pawn, sapience, !isManhunter);
                     if (isManhunter)

--- a/Source/Pawnmorphs/Esoteria/UserInterface/Settings/Dialog_BlacklistAnimal.cs
+++ b/Source/Pawnmorphs/Esoteria/UserInterface/Settings/Dialog_BlacklistAnimal.cs
@@ -66,7 +66,9 @@ namespace Pawnmorph.UserInterface.Settings
 
 			_morphAnimals = MorphDef.AllDefs.SelectMany(x => x.AllAssociatedAnimals).ToHashSet();
 
-			var filterList = new ListFilter<ThingDef>(animals, (animal, filterText) => animal.LabelCap.ToString().ToLower().Contains(filterText));
+			var filterList = new ListFilter<ThingDef>(animals, 
+				(animal, filterText) => animal.LabelCap.ToString().ToLower().Contains(filterText) ||
+				OPTIONS[_canBeFormerHumanDictonary[animal]].ToLower().Contains(filterText));
 			_animalListBox = new FilterListBox<ThingDef>(filterList);
 		}
 

--- a/Source/Pawnmorphs/Esoteria/UserInterface/Settings/Dialog_BlacklistAnimal.cs
+++ b/Source/Pawnmorphs/Esoteria/UserInterface/Settings/Dialog_BlacklistAnimal.cs
@@ -49,6 +49,10 @@ namespace Pawnmorph.UserInterface.Settings
 		{
 			_settingsReference = settingsReference;
 			_canBeFormerHumanDictonary = new Dictionary<ThingDef, FormerHumanRestrictions>();
+
+
+			this.resizeable = true;
+			this.draggable = true;
 		}
 
 		public override void PostOpen()
@@ -92,7 +96,7 @@ namespace Pawnmorph.UserInterface.Settings
 				string source = item.modContentPack?.ModMetaData?.Name;
 				if (String.IsNullOrWhiteSpace(source) == false)
 				{
-					tooltip += "Added by " + source;
+					tooltip += "PMBlacklistFormerHumansAddedBy".Translate(source);
 					tooltip += Environment.NewLine;
 					tooltip += Environment.NewLine;
 				}

--- a/Source/Pawnmorphs/Esoteria/UserInterface/Settings/Dialog_BlacklistAnimal.cs
+++ b/Source/Pawnmorphs/Esoteria/UserInterface/Settings/Dialog_BlacklistAnimal.cs
@@ -21,7 +21,7 @@ namespace Pawnmorph.UserInterface.Settings
 		private static readonly Vector2 RESET_BUTTON_SIZE = new Vector2(120f, 40f);
 		private static readonly Vector2 CANCEL_BUTTON_SIZE = new Vector2(120f, 40f);
 		private static readonly Vector2 RAW_BUTTON_SIZE = new Vector2(28, 28f);
-		private const float SPACER_SIZE = 17f;
+		private const float SPACER_SIZE = 8f;
 
 		private static readonly Dictionary<FormerHumanRestrictions, string> OPTIONS = new Dictionary<FormerHumanRestrictions, string>()
 		{
@@ -77,16 +77,11 @@ namespace Pawnmorph.UserInterface.Settings
 		{
 			float curY = 0;
 			Text.Font = GameFont.Medium;
-			Widgets.Label(new Rect(0, curY, inRect.width, Text.LineHeight), HEADER_TEXT);
-
-			curY += Text.LineHeight;
+			Widgets.Label(0, ref curY, inRect.width, HEADER_TEXT);
 
 			Text.Font = GameFont.Small;
-			Rect descriptionRect = new Rect(0, curY, inRect.width, 60);
-			Widgets.Label(descriptionRect, DESCRIPTION_TEXT);
-
-			curY += descriptionRect.height;
-			curY += 35;
+			Widgets.Label(0, ref curY, inRect.width, DESCRIPTION_TEXT);
+			curY += SPACER_SIZE;
 
 			float totalHeight = inRect.height - curY - Math.Max(APPLY_BUTTON_SIZE.y, Math.Max(RESET_BUTTON_SIZE.y, CANCEL_BUTTON_SIZE.y)) - SPACER_SIZE;
 			_animalListBox.Draw(inRect, 0, curY, totalHeight, (item, listing) =>

--- a/Source/Pawnmorphs/Esoteria/UserInterface/Settings/Dialog_BlacklistAnimal.cs
+++ b/Source/Pawnmorphs/Esoteria/UserInterface/Settings/Dialog_BlacklistAnimal.cs
@@ -25,10 +25,18 @@ namespace Pawnmorph.UserInterface.Settings
 
 		private static readonly Dictionary<FormerHumanRestrictions, string> OPTIONS = new Dictionary<FormerHumanRestrictions, string>()
 		{
-			{ FormerHumanRestrictions.Enabled, "PMBlacklistFormerHumansEnabled".Translate() },
-			{ FormerHumanRestrictions.Restricted, "PMBlacklistFormerHumansRestricted".Translate() },
-			{ FormerHumanRestrictions.Disabled, "PMBlacklistFormerHumansDisabled".Translate() },
+			[FormerHumanRestrictions.Enabled] = "PMBlacklistFormerHumansEnabled".Translate(),
+			[FormerHumanRestrictions.Restricted] = "PMBlacklistFormerHumansRestricted".Translate(),
+			[FormerHumanRestrictions.Disabled] = "PMBlacklistFormerHumansDisabled".Translate(),
 		};
+
+		private static readonly Dictionary<FormerHumanRestrictions, string> OPTIONS_DESCRIPTIONS = new Dictionary<FormerHumanRestrictions, string>()
+		{
+			[FormerHumanRestrictions.Enabled] = "PMBlacklistFormerHumansEnabledDescription".Translate(),
+			[FormerHumanRestrictions.Restricted] = "PMBlacklistFormerHumansRestrictedDescription".Translate(),
+			[FormerHumanRestrictions.Disabled] = "PMBlacklistFormerHumansDisabledDescription".Translate(),
+		};
+
 
 		private Dictionary<ThingDef, FormerHumanRestrictions> _canBeFormerHumanDictonary;
 		Dictionary<string, FormerHumanRestrictions> _settingsReference;
@@ -58,8 +66,6 @@ namespace Pawnmorph.UserInterface.Settings
 
 			_morphAnimals = MorphDef.AllDefs.SelectMany(x => x.AllAssociatedAnimals).ToHashSet();
 
-			Log.Warning(String.Join(Environment.NewLine, animals.Select(x => x.LabelCap)));
-
 			var filterList = new ListFilter<ThingDef>(animals, (animal, filterText) => animal.LabelCap.ToString().ToLower().Contains(filterText));
 			_animalListBox = new FilterListBox<ThingDef>(filterList);
 		}
@@ -84,7 +90,18 @@ namespace Pawnmorph.UserInterface.Settings
 			_animalListBox.Draw(inRect, 0, curY, totalHeight, (item, listing) =>
 			{
 				FormerHumanRestrictions current = _canBeFormerHumanDictonary[item];
-				if (listing.ButtonTextLabeled(item.LabelCap, OPTIONS[current], tooltip: item.modContentPack.ModMetaData.Name))
+				
+				string tooltip = "";
+				string source = item.modContentPack?.ModMetaData?.Name;
+				if (String.IsNullOrWhiteSpace(source) == false)
+				{
+					tooltip += "Added by " + source;
+					tooltip += Environment.NewLine;
+					tooltip += Environment.NewLine;
+				}
+				tooltip += OPTIONS_DESCRIPTIONS[current];
+
+				if (listing.ButtonTextLabeled(item.LabelCap, OPTIONS[current], tooltip: tooltip))
 				{
 					List<FloatMenuOption> options = new List<FloatMenuOption>();
 

--- a/Source/Pawnmorphs/Esoteria/UserInterface/Settings/Dialog_RaceReplacements.cs
+++ b/Source/Pawnmorphs/Esoteria/UserInterface/Settings/Dialog_RaceReplacements.cs
@@ -155,7 +155,9 @@ namespace Pawnmorph.UserInterface.Settings
                 try
                 {
                     string[] items = value.Split(new[] { '[', ']' }, StringSplitOptions.RemoveEmptyEntries);
-                    _settingsReference = items.Select(x => x.Split(',')).Where(x => x[1].Length > 0).ToDictionary(y => y[0], y => y[1]);
+                    Dictionary<string, string> buffer = items.Select(x => x.Split(',')).Where(x => x[1].Length > 0).ToDictionary(y => y[0], y => y[1]);
+                    _settingsReference.Clear();
+                    _settingsReference.AddRange(buffer);
                     RefreshAliens();
                 }
                 catch (Exception)

--- a/Source/Pawnmorphs/Esoteria/Utilities/RandUtilities.cs
+++ b/Source/Pawnmorphs/Esoteria/Utilities/RandUtilities.cs
@@ -102,5 +102,61 @@ namespace Pawnmorph.Utilities
 
             return baseVal;
         }
-    }
+
+		private static float Marsaglia(float d, float c)
+		{
+			while (true)
+			{
+				float x, v;
+
+				do
+				{
+					x = generateNormalRandom();
+					v = Mathf.Pow(1.0f + c * x, 3);
+				}
+				while (v <= 0);
+
+				float u = Rand.Range(0.0f, 1.0f);
+
+				//Shortcut to make the procedure faster according to the paper.
+				if (u < 1 - 0.0331 * Mathf.Pow(x, 4))
+					return d * v;
+				//Normal step.
+				if (Math.Log(u) < 0.5 * Mathf.Pow(x, 2) + d * (1.0 - v + Math.Log(v)))
+					return d * v;
+			}
+		}
+
+		private static float generateGammaRandom(float shape, float scale)
+		{
+			if (shape < 1)
+			{
+				float d = shape + 1.0f - 1.0f / 3.0f;
+				float c = (1.0f / 3.0f) / Mathf.Sqrt(d);
+
+				float u = Rand.Range(0.0f, 1.0f);
+				return scale * Marsaglia(d, c) * Mathf.Pow(u, 1.0f / shape);
+			}
+			else
+			{
+				float d = shape - 1.0f / 3.0f;
+				float c = (1.0f / 3.0f) / Mathf.Sqrt(d);
+
+				return scale * Marsaglia(d, c);
+			}
+		}
+
+        /// <summary>
+        /// Generates a random number between 0 and 1 using a beta distribution.
+        /// </summary>
+        /// <param name="alpha">The alpha component.</param>
+        /// <param name="beta">The beta component.</param>
+        /// <returns></returns>
+        public static float generateBetaRandom(float alpha, float beta)
+		{
+			float x = generateGammaRandom(alpha, 1);
+			float y = generateGammaRandom(beta, 1);
+			return x / (x + y);
+		}
+	}
 }


### PR DESCRIPTION
Reworked how former humans are decided and managed:
- Added a concept of restricted and banned former humans.
  - Restricted former humans cannot happen in fully random mutagen.
  - Banned former humans cannot happen at all.
- Centralized former human check.
- Added default former human ban list configuration.
  - All animals associated with powerful morphs are by default restricted.
  - Genetic Rim archotech centipede is by default disabled.
  - Alpha animals gallatross is by default restricted.
- Added options menu to ban or restrict former humans.
  - Animals related to defined morphs can be restricted but not banned.
- Added configurable chance for hostiles to retain their faction. (Also affects pawns from friendly factions)
  - Default is off.
- Animals spawning as former humans now have a significant bias towards being ferals.

We may need a better description / explanation for the options and impact.