### PR TITLE
Issue 819 - narrow head conflict

### DIFF
--- a/Languages/English/Keyed/OptionalPatches.xml
+++ b/Languages/English/Keyed/OptionalPatches.xml
@@ -3,4 +3,6 @@
     <PMFoodStackMultiplierDescription>Multiplies the max meal size by pawn bodysize.</PMFoodStackMultiplierDescription>
     <PMPawnScalingCaption>Pawn scaling.</PMPawnScalingCaption>
     <PMPawnScalingDescription>Changes the size of pawns based on their bodysize.\nThis patch is experimental and may incur visual bugs and glitches.</PMPawnScalingDescription>
+    <PMNarrowHeadsCaption>Narrow heads.</PMNarrowHeadsCaption>
+    <PMNarrowHeadsDescription>Disables all narrow heads, replacing them with average.\nMutation graphics do not fit narrow heads.</PMNarrowHeadsDescription>
 </LanguageData>

--- a/Source/Pawnmorphs/Esoteria/HPatches/Optional/NarrowHeads.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/Optional/NarrowHeads.cs
@@ -1,16 +1,28 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using HarmonyLib;
 using JetBrains.Annotations;
 using RimWorld;
 using Verse;
 
-namespace Pawnmorph.HPatches
+namespace Pawnmorph.HPatches.Optional
 {
+	[OptionalPatch("PMNarrowHeadsCaption", "PMNarrowHeadsDescription", nameof(_enabled), true)]
 	[HarmonyPatch(typeof(Game))]
 	[UsedImplicitly]
-	internal static class GamePatches
+	internal static class NarrowHeads
 	{
+		static bool _enabled = true;
+
+		static bool Prepare(MethodBase original)
+		{
+			if (original == null && _enabled)
+				Log.Message("[PM] Optional narrow head patch enabled.");
+
+			return _enabled;
+		}
+
 		private static readonly Dictionary<string, string> HeadReplacements = new()
 		{
 			{ "Male_NarrowNormal", "Male_AverageNormal" },
@@ -27,6 +39,7 @@ namespace Pawnmorph.HPatches
 		{
 			FixMissingNarrowHeads();
 		}
+
 		private static void FixMissingNarrowHeads()
 		{
 			Dictionary<HeadTypeDef, HeadTypeDef> headMap =

--- a/Source/Pawnmorphs/Esoteria/Pawnmorph.csproj
+++ b/Source/Pawnmorphs/Esoteria/Pawnmorph.csproj
@@ -324,7 +324,7 @@
     <Compile Include="Genebank\IGenebankEntry.cs" />
     <Compile Include="Genebank\Model\MutationGenebankEntry.cs" />
     <Compile Include="Genebank\Model\TemplateGenebankEntry.cs" />
-    <Compile Include="HPatches\GamePatches.cs" />
+    <Compile Include="HPatches\Optional\NarrowHeads.cs" />
     <Compile Include="HPatches\GeneTrackerPatches.cs" />
     <Compile Include="HPatches\PawnMindStatePatches.cs" />
     <Compile Include="PMStyleDefOf.cs" />


### PR DESCRIPTION
Narrow heads patch conflict with other mods also patching away narrow heads.
Changing it to an optional patch (default enabled) allows users to disable it if they have a conflict.