### PR TITLE
Mutation log

### DIFF
--- a/Languages/English/Keyed/Abilities.xml
+++ b/Languages/English/Keyed/Abilities.xml
@@ -2,4 +2,6 @@
     <FailFly_Roofed>Cannot fly from under roof.</FailFly_Roofed>
     <FailFly_Lift>Mutations do not provide enough lift to fly.</FailFly_Lift>
     <Fail_Downed>Downed.</Fail_Downed>
+    <Cooldown_Hours>Cooling down: {0}h</Cooldown_Hours>
+    <Cooldown_Seconds>Cooling down: {0}s</Cooldown_Seconds>
 </LanguageData>

--- a/Languages/English/Keyed/Settings.xml
+++ b/Languages/English/Keyed/Settings.xml
@@ -59,4 +59,6 @@
 	<PMSequencerMultiplerTooltip>Speed multiplier when sequencing mutations.</PMSequencerMultiplerTooltip>
 	<PMSequencerAutoAnimalGenome>Auto sequence animal genomes</PMSequencerAutoAnimalGenome>
 	<PMSequencerAutoAnimalGenomeTooltip>Automatically sequence all mutations from animal genome when downloaded.</PMSequencerAutoAnimalGenomeTooltip>
+	<mutationLogLength>Mutation log length</mutationLogLength>
+	<mutationLogLengthTooltip>Max number of entries remembered by the mutation log.</mutationLogLengthTooltip>
 </LanguageData>

--- a/Languages/English/Keyed/UI_Localization.xml
+++ b/Languages/English/Keyed/UI_Localization.xml
@@ -15,4 +15,7 @@
 	<!-- Info Card -->
 	<PmMorphInfo_NoMorph>No Morphs</PmMorphInfo_NoMorph>
 	<PmMorphInfo_MorphDisplay>{MORPH}</PmMorphInfo_MorphDisplay>
+	
+	<PmHoursAgo>{0} hours ago</PmHoursAgo>
+	<PmLessThanHour>Less than an hour ago</PmLessThanHour>
 </LanguageData>

--- a/Source/Pawnmorphs/Esoteria/Abilities/MutationAbility.cs
+++ b/Source/Pawnmorphs/Esoteria/Abilities/MutationAbility.cs
@@ -224,9 +224,9 @@ namespace Pawnmorph.Abilities
 		private void UpdateCooldownText()
 		{
 			if (_currentCooldown > Utilities.TimeMetrics.TICKS_PER_HOUR)
-				Gizmo.disabledReason = $"Cooling down: {_currentCooldown / Utilities.TimeMetrics.TICKS_PER_HOUR}h";
+				Gizmo.disabledReason = $"Cooldown_Hours".Translate(_currentCooldown / Utilities.TimeMetrics.TICKS_PER_HOUR);
 			else
-				Gizmo.disabledReason = $"Cooling down: {_currentCooldown / 60}s";
+				Gizmo.disabledReason = $"Cooldown_Seconds".Translate(_currentCooldown / Utilities.TimeMetrics.TICKS_PER_REAL_SECOND);
 		}
 
 		/// <summary>

--- a/Source/Pawnmorphs/Esoteria/HPatches/WorldPawnsPatches.cs
+++ b/Source/Pawnmorphs/Esoteria/HPatches/WorldPawnsPatches.cs
@@ -1,0 +1,28 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Verse;
+
+namespace Pawnmorph.HPatches
+{
+	[HarmonyPatch(typeof(RimWorld.Planet.WorldPawns))]
+	internal static class WorldPawnsPatches
+	{
+		[HarmonyPatch("ShouldMothball"), HarmonyPostfix]
+		private static bool ShouldMothballPostfix(bool __result, Pawn p)
+		{
+			if (__result)
+			{
+				MutationTracker tracker = p.GetMutationTracker();
+				if (tracker != null)
+				{
+					tracker.ClearMutationLog();
+				}
+			}
+			return __result;
+		}
+	}
+}

