### PR TITLE
Issue 818 - Changed mutation tracker comp patch to assign to all pawns.

### DIFF
--- a/Patches/Core/Core_AddedComps.xml
+++ b/Patches/Core/Core_AddedComps.xml
@@ -30,7 +30,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-		<xpath>/Defs/ThingDef[@Name="BasePawn"]/comps</xpath>
+		<xpath>/Defs/ThingDef[thingClass="Pawn"]/comps</xpath>
 		<value>
 			<li>
 				<compClass>Pawnmorph.AspectTracker</compClass>

--- a/Source/Pawnmorphs/Esoteria/FormerHumans/FormerHumanPawnGenerator.cs
+++ b/Source/Pawnmorphs/Esoteria/FormerHumans/FormerHumanPawnGenerator.cs
@@ -68,7 +68,8 @@ namespace Pawnmorph.FormerHumans
 					fixedBirthName: settings.FirstName, fixedLastName: settings.LastName,
 					fixedGender: settings.Gender, colonistRelationChanceFactor: settings.ColonistRelationChanceFactor ?? 1);
 			Pawn pawn = PawnGenerator.GeneratePawn(request);
-			CleanupPawn(pawn);
+			TransformerUtility.HandleApparelAndEquipment(pawn, null);
+
 			return pawn;
 		}
 
@@ -151,17 +152,6 @@ namespace Pawnmorph.FormerHumans
 				MutationResult res = MutationUtilities.AddMutation(lPawn, rM, addList, aEffects);
 				if (res) i++; //only increment if we actually added any mutations 
 			}
-		}
-
-
-		/// <summary>
-		/// Cleans the pawn up post-generation so that they don't have any gear/equipment when reverted
-		/// </summary>
-		/// <param name="lPawn">L pawn.</param>
-		private static void CleanupPawn(Pawn lPawn) //TODO Unify this with TransformerUtility.CleanUpHumanPawnPostTf()
-		{
-			lPawn.equipment?.DestroyAllEquipment();
-			lPawn.apparel?.DestroyAll();
 		}
 
 	}

--- a/Source/Pawnmorphs/Esoteria/TransformerUtility.cs
+++ b/Source/Pawnmorphs/Esoteria/TransformerUtility.cs
@@ -688,7 +688,7 @@ namespace Pawnmorph
 			DebugLogUtils.Assert(!pawn.guest.IsPrisoner, $"{pawn.Name} is being cleaned up but is still a prisoner");
 		}
 
-		private static void HandleApparelAndEquipment(Pawn originalPawn, Caravan caravan)
+		internal static void HandleApparelAndEquipment(Pawn originalPawn, Caravan caravan)
 		{
 			var apparelTracker = originalPawn.apparel;
 			var equipmentTracker = originalPawn.equipment;


### PR DESCRIPTION
Closes #818

Ferian race mod did not use BasePawn and so didn't get a mutation tracker assigned causing lots of errors.
Changing the patch to point at any XML with "Pawn" as class should cover custom pawn definitions too.