### PR TITLE
Optimize mutation descriptions

### DIFF
--- a/Source/Pawnmorphs/Esoteria/HPatches/HealthCardUtilsPatch.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/HealthCardUtilsPatch.cs
@@ -13,46 +13,6 @@ using static Pawnmorph.Utilities.PatchUtilities;
 
 namespace Pawnmorph
 {
-	/// <summary> Draw an info icon for mutations with their descriptions in tooltip. </summary>
-	[HarmonyPatch(typeof(HealthCardUtility), "DrawHediffRow")]
-	[StaticConstructorOnStartup]
-	public static class PatchHealthCardUtilityDrawHediffRow
-	{
-		private static readonly Texture2D icon = ContentFinder<Texture2D>.Get("UI/Icons/Info", true);
-		[HarmonyAfter("PeteTimesSix.CompactHediffs")]
-		static void Prefix(Rect rect, Pawn pawn, IEnumerable<Hediff> diffs, ref float curY)
-		{
-			var dLst = diffs.MakeSafe().ToList();
-			if (dLst.OfType<IDescriptiveHediff>().FirstOrDefault(x => x.Description != null) == null) return;
-
-			float firstRowWidth = rect.width * 0.275f;
-			Rect rectIcon = new Rect(firstRowWidth - icon.width - 4, curY + 1, icon.width, icon.height);
-			var toolTipRect = rect;
-			toolTipRect.x = rectIcon.x;
-			toolTipRect.y = rectIcon.y;
-			toolTipRect.height = rectIcon.height * dLst.Count;
-
-			//GUI.DrawTexture(rectIcon, icon);
-			TooltipHandler.TipRegion(toolTipRect, () => Tooltip(dLst), (int)curY + 117857);
-		}
-
-		static string Tooltip(IEnumerable<Hediff> diffs)
-		{
-			StringBuilder tooltip = new StringBuilder();
-			foreach (var mutation in diffs.OfType<IDescriptiveHediff>())
-			{
-				var desc = mutation.Description;
-				if (desc == null) continue;
-
-				tooltip.AppendLine(desc);
-			}
-
-			return tooltip.ToString();
-
-		}
-	}
-
-
 	[HarmonyPatch(typeof(RimWorld.HealthCardUtility), "GetTooltip")]
 	static class GetTooltip
 	{

--- a/Source/Pawnmorphs/Esoteria/Hediffs/Hediff_Descriptive.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Hediff_Descriptive.cs
@@ -22,7 +22,7 @@ namespace Pawnmorph.Hediffs
 		/// <value>
 		/// The tooltip description.
 		/// </value>
-		public virtual string Description
+		public override string Description
 		{
 			get
 			{
@@ -56,7 +56,6 @@ namespace Pawnmorph.Hediffs
 				return _descriptionBuilder.ToString();
 			}
 		}
-
 
 		/// <summary>
 		/// Controls the base portion of the label (the part not in parentheses)

--- a/Source/Pawnmorphs/Esoteria/MutationRuleDef.cs
+++ b/Source/Pawnmorphs/Esoteria/MutationRuleDef.cs
@@ -21,7 +21,7 @@ namespace Pawnmorph
 		/// <summary>
 		///     how often the rules are checked
 		/// </summary>
-		public const int CHECK_RATE = TimeMetrics.TICKS_PER_REAL_SECOND * 3 / 2;
+		public const int CHECK_RATE = 1000;
 
 
 		[Unsaved] private List<IMRuleEntry> _allRules;
@@ -301,7 +301,7 @@ namespace Pawnmorph
 
 			if (!ConditionsMet(pawn)) return false;
 
-			if (RuleDef.mtth <= 0 || Rand.MTBEventOccurs(RuleDef.mtth, 60000, MutationRuleDef.CHECK_RATE))
+			if (RuleDef.mtth <= 0 || Rand.MTBEventOccurs(RuleDef.mtth, TimeMetrics.TICKS_PER_DAY, MutationRuleDef.CHECK_RATE))
 			{
 				DoRule(pawn);
 				return true;

--- a/Source/Pawnmorphs/Esoteria/MutationTracker.cs
+++ b/Source/Pawnmorphs/Esoteria/MutationTracker.cs
@@ -120,12 +120,20 @@ namespace Pawnmorph
 		public Pawn Pawn => (Pawn)parent;
 
 
+		private bool? immune = null;
+
 		/// <summary>
 		///     called every tick
 		/// </summary>
 		public override void CompTick()
 		{
-			if (!MutagenDefOf.defaultMutagen.CanInfect(Pawn.def)) return; //tracker is added on some kinds of pawns that can't get mutations, like mechanoids 
+			// Could potentially use post-tick action to self-remove MutationTracker if pawn is immune.
+			if (immune == null)
+				immune = MutagenDefOf.defaultMutagen.CanInfect(Pawn.def) == false;
+			
+			if (immune == true) 
+				return; //tracker is added on some kinds of pawns that can't get mutations, like mechanoids 
+			
 			if (InfluencesDirty)
 			{
 				RecalcInfluences();


### PR DESCRIPTION
Some optimizations to remove a no-longer-needed harmony patch for pawn health tab.
I noticed that Rimworld now allows you to override Hediff.Description, so we can now inject our custom descriptions into vanilla's tooltip system without using a custom patch!

Also an issue of MutationTracker calling CanInfect every single tick for every single pawn.