--- a/Source/Pawnmorphs/Esoteria/HediffGiver_Mutation.cs
+++ b/Source/Pawnmorphs/Esoteria/HediffGiver_Mutation.cs
@@ -124,10 +124,6 @@ namespace Pawnmorph
 			if (!mutagenDef.CanInfect(pawn)) return false;
 			if (!hediff.IsValidFor(pawn)) return false;
 			bool added = PawnmorphHediffGiverUtility.TryApply(pawn, hediff, partsToAffect, canAffectAnyLivePart, countToAffect, outAddedHediffs);
-			if (addLogEntry && added && partsToAffect != null)
-			{
-				AddMutationLogFor(pawn, mutagenDef);
-			}
 
 			if (added)
 			{
@@ -138,12 +134,6 @@ namespace Pawnmorph
 				}
 			}
 			return added;
-		}
-
-		private void AddMutationLogFor(Pawn pawn, MutagenDef mutagenDef)
-		{
-			var log = new MutationLogEntry(pawn, hediff, mutagenDef, partsToAffect);
-			Find.PlayLog.Add(log);
 		}
 
 		/// <summary>tries to apply the mutations to the given body part records</summary>
@@ -176,7 +166,6 @@ namespace Pawnmorph
 			var hediffInst = HediffMaker.MakeHediff(hediff, pawn, recordToAdd);
 			pawn.health.AddHediff(hediffInst, recordToAdd);
 			DoMutationAddedEffects(pawn);
-			AddMutationLogFor(pawn, mutagen);
 
 			return true;
 		}

--- a/Source/Pawnmorphs/Esoteria/HediffGiver_Mutation.cs
+++ b/Source/Pawnmorphs/Esoteria/HediffGiver_Mutation.cs
@@ -119,7 +119,7 @@ namespace Pawnmorph
 		/// <param name="cause">The cause.</param>
 		/// <param name="addLogEntry">if set to <c>true</c> [add log entry].</param>
 		/// <returns>if the mutation was added or not</returns>
-		public bool TryApply(Pawn pawn, MutagenDef mutagenDef, List<Hediff> outAddedHediffs = null, Hediff cause = null, bool addLogEntry = true)
+		public bool TryApply(Pawn pawn, MutagenDef mutagenDef, List<Hediff> outAddedHediffs = null, Hediff cause = null)
 		{
 			if (!mutagenDef.CanInfect(pawn)) return false;
 			if (!hediff.IsValidFor(pawn)) return false;

--- a/Source/Pawnmorphs/Esoteria/Hediffs/Hediff_MutagenicBase.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Hediff_MutagenicBase.cs
@@ -174,7 +174,7 @@ namespace Pawnmorph.Hediffs
 				_causes.Add(MutationCauses.WEAPON_PREFIX, weaponSource);
 			}
 
-			_causes.SetLocation(pawn.GetCorrectPosition());
+			_causes.SetLocation(pawn.GetCorrectPosition(), pawn.GetCorrectMap());
 			if (def.stages != null && def.stages.Count > 0)
 				CheckCurrentStage(null, def.stages[base.CurStageIndex]);
 		}

--- a/Source/Pawnmorphs/Esoteria/Hediffs/Hediff_MutagenicBase.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Hediff_MutagenicBase.cs
@@ -173,6 +173,8 @@ namespace Pawnmorph.Hediffs
 
 				_causes.Add(MutationCauses.WEAPON_PREFIX, weaponSource);
 			}
+
+			_causes.SetLocation(pawn.GetCorrectPosition());
 			if (def.stages != null && def.stages.Count > 0)
 				CheckCurrentStage(null, def.stages[base.CurStageIndex]);
 		}

--- a/Source/Pawnmorphs/Esoteria/ITab_Pawn_Mutations.cs
+++ b/Source/Pawnmorphs/Esoteria/ITab_Pawn_Mutations.cs
@@ -417,6 +417,26 @@ namespace Pawnmorph
 			// Draw the entry's text.
 			Widgets.Label(entryRect, text);
 
