### PR TITLE
Issue 694 + 418 - error on gaining thought.

### DIFF
--- a/Source/Pawnmorphs/Esoteria/Thoughts/FormerHumanMemory.cs
+++ b/Source/Pawnmorphs/Esoteria/Thoughts/FormerHumanMemory.cs
@@ -64,6 +64,8 @@ namespace Pawnmorph.Thoughts
 			get
 			{
 				// It seems some mods might call CurStageIndex in prefix before thought has been attached to a pawn.
+				// For example, Vanilla Traits Expanded.
+				// https://github.com/Vanilla-Expanded/VanillaTraitsExpanded/blob/b55456925c4a4ffbc7347444e98a622d3562508c/1.4/Source/VanillaTraitsExpanded/HarmonyPatches/Thought_Patches.cs#LL218C63-L218C92
 				if (pawn == null)
 					return 0;
 

--- a/Source/Pawnmorphs/Esoteria/Thoughts/FormerHumanMemory.cs
+++ b/Source/Pawnmorphs/Esoteria/Thoughts/FormerHumanMemory.cs
@@ -63,6 +63,10 @@ namespace Pawnmorph.Thoughts
 		{
 			get
 			{
+				// It seems some mods might call CurStageIndex in prefix before thought has been attached to a pawn.
+				if (pawn == null)
+					return 0;
+
 				var fSapienceStatus = pawn.GetQuantizedSapienceLevel();
 				if (fSapienceStatus == null)
 				{


### PR DESCRIPTION
VanillaTraitsExpanded checks CurStageIndex in a gain thought prefix, which means the thought hasn't bee assigned to a pawn yet.
For former human memories, this will then check sapience level and cause a null reference.

Closes #694
Closes #418