### PR TITLE
allowed sapient former humans to carry things on caravans

### DIFF
--- a/Source/Pawnmorphs/Esoteria/PawnmorphPatches.cs
+++ b/Source/Pawnmorphs/Esoteria/PawnmorphPatches.cs
@@ -344,7 +344,8 @@ namespace Pawnmorph
 			methodsToPatch.Add(typeof(MentalState_Manhunter).GetMethod(nameof(MentalState_Manhunter.ForceHostileTo), INSTANCE_FLAGS, null, new[] { typeof(Thing) }, null));
 			methodsToPatch.Add(typeof(Pawn).GetMethod(nameof(Pawn.ThreatDisabledBecauseNonAggressiveRoamer), instanceFlags));
 
-
+			//caravan and inventory patch 
+            methodsToPatch.Add(typeof(MassUtility).GetMethod(nameof(MassUtility.CanEverCarryAnything), staticFlags)); 
 
 			//now patch them 
 			foreach (var methodInfo in methodsToPatch)


### PR DESCRIPTION
simple fix to allow sapient former humans to carry things on caravans regardless if they are pack animals 

fixed #847