+
+
+			TipSignal tip = new TipSignal(() =>
+			{
+				string tooltip;
+				int ticksAgo = entry.Age;
+				
+				if (ticksAgo > TimeMetrics.TICKS_PER_DAY)
+					tooltip = $"PmHoursAgo".Translate(ticksAgo / TimeMetrics.TICKS_PER_DAY);
+				if (ticksAgo > TimeMetrics.TICKS_PER_HOUR)
+					tooltip = $"PmHoursAgo".Translate(ticksAgo / TimeMetrics.TICKS_PER_HOUR);
+				else
+					tooltip = $"PmLessThanHour".Translate();
+
+				return tooltip;
+
+			}, (int)curPos.y * 37);
+			TooltipHandler.TipRegion(entryRect, tip);
+
+
 			if (entry.Causes.Location.HasValue)
 			{
 				if (Mouse.IsOver(entryRect))

--- a/Source/Pawnmorphs/Esoteria/ITab_Pawn_Mutations.cs
+++ b/Source/Pawnmorphs/Esoteria/ITab_Pawn_Mutations.cs
@@ -102,7 +102,7 @@ namespace Pawnmorph
 			Vector2 col2 = new Vector2(viewRect.width / 3, col1.y);
 			Vector2 col3 = new Vector2(viewRect.width / 3 * 2, col2.y);
 			float colWidth = viewRect.width / 3 - 10f;
-
+			
 			// Draw the headers for all three columns (labels are provided by the xml).
 			DrawColumnHeader(ref col1, colWidth, "MorphsITabHeader".Translate());
 			DrawColumnHeader(ref col2, colWidth, "TraitsITabHeader".Translate());
@@ -375,9 +375,13 @@ namespace Pawnmorph
 
 		IEnumerable<ITab_Pawn_Log_Utility.LogLineDisplayable> GetMutationLogs(Pawn pawn)
 		{
-			foreach (MutationLogEntry mutationLogEntry in Find.PlayLog.AllEntries.Where(e => e.Concerns(pawn)).OfType<MutationLogEntry>())
+			MutationTracker tracker = pawn.GetMutationTracker();
+			if (tracker != null)
 			{
-				yield return new ITab_Pawn_Log_Utility.LogLineDisplayableLog(mutationLogEntry, pawn);
+				foreach (MutationLogEntry mutationLogEntry in tracker.MutationLog)
+				{
+					yield return new ITab_Pawn_Log_Utility.LogLineDisplayableLog(mutationLogEntry, pawn);
+				}
 			}
 		}
 

--- a/Source/Pawnmorphs/Esoteria/ITab_Pawn_Mutations.cs
+++ b/Source/Pawnmorphs/Esoteria/ITab_Pawn_Mutations.cs
@@ -202,7 +202,7 @@ namespace Pawnmorph
 				foreach (var influence in influences.OrderByDescending(x => x.Value))
 				{
 					var nVal = influence.Value / maxRaceInfluence;
-					if (humInf / maxRaceInfluence > nVal)
+					if (renderHuman == false && humInf / maxRaceInfluence > nVal)
 					{
 						GUI.color = Color.green;
 						DrawInfluenceRow(ref curPos, width, "Human", humInf / maxRaceInfluence);
@@ -357,12 +357,12 @@ namespace Pawnmorph
 			Widgets.BeginScrollView(outRect, ref logScrollPosition, viewRect, true);
 
 			var cachedLogDisplay = GetMutationLogs(PawnToShowMutationsFor);
-			foreach (ITab_Pawn_Log_Utility.LogLineDisplayable line in cachedLogDisplay)
+			foreach (KeyValuePair<MutationLogEntry, ITab_Pawn_Log_Utility.LogLineDisplayable> line in cachedLogDisplay)
 			{
 				StringBuilder stringBuilder = new StringBuilder();
-				line.AppendTo(stringBuilder);
+				line.Value.AppendTo(stringBuilder);
 				stringBuilder.Length--;
-				DrawMutLogEntry(ref curPos, viewRect.width, stringBuilder.ToString());
+				DrawMutLogEntry(ref curPos, viewRect.width, stringBuilder.ToString(), line.Key);
 			}
 
 			// Set the scroll view height
@@ -373,16 +373,17 @@ namespace Pawnmorph
 			Widgets.EndScrollView();
 		}
 
-		IEnumerable<ITab_Pawn_Log_Utility.LogLineDisplayable> GetMutationLogs(Pawn pawn)
+		List<KeyValuePair<MutationLogEntry, ITab_Pawn_Log_Utility.LogLineDisplayable>> logCache = new List<KeyValuePair<MutationLogEntry, ITab_Pawn_Log_Utility.LogLineDisplayable>>();
+		List<KeyValuePair<MutationLogEntry, ITab_Pawn_Log_Utility.LogLineDisplayable>> GetMutationLogs(Pawn pawn)
 		{
+			logCache.Clear();
 			MutationTracker tracker = pawn.GetMutationTracker();
 			if (tracker != null)
 			{
-				foreach (MutationLogEntry mutationLogEntry in tracker.MutationLog)
-				{
-					yield return new ITab_Pawn_Log_Utility.LogLineDisplayableLog(mutationLogEntry, pawn);
-				}
+				logCache.AddRange(tracker.MutationLog.Select(x => new KeyValuePair<MutationLogEntry, ITab_Pawn_Log_Utility.LogLineDisplayable>(x, new ITab_Pawn_Log_Utility.LogLineDisplayableLog(x, pawn))));
+				logCache.Reverse();
 			}
+			return logCache;
 		}
 
 
@@ -403,7 +404,7 @@ namespace Pawnmorph
 			GUI.color = Color.white;
 		}
 
-		private void DrawMutLogEntry(ref Vector2 curPos, float width, string text)
+		private void DrawMutLogEntry(ref Vector2 curPos, float width, string text, MutationLogEntry entry)
 		{
 			// Set up the drawing rect
 			Rect entryRect = new Rect(curPos.x, curPos.y, width, Text.CalcHeight(text, width));
@@ -415,6 +416,20 @@ namespace Pawnmorph
 
 			// Draw the entry's text.
 			Widgets.Label(entryRect, text);
+
+			if (entry.Causes.Location.HasValue)
+			{
+				if (Mouse.IsOver(entryRect))
+				{
+					Widgets.DrawHighlight(entryRect);
+					TargetHighlighter.Highlight(entry.Causes.Location.Value);
+				}
+
+				if (Widgets.ButtonInvisible(entryRect))
+				{
+					CameraJumper.TryJump(entry.Causes.Location.Value);
+				}
+			}
 
 			// Update the location for the next entry.
 			curPos.y += entryRect.height;

--- a/Source/Pawnmorphs/Esoteria/MutagenDef.cs
+++ b/Source/Pawnmorphs/Esoteria/MutagenDef.cs
@@ -261,51 +261,26 @@ namespace Pawnmorph
 				yield return $"type {mutagenType.Name} is not a subtype of Mutagen";
 		}
 
-
-		[NotNull]
-		private static readonly Dictionary<MutationDef, List<BodyPartDef>> _scratchDict =
-			new Dictionary<MutationDef, List<BodyPartDef>>();
-
-
 		private void HandlePostMutationEffects(Pawn pawn, in MutationResult res, AncillaryMutationEffects? aEffects, Hediff cause)
 		{
-			bool doLog = aEffects?.AddLogEntry ?? AncillaryMutationEffects.Default.AddLogEntry;
 			if (res)
 			{
 				this.TryApplyAspects(pawn);
 
-			}
-
-			if (doLog && res)
-			{
-				_scratchDict.Clear();
+				var mBase = cause as Hediff_MutagenicBase;
 				foreach (Hediff_AddedMutation mutation in res)
 				{
-					if (!_scratchDict.TryGetValue(mutation.Def, out List<BodyPartDef> lst))
-					{
-						lst = new List<BodyPartDef>();
-						_scratchDict[mutation.Def] = lst;
-					}
-
-					if (!lst.Contains(mutation.Part.def)) lst.Add(mutation.Part.def);
-				}
-
-				var mBase = cause as Hediff_MutagenicBase;
-
-				foreach (KeyValuePair<MutationDef, List<BodyPartDef>> keyValuePair in _scratchDict)
-				{
-					var logEntry = new MutationLogEntry(pawn, keyValuePair.Key, this, keyValuePair.Value);
 					if (cause != null)
 					{
 						if (mBase != null)
 						{
-							logEntry.Causes.Add(mBase.Causes);
+							mutation.Causes.Add(mBase.Causes);
+
+							if (mBase.Causes.Location.HasValue)
+								mutation.Causes.SetLocation(mBase.Causes.Location.Value);
 						}
-						logEntry.Causes.Add(MutationCauses.HEDIFF_PREFIX, cause.def);
+						mutation.Causes.Add(MutationCauses.HEDIFF_PREFIX, cause.def);
 					}
-
-
-					Find.PlayLog?.Add(logEntry);
 				}
 			}
 		}

--- a/Source/Pawnmorphs/Esoteria/MutagenicStone.cs
+++ b/Source/Pawnmorphs/Esoteria/MutagenicStone.cs
@@ -45,19 +45,14 @@ namespace Pawnmorph
 			}
 		}
 
-		private static void MutatePawn(Pawn pawn, MutagenDef mutagen)
+		private void MutatePawn(Pawn pawn, MutagenDef mutagen)
 		{
-			HediffSet hediffSet = pawn.health.hediffSet;
-
 			if (!pawn.Spawned || !mutagen.CanInfect(pawn))
 				return;
 
-
-
-			pawn.health.AddHediff(MorphTransformationDefOf.FullRandomTF);
-
-			Hediff hediff = pawn.health.hediffSet.GetFirstHediffOfDef(MorphTransformationDefOf.FullRandomTF);
-			if (hediff is Hediff_MutagenicBase mBase) mBase.Causes.TryAddMutagenCause(MutagenDefOf.PM_MutaniteMutagen);
+			Hediff hediff = pawn.health.AddHediff(MorphTransformationDefOf.FullRandomTF);
+			if (hediff is Hediff_MutagenicBase mBase)
+				mBase.Causes.TryAddMutagenCause(MutagenDefOf.PM_MutaniteMutagen);
 
 			IntermittentMagicSprayer.ThrowMagicPuffDown(pawn.Position.ToVector3(), pawn.Map);
 		}

--- a/Source/Pawnmorphs/Esoteria/MutationCauses.cs
+++ b/Source/Pawnmorphs/Esoteria/MutationCauses.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using JetBrains.Annotations;
 using Pawnmorph.Utilities;
 using RimWorld;
+using RimWorld.Planet;
 using Verse;
 using Verse.Grammar;
 
@@ -43,7 +44,7 @@ namespace Pawnmorph
 
 
 		[NotNull] private List<CauseEntry> _entries;
-		private IntVec3? _location;
+		private GlobalTargetInfo? _location;
 
 		/// <summary>
 		///     Initializes a new instance of the <see cref="MutationCauses" /> class.
@@ -58,15 +59,25 @@ namespace Pawnmorph
 		/// Sets the source location.
 		/// </summary>
 		/// <param name="cell">The location of whatever caused the mutation.</param>
-		public void SetLocation(IntVec3 cell)
+		/// <param name="map">The map that contains the cell.</param>
+		public void SetLocation(IntVec3 cell, Map map)
 		{
-			_location = cell;
+			_location = new GlobalTargetInfo(cell, map);
+		}
+
+		/// <summary>
+		/// Sets the source location.
+		/// </summary>
+		/// <param name="location">The global location of whatever caused the mutation.</param>
+		public void SetLocation(GlobalTargetInfo location)
+		{
+			_location = location;
 		}
 
 		/// <summary>
 		/// Gets the associated location. (If any)
 		/// </summary>
-		public IntVec3? Location => _location;
+		public GlobalTargetInfo? Location => _location;
 
 		/// <summary>Returns an enumerator that iterates through a collection.</summary>
 		/// <returns>An <see cref="T:System.Collections.IEnumerator" /> object that can be used to iterate through the collection.</returns>

--- a/Source/Pawnmorphs/Esoteria/MutationCauses.cs
+++ b/Source/Pawnmorphs/Esoteria/MutationCauses.cs
@@ -43,6 +43,7 @@ namespace Pawnmorph
 
 
 		[NotNull] private List<CauseEntry> _entries;
+		private IntVec3? _location;
 
 		/// <summary>
 		///     Initializes a new instance of the <see cref="MutationCauses" /> class.
@@ -50,7 +51,22 @@ namespace Pawnmorph
 		public MutationCauses()
 		{
 			_entries = new List<CauseEntry>();
+			_location = null;
 		}
+
+		/// <summary>
+		/// Sets the source location.
+		/// </summary>
+		/// <param name="cell">The location of whatever caused the mutation.</param>
+		public void SetLocation(IntVec3 cell)
+		{
+			_location = cell;
+		}
+
+		/// <summary>
+		/// Gets the associated location. (If any)
+		/// </summary>
+		public IntVec3? Location => _location;
 
 		/// <summary>Returns an enumerator that iterates through a collection.</summary>
 		/// <returns>An <see cref="T:System.Collections.IEnumerator" /> object that can be used to iterate through the collection.</returns>

--- a/Source/Pawnmorphs/Esoteria/MutationCauses.cs
+++ b/Source/Pawnmorphs/Esoteria/MutationCauses.cs
@@ -100,6 +100,15 @@ namespace Pawnmorph
 		public void ExposeData()
 		{
 			Scribe_Collections.Look(ref _entries, "entries", LookMode.Deep);
+
+			GlobalTargetInfo location = GlobalTargetInfo.Invalid;
+			if (_location.HasValue)
+				location = _location.Value;
+
+			Scribe_TargetInfo.Look(ref location, nameof(_location));
+
+			if (location.IsValid)
+				_location = location;
 		}
 
 		/// <summary>

--- a/Source/Pawnmorphs/Esoteria/MutationLogEntry.cs
+++ b/Source/Pawnmorphs/Esoteria/MutationLogEntry.cs
@@ -89,6 +89,14 @@ namespace Pawnmorph
 			_pawn = pawn;
 			_mutationDef = mutationDef;
 		}
+
+		public MutationLogEntry(Pawn pawn, Hediff_AddedMutation mutation)
+			: this(pawn, mutation.def, mutation.Part.def)
+		{
+			_causes = mutation.Causes;
+		}
+
+
 		/// <summary>
 		/// true if this log is about the given thing.
 		/// </summary>

--- a/Source/Pawnmorphs/Esoteria/MutationTracker.cs
+++ b/Source/Pawnmorphs/Esoteria/MutationTracker.cs
@@ -347,11 +347,16 @@ namespace Pawnmorph
 			List<MutationLogEntry> tmpList = new List<MutationLogEntry>(_mutationLog);
 			Scribe_Collections.Look(ref tmpList, "pm_mutationLog", LookMode.Deep);
 
+
+			if (Scribe.mode == LoadSaveMode.LoadingVars)
+			{
+				if (tmpList != null)
+					_mutationLog = new Queue<MutationLogEntry>(tmpList);
+			}
+
+
 			if (Scribe.mode == LoadSaveMode.PostLoadInit)
 			{
-				if (tmpList == null)
-					_mutationLog = new Queue<MutationLogEntry>(tmpList);
-
 				// Generate lookup dict manually during load for backwards compatibility.
 				if (!MutagenDefOf.defaultMutagen.CanInfect(Pawn)) 
 					return; //tracker is added on some kinds of pawns that can't get mutations, like mechanoids 
@@ -473,6 +478,14 @@ namespace Pawnmorph
 			}
 
 			return false;
+		}
+
+		/// <summary>
+		/// Deletes all entries from the pawn's mutation log.
+		/// </summary>
+		internal void ClearMutationLog()
+		{
+			_mutationLog.Clear();
 		}
 	}
 }

--- a/Source/Pawnmorphs/Esoteria/MutationTracker.cs
+++ b/Source/Pawnmorphs/Esoteria/MutationTracker.cs
@@ -28,6 +28,8 @@ namespace Pawnmorph
 
 		[NotNull] private readonly Dictionary<AnimalClassBase, float> _influenceDict = new Dictionary<AnimalClassBase, float>();
 
+		private Queue<MutationLogEntry> _mutationLog = new Queue<MutationLogEntry>(20);
+
 		/// <summary>
 		/// Gets or sets a value indicating whether debug messages are enabled.
 		/// </summary>
@@ -96,7 +98,10 @@ namespace Pawnmorph
 		/// <summary> Get the current influence associated with the given key. </summary>
 		public float this[MorphDef key] => _influenceDict.TryGetValue(key);
 
-
+		/// <summary>
+		/// Gets the mutation log for this pawn.
+		/// </summary>
+		public IEnumerable<MutationLogEntry> MutationLog => _mutationLog;
 
 
 		/// <summary>
@@ -299,7 +304,19 @@ namespace Pawnmorph
 			MutationsCount += 1;
 			_influencesDirty = true;
 
+			LogMutation(mutation);
 			NotifyCompsAdded(mutation);
+		}
+
+		private void LogMutation(Hediff_AddedMutation mutation)
+		{
+			var logEntry = new MutationLogEntry(Pawn, mutation);
+
+			_mutationLog.Enqueue(logEntry);
+			while (_mutationLog.Count > PawnmorpherMod.Settings.mutationLogLength)
+			{
+				_mutationLog.Dequeue();
+			}
 		}
 
 		private void RecalcInfluences()
@@ -327,10 +344,17 @@ namespace Pawnmorph
 		{
 			base.PostExposeData();
 
+			List<MutationLogEntry> tmpList = new List<MutationLogEntry>(_mutationLog);
+			Scribe_Collections.Look(ref tmpList, "pm_mutationLog", LookMode.Deep);
+
 			if (Scribe.mode == LoadSaveMode.PostLoadInit)
-			// Generate lookup dict manually during load for backwards compatibility.
 			{
-				if (!MutagenDefOf.defaultMutagen.CanInfect(Pawn)) return; //tracker is added on some kinds of pawns that can't get mutations, like mechanoids 
+				if (tmpList == null)
+					_mutationLog = new Queue<MutationLogEntry>(tmpList);
+
+				// Generate lookup dict manually during load for backwards compatibility.
+				if (!MutagenDefOf.defaultMutagen.CanInfect(Pawn)) 
+					return; //tracker is added on some kinds of pawns that can't get mutations, like mechanoids 
 
 				RecalculateMutationInfluences();
 			}
@@ -359,7 +383,7 @@ namespace Pawnmorph
 				if (!(parentAllComp is IMutationEventReceiver receiver)) continue;
 				receiver.MutationAdded(mutation, this);
 			}
-
+			
 			//notify hediffs & comps 
 			var hediffs = Pawn.health?.hediffSet?.hediffs;
 			if (hediffs != null)

--- a/Source/Pawnmorphs/Esoteria/MutationTracker.cs
+++ b/Source/Pawnmorphs/Esoteria/MutationTracker.cs
@@ -101,7 +101,7 @@ namespace Pawnmorph
 		/// <summary>
 		/// Gets the mutation log for this pawn.
 		/// </summary>
-		public IEnumerable<MutationLogEntry> MutationLog => _mutationLog;
+		public IReadOnlyCollection<MutationLogEntry> MutationLog => _mutationLog;
 
 
 		/// <summary>

--- a/Source/Pawnmorphs/Esoteria/Pawnmorph.csproj
+++ b/Source/Pawnmorphs/Esoteria/Pawnmorph.csproj
@@ -342,6 +342,7 @@
     <Compile Include="HPatches\GamePatches.cs" />
     <Compile Include="HPatches\GeneTrackerPatches.cs" />
     <Compile Include="HPatches\PawnMindStatePatches.cs" />
+    <Compile Include="HPatches\WorldPawnsPatches.cs" />
     <Compile Include="Interfaces\IConfigurableObject.cs" />
     <Compile Include="ModExtensions\AdministerableExtension.cs" />
     <Compile Include="ModExtensions\AnimalFilterModExtension.cs" />

--- a/Source/Pawnmorphs/Esoteria/PawnmorpherMod.cs
+++ b/Source/Pawnmorphs/Esoteria/PawnmorpherMod.cs
@@ -124,9 +124,10 @@ namespace Pawnmorph
 
 			coreNode.AddChild(nameof(PawnmorpherSettings.hostileKeepFactionTfChance), null, (in Rect x) => Widgets.HorizontalSlider(x, ref settings.hostileKeepFactionTfChance, new FloatRange(0, 1), settings.hostileKeepFactionTfChance.ToStringByStyle(ToStringStyle.PercentOne)), true);
 
+			coreNode.AddChild(nameof(PawnmorpherSettings.mutationLogLength), "mutationLogLengthTooltip", (in Rect x) => settings.mutationLogLength = (int)Widgets.HorizontalSlider(x, settings.mutationLogLength, 0, 30, label: settings.mutationLogLength.ToString(), roundTo: 0));
 
 
-
+			// Sequencer node
 			TreeNode_FilterBox sequencerNode = coreNode.AddChild("PMSequencer");
 			sequencerNode.AddChild("PMSequencerMultipler", "PMSequencerMultiplerTooltip", callback: (in Rect x) => settings.SequencingMultiplier = Widgets.HorizontalSlider(x, settings.SequencingMultiplier, 0.1f, 10, true, settings.SequencingMultiplier.ToStringPercent(), 0.1f.ToStringPercent(), 10f.ToStringPercent(), 0.1f));
 			sequencerNode.AddChild("PMSequencerAutoAnimalGenome", "PMSequencerAutoAnimalGenomeTooltip", callback: (in Rect x) => Widgets.Checkbox(x.position, ref settings.AutoSequenceAnimalGenome));

--- a/Source/Pawnmorphs/Esoteria/PawnmorpherSettings.cs
+++ b/Source/Pawnmorphs/Esoteria/PawnmorpherSettings.cs
@@ -119,7 +119,7 @@ namespace Pawnmorph
 		public Dictionary<string, bool> optionalPatches;
 
 
-
+		public int mutationLogLength = 10;
 
 
 
@@ -181,6 +181,7 @@ namespace Pawnmorph
 			Scribe_Values.Look(ref hazardousChaobulbs, nameof(hazardousChaobulbs), true);
 			Scribe_Values.Look(ref hostileKeepFactionTfChance, nameof(hostileKeepFactionTfChance));
 			Scribe_Values.Look(ref generateEndoGenesForAliens, nameof(generateEndoGenesForAliens), true);
+			Scribe_Values.Look(ref mutationLogLength, nameof(mutationLogLength), 10);
 
 
 

--- a/Source/Pawnmorphs/Esoteria/Rituals/AttachableOutcomeEffectWorkers/AddRandomVeneratedMutation.cs
+++ b/Source/Pawnmorphs/Esoteria/Rituals/AttachableOutcomeEffectWorkers/AddRandomVeneratedMutation.cs
@@ -77,6 +77,7 @@ namespace Pawnmorph.Rituals.AttachableOutcomeEffectWorkers
 					{
 						added.Causes.TryAddCause("ritualOutcome", def);
 						added.Causes.TryAddPrecept(jobRitual.Ritual);
+						added.Causes.SetLocation(jobRitual.Spot, jobRitual.Map);
 					}
 
 					mAdded++;


### PR DESCRIPTION
Significant update to MutationLog:
Moved log responsibility to MutationTracker.
Log entries are now made when mutation tracker is notified of new mutations.
Log entries reference the causes object of the mutation they cover.
Log entries now show an arrow if a location is associated with the entry, and allows clicking it to move camera there.
Entries show a tooltip of time since entry was made.
Added setting to set mutation log length.
Made mothballing clear mutation log to prevent save bloat.

Fixed mutation entries not being made.
Fixed mutation entries referencing wrong body part.
Fixed mutation entries being randomly removed due to being managed by world log.
