### PR TITLE
Mutation log extensions

### DIFF
--- a/1.4/Defs/Drugs/Drugs_Antigen.xml
+++ b/1.4/Defs/Drugs/Drugs_Antigen.xml
@@ -62,7 +62,10 @@ Raw antigen is often used as an emergency treatment for mutagenic diseases and m
 				<severityPerDay>-4</severityPerDay>
 			</li>
 			<li Class="Pawnmorph.Hediffs.CompProperties_RemoveType">
-				<removeType>Pawnmorph.Hediffs.MorphTf</removeType>
+				<removeTypes>
+					<li>Pawnmorph.Hediffs.MorphTf</li>
+					<li>Pawnmorph.Hediffs.Hediff_MutagenicBase</li>
+				</removeTypes>
 			</li>
 		</comps>
 		<stages>

--- a/1.4/Defs/Drugs/Drugs_Bases.xml
+++ b/1.4/Defs/Drugs/Drugs_Bases.xml
@@ -86,6 +86,11 @@
 			<Mutanite>2</Mutanite>
 			<Neutroamine>10</Neutroamine>
 		</costList>
+    <modExtensions>
+			<li Class="Pawnmorph.DefExtensions.MutationCauseExtension">
+				<rulePackDef>InjectorCauseLogPack</rulePackDef>
+			</li>
+    </modExtensions>
 	</ThingDef>
 	
 

--- a/1.4/Defs/Drugs/Drugs_Pills.xml
+++ b/1.4/Defs/Drugs/Drugs_Pills.xml
@@ -381,7 +381,10 @@ Intelliboost is unable to restore the consciousness of permanantly feral humans,
 				<showHoursToRecover>true</showHoursToRecover>
 			</li>
 			<li Class="Pawnmorph.Hediffs.CompProperties_RemoveType">
-				<removeType>Pawnmorph.Hediffs.MorphTf</removeType>
+				<removeTypes>
+					<li>Pawnmorph.Hediffs.MorphTf</li>
+					<li>Pawnmorph.Hediffs.Hediff_MutagenicBase</li>
+				</removeTypes>
 			</li>
 
 		</comps>

--- a/1.4/Defs/Hediffs/Hediffs_Bases.xml
+++ b/1.4/Defs/Hediffs/Hediffs_Bases.xml
@@ -1,6 +1,6 @@
 <Defs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../Schemas/HediffDef.xsd">
 	<HediffDef Abstract="true" Name="MorphParent">
-		<hediffClass>Pawnmorph.Hediffs.MorphTf</hediffClass>
+		<hediffClass>Pawnmorph.Hediffs.Hediff_MutagenicBase</hediffClass>
 		<defaultLabelColor>(77,68,179)</defaultLabelColor>
 		<scenarioCanAdd>true</scenarioCanAdd>
 		<isBad>false</isBad>

--- a/1.4/Defs/Hediffs/Hediffs_Drug.xml
+++ b/1.4/Defs/Hediffs/Hediffs_Drug.xml
@@ -12,9 +12,12 @@
             <li Class="HediffCompProperties_SeverityPerDay">
                 <severityPerDay>-0.4</severityPerDay>
             </li>
-            <li Class="Pawnmorph.Hediffs.CompProperties_RemoveType">
-                <removeType>Pawnmorph.Hediffs.MorphTf</removeType>
-            </li>
+			<li Class="Pawnmorph.Hediffs.CompProperties_RemoveType">
+				<removeTypes>
+					<li>Pawnmorph.Hediffs.MorphTf</li>
+					<li>Pawnmorph.Hediffs.Hediff_MutagenicBase</li>
+				</removeTypes>
+			</li>
 
         </comps>
         <stages>

--- a/1.4/Defs/Hediffs/Hediffs_Misc.xml
+++ b/1.4/Defs/Hediffs/Hediffs_Misc.xml
@@ -34,9 +34,11 @@
 				<severityPerDay>-2</severityPerDay>
 			</li>
 			<li Class="Pawnmorph.Hediffs.CompProperties_RemoveType">
-				<removeType>Pawnmorph.Hediffs.MorphTf</removeType>
+				<removeTypes>
+					<li>Pawnmorph.Hediffs.MorphTf</li>
+					<li>Pawnmorph.Hediffs.Hediff_MutagenicBase</li>
+				</removeTypes>
 			</li>
-
 		</comps>
 		<stages>
 			<li>

--- a/1.4/Defs/MorphsAndMutationDefs/Shared/GenericMutations.xml
+++ b/1.4/Defs/MorphsAndMutationDefs/Shared/GenericMutations.xml
@@ -471,6 +471,16 @@
 		<categories>
 			<li>Minor</li>
 		</categories>
+        <modExtensions>
+            <li Class="Pawnmorph.DefExtensions.MutationCauseExtension">
+                <rulePack>
+                    <rulesStrings>
+                        <li>mutagen_cause->[PAWN_possessive] [SOURCEPART_label]</li>
+                    	<li>caused_by->spreading from</li>
+                    </rulesStrings>
+                </rulePack>
+            </li>
+        </modExtensions>
 	</Pawnmorph.Hediffs.MutationDef>
 
 	<!-- Misc - Suggestion: only the last stage has values, pain in growing -->

--- a/1.4/Defs/Mutagens/ChaoticMutagens.xml
+++ b/1.4/Defs/Mutagens/ChaoticMutagens.xml
@@ -53,6 +53,9 @@
         <causeRulePack>
             <rulesStrings>
                 <li>mutagen_cause->bulidup from [weapon_label]</li>
+                <li>caused_by->caused by</li>
+                <li>caused_by->because of</li>
+                <li>caused_by->after</li>
             </rulesStrings>
         </causeRulePack>
     </Pawnmorph.MutagenDef>
@@ -63,6 +66,9 @@
         <causeRulePack>
             <rulesStrings>
                 <li>mutagen_cause->bulidup from mutagenic fallout</li>
+                <li>caused_by->caused by</li>
+                <li>caused_by->because of</li>
+                <li>caused_by->after</li>
             </rulesStrings>
         </causeRulePack>
     </Pawnmorph.MutagenDef>
@@ -73,6 +79,10 @@
             <rulesStrings>
                 <li>mutagen_cause->standing too close to mutanite</li>
                 <li>mutagen_cause->licking weird glowing rocks</li>
+				        <li>caused_by->from</li>
+                <li>caused_by->caused by</li>
+                <li>caused_by->because of</li>
+                <li>caused_by->after</li>
             </rulesStrings>
         </causeRulePack>
     </Pawnmorph.MutagenDef>
@@ -87,6 +97,10 @@
         <causeRulePack>
             <rulesStrings>
                 <li>mutagen_cause->failed chaobulb harvest</li>
+				        <li>caused_by->from</li>
+                <li>caused_by->caused by</li>
+                <li>caused_by->because of</li>
+                <li>caused_by->after</li>
             </rulesStrings>
         </causeRulePack>
     </Pawnmorph.MutagenDef>

--- a/1.4/Defs/Mutagens/defaultMutagen.xml
+++ b/1.4/Defs/Mutagens/defaultMutagen.xml
@@ -2,12 +2,6 @@
 <Defs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../Schemas/MutagenDef.xsd">
 	<Pawnmorph.MutagenDef ParentName="SimpleMutagenBase">
 		<defName>defaultMutagen</defName>
-		<!--<causeRulePack>
-			<rulesStrings>
-				<li>mutagen_cause->getting jabbed by an injector</li>
-				<li>mutagen_cause->injector</li>
-			</rulesStrings>
-		</causeRulePack>-->
 	</Pawnmorph.MutagenDef>
 	<Pawnmorph.MutagenDef ParentName="SimpleMutagenBase">
 		<defName>PM_ChamberMutagen</defName>
@@ -46,12 +40,6 @@
 
 	<Pawnmorph.MutagenDef ParentName="AspectGivingMutagenBase">
 		<defName>AspectGivingMutagen</defName>
-		<!--<causeRulePack>
-			<rulesStrings>
-				<li>mutagen_cause->getting jabbed by an injector</li>
-				<li>mutagen_cause->injector</li>
-			</rulesStrings>
-		</causeRulePack>-->
 	</Pawnmorph.MutagenDef>
 
 

--- a/1.4/Defs/RulePacks/MutationCauseRulePacks.xml
+++ b/1.4/Defs/RulePacks/MutationCauseRulePacks.xml
@@ -1,0 +1,16 @@
+
+<Defs>
+	<RulePackDef>
+        <defName>InjectorCauseLogPack</defName>
+        <rulePack>
+            <rulesStrings>
+				        <li>mutagen_cause->getting jabbed by an injector</li>
+				        <li>mutagen_cause->an injector</li>
+				        <li>caused_by->from</li>
+                <li>caused_by->caused by</li>
+                <li>caused_by->because of</li>
+                <li>caused_by->after</li>
+            </rulesStrings>
+        </rulePack>
+    </RulePackDef>
+</Defs>

--- a/1.4/Defs/Things/Morph Products.xml
+++ b/1.4/Defs/Things/Morph Products.xml
@@ -63,6 +63,16 @@
 				</li>
 			</outcomeDoers>
 		</ingestible>
+        <modExtensions>
+            <li Class="Pawnmorph.DefExtensions.MutationCauseExtension">
+                <rulePack>
+                    <rulesStrings>
+                        <li>mutagen_cause->drinking strange milk</li>
+                        <li>caused_by->after</li>
+                    </rulesStrings>
+                </rulePack>
+            </li>
+        </modExtensions>
 	</ThingDef>
 
 	<!-- ========== mutagenic Eggs ========== -->
@@ -98,6 +108,16 @@
 				</li>
 			</outcomeDoers>
 		</ingestible>
+        <modExtensions>
+            <li Class="Pawnmorph.DefExtensions.MutationCauseExtension">
+                <rulePack>
+                    <rulesStrings>
+                        <li>mutagen_cause->eating a strange egg</li>
+                        <li>caused_by->after</li>
+                    </rulesStrings>
+                </rulePack>
+            </li>
+        </modExtensions>
 	</ThingDef>
 
 </Defs>

--- a/Languages/English/Keyed/MutationLog.xml
+++ b/Languages/English/Keyed/MutationLog.xml
@@ -1,3 +1,4 @@
 <LanguageData>
     <PmUnkownMutagenCause>PmUnkownMutagenCause</PmUnkownMutagenCause>
+    <Log_CausedBy>caused by</Log_CausedBy>
 </LanguageData>

--- a/Source/Pawnmorphs/Esoteria/Hediffs/CompProperties_RemoveType.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/CompProperties_RemoveType.cs
@@ -15,7 +15,7 @@ namespace Pawnmorph.Hediffs
 		/// <summary>
 		/// The type of hediff to remove 
 		/// </summary>
-		public Type removeType; //the type of hediff to remove 
+		public List<Type> removeTypes; //the type of hediff to remove 
 
 		/// <summary>
 		/// a black list of hediffs to ignore 
@@ -34,7 +34,7 @@ namespace Pawnmorph.Hediffs
 				yield return configError;
 			}
 
-			if (removeType == null)
+			if (removeTypes == null)
 			{
 				yield return "remove type is null";
 			}
@@ -65,7 +65,7 @@ namespace Pawnmorph.Hediffs
 			List<Hediff> hediffs = Pawn.health.hediffSet.hediffs;
 
 			foreach (Hediff hediff in hediffs)
-				if (!Props.blackList.Contains(hediff.def) && Props.removeType.IsInstanceOfType(hediff))
+				if (!Props.blackList.Contains(hediff.def) && Props.removeTypes.Any(x => x.IsInstanceOfType(hediff)))
 				{
 					Pawn.health.RemoveHediff(hediff); //we can only remove one hediff per tick 
 					return;

--- a/Source/Pawnmorphs/Esoteria/Hediffs/Hediff_MutagenicBase.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Hediff_MutagenicBase.cs
@@ -343,6 +343,9 @@ namespace Pawnmorph.Hediffs
 							res.sourceHediffDef = def;
 							res.Causes.Add(_causes);
 							res.Causes.Add(MutationCauses.HEDIFF_PREFIX, def);
+
+							if (Causes.Location.HasValue)
+								res.Causes.SetLocation(Causes.Location.Value);
 						}
 
 						// Notify the observers of any added mutations

--- a/Source/Pawnmorphs/Esoteria/Hediffs/Hediff_MutagenicBase.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/Hediff_MutagenicBase.cs
@@ -174,7 +174,7 @@ namespace Pawnmorph.Hediffs
 				_causes.Add(MutationCauses.WEAPON_PREFIX, weaponSource);
 			}
 
-			_causes.SetLocation(pawn.GetCorrectPosition(), pawn.GetCorrectMap());
+			_causes.SetLocation(pawn);
 			if (def.stages != null && def.stages.Count > 0)
 				CheckCurrentStage(null, def.stages[base.CurStageIndex]);
 		}

--- a/Source/Pawnmorphs/Esoteria/Hediffs/SpreadingMutationComp.cs
+++ b/Source/Pawnmorphs/Esoteria/Hediffs/SpreadingMutationComp.cs
@@ -89,7 +89,18 @@ namespace Pawnmorph.Hediffs
 			if (CanInfect(record))
 			{
 				var hediff = HediffMaker.MakeHediff(Def, Pawn, record);
+				if (hediff is Hediff_AddedMutation mutation)
+				{
+					// Include the skin mutation as the actual cause.
+					mutation.Causes.Add(string.Empty, parent.def);
+
+					// Include the source body part too.
+					mutation.Causes.Add("SOURCEPART", parent.Part.def);
+				}
+
+
 				Pawn.health.AddHediff(hediff, record);
+
 				return true;
 			}
 

--- a/Source/Pawnmorphs/Esoteria/IngestionOutcomeDoer_GiveHediff.cs
+++ b/Source/Pawnmorphs/Esoteria/IngestionOutcomeDoer_GiveHediff.cs
@@ -1,6 +1,7 @@
 ﻿// IngestionOutcomeDoer_GiveHediff.cs created by Iron Wolf for Pawnmorph on 08/12/2021 9:10 AM
 // last updated 08/12/2021  9:10 AM
 
+using Pawnmorph.Hediffs;
 using RimWorld;
 using Verse;
 
@@ -29,7 +30,17 @@ namespace Pawnmorph
 			severity = severity < 0 ? hediffDef.initialSeverity : severity;
 			var h = HediffMaker.MakeHediff(hediffDef, pawn);
 			h.Severity = severity;
+
+			MutationCauses causes = null;
+			if (h is Hediff_MutagenicBase mutagenicBase)
+				causes = mutagenicBase.Causes;
+			else if (h is Hediff_AddedMutation mutation)
+				causes = mutation.Causes;
+
 			pawn?.health?.AddHediff(h);
+
+			if (causes != null)
+				causes.TryAddCause(string.Empty, ingested.def);
 		}
 
 	}

--- a/Source/Pawnmorphs/Esoteria/IngestionOutcomeDoer_GiveHediffAll.cs
+++ b/Source/Pawnmorphs/Esoteria/IngestionOutcomeDoer_GiveHediffAll.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using Pawnmorph.Hediffs;
 using RimWorld;
 using Verse;
 
@@ -37,6 +38,16 @@ namespace Pawnmorph
 				if (divideByBodySize) num /= pawn.BodySize;
 				AddictionUtility.ModifyChemicalEffectForToleranceAndBodySize(pawn, toleranceChemical, ref num);
 				hediff.Severity = num;
+
+				MutationCauses causes = null;
+				if (hediff is Hediff_MutagenicBase mutagenicBase)
+					causes = mutagenicBase.Causes;
+				else if (hediff is Hediff_AddedMutation mutation)
+					causes = mutation.Causes;
+
+				if (causes != null)
+					causes.TryAddCause(string.Empty, ingested.def);
+
 				pawn.health.AddHediff(hediff, null, null);
 			}
 		}

--- a/Source/Pawnmorphs/Esoteria/IngestionOutcomeDoer_GiveHediffIfNonePresent.cs
+++ b/Source/Pawnmorphs/Esoteria/IngestionOutcomeDoer_GiveHediffIfNonePresent.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Pawnmorph.Hediffs;
 using Pawnmorph.Utilities;
 using RimWorld;
 using Verse;
@@ -56,6 +57,17 @@ namespace Pawnmorph
 				if (divideByBodySize) num /= pawn.BodySize;
 				AddictionUtility.ModifyChemicalEffectForToleranceAndBodySize(pawn, toleranceChemical, ref num);
 				hediff.Severity = num;
+
+
+				MutationCauses causes = null;
+				if (hediff is Hediff_MutagenicBase mutagenicBase)
+					causes = mutagenicBase.Causes;
+				else if (hediff is Hediff_AddedMutation mutation)
+					causes = mutation.Causes;
+
+				if (causes != null)
+					causes.TryAddCause(string.Empty, ingested.def);
+
 				pawn.health.AddHediff(hediff, null, null);
 			}
 		}

--- a/Source/Pawnmorphs/Esoteria/IngestionOutcomeDoer_GiveHediffRandom.cs
+++ b/Source/Pawnmorphs/Esoteria/IngestionOutcomeDoer_GiveHediffRandom.cs
@@ -49,12 +49,18 @@ namespace Pawnmorph
 				AddictionUtility.ModifyChemicalEffectForToleranceAndBodySize(pawn, toleranceChemical, ref num);
 
 			hediff.Severity = num;
-			pawn.health.AddHediff(hediff, null, null);
 
-			if (hediff is Hediff_MutagenicBase mutagen)
-			{
-				mutagen.Causes.Add(string.Empty, ingested.def);
-			}
+
+			MutationCauses causes = null;
+			if (hediff is Hediff_MutagenicBase mutagenicBase)
+				causes = mutagenicBase.Causes;
+			else if (hediff is Hediff_AddedMutation mutation)
+				causes = mutation.Causes;
+
+			if (causes != null)
+				causes.TryAddCause(string.Empty, ingested.def);
+
+			pawn.health.AddHediff(hediff, null, null);
 		}
 	}
 }

--- a/Source/Pawnmorphs/Esoteria/IngestionOutcomeDoer_GiveHediffRandom.cs
+++ b/Source/Pawnmorphs/Esoteria/IngestionOutcomeDoer_GiveHediffRandom.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Pawnmorph.Hediffs;
 using Pawnmorph.Utilities;
 using RimWorld;
 using Verse;
@@ -49,6 +50,11 @@ namespace Pawnmorph
 
 			hediff.Severity = num;
 			pawn.health.AddHediff(hediff, null, null);
+
+			if (hediff is Hediff_MutagenicBase mutagen)
+			{
+				mutagen.Causes.Add(string.Empty, ingested.def);
+			}
 		}
 	}
 }

--- a/Source/Pawnmorphs/Esoteria/MutagenDef.cs
+++ b/Source/Pawnmorphs/Esoteria/MutagenDef.cs
@@ -266,22 +266,6 @@ namespace Pawnmorph
 			if (res)
 			{
 				this.TryApplyAspects(pawn);
-
-				var mBase = cause as Hediff_MutagenicBase;
-				foreach (Hediff_AddedMutation mutation in res)
-				{
-					if (cause != null)
-					{
-						if (mBase != null)
-						{
-							mutation.Causes.Add(mBase.Causes);
-
-							if (mBase.Causes.Location.HasValue)
-								mutation.Causes.SetLocation(mBase.Causes.Location.Value);
-						}
-						mutation.Causes.Add(MutationCauses.HEDIFF_PREFIX, cause.def);
-					}
-				}
 			}
 		}
 

--- a/Source/Pawnmorphs/Esoteria/MutagenicBuildupUtilities.cs
+++ b/Source/Pawnmorphs/Esoteria/MutagenicBuildupUtilities.cs
@@ -163,10 +163,12 @@ namespace Pawnmorph
 			fHediff.Severity = finalSev;
 
 			float aSev = Mathf.Max(sev, 0.01f); //prevent division by zero 
-			if (adjustValue / aSev > 0.5f && fHediff is Hediff_MutagenicBase mutagenicBase && !mutagenicBase.Causes.HasDefCause(mutagen))
+			if (fHediff is Hediff_MutagenicBase mutagenicBase)
 			{
-				mutagenicBase.Causes.Add(MutationCauses.MUTAGEN_PREFIX, mutagen);
+				mutagenicBase.Causes.TryAddMutagenCause(mutagen);
+				mutagenicBase.Causes.SetLocation(pawn);
 			}
+
 			return finalSev - sev;
 		}
 	}

--- a/Source/Pawnmorphs/Esoteria/MutationCauses.CauseEntry.cs
+++ b/Source/Pawnmorphs/Esoteria/MutationCauses.CauseEntry.cs
@@ -124,7 +124,7 @@ namespace Pawnmorph
 
 				//in addition to sub classing there should be a way to add additional rules via xml 
 				//probably a CauseRuleExtension or something 
-				return GetFromDef(causeDef, additionalPrefix);
+				return GetFromDef(causeDef, pfx);
 			}
 
 			/// <summary>Returns a string that represents the current object.</summary>

--- a/Source/Pawnmorphs/Esoteria/MutationCauses.cs
+++ b/Source/Pawnmorphs/Esoteria/MutationCauses.cs
@@ -68,6 +68,15 @@ namespace Pawnmorph
 		/// <summary>
 		/// Sets the source location.
 		/// </summary>
+		/// <param name="thing">The thing to take location from.</param>
+		public void SetLocation(Thing thing)
+		{
+			_location = new GlobalTargetInfo(thing.GetCorrectPosition(), thing.GetCorrectMap());
+		}
+
+		/// <summary>
+		/// Sets the source location.
+		/// </summary>
 		/// <param name="location">The global location of whatever caused the mutation.</param>
 		public void SetLocation(GlobalTargetInfo location)
 		{

--- a/Source/Pawnmorphs/Esoteria/MutationLogEntry.cs
+++ b/Source/Pawnmorphs/Esoteria/MutationLogEntry.cs
@@ -29,6 +29,11 @@ namespace Pawnmorph
 		/// </summary>
 		public const string MUTAGEN_CAUSE_STRING = "mutagen_cause";
 
+		/// <summary>
+		/// identifier for a block of text representing the default caused by part of the mutation log. 
+		/// </summary>
+		public const string MUTAGEN_CAUSED_BY_STRING = "caused_by";
+
 		private HediffDef _mutationDef;
 		private BodyPartRecord _bodyPart;
 		private Pawn _pawn;
@@ -201,13 +206,13 @@ namespace Pawnmorph
 
 				if (grammarRequest.HasRule(MUTAGEN_CAUSE_STRING))
 				{
-
-					grammarRequest.Rules.Add(new Rule_String("caused_by", "caused by"));
+					if (grammarRequest.HasRule(MUTAGEN_CAUSED_BY_STRING) == false)
+						grammarRequest.Rules.Add(new Rule_String(MUTAGEN_CAUSED_BY_STRING, "Log_CausedBy".Translate()));
 					//grammarRequest.Rules.Add(new Rule_String(MUTAGEN_CAUSE_STRING, UNKNOWN_CAUSE.Translate()));
 				}
 				else
 				{
-					grammarRequest.Rules.Add(new Rule_String("caused_by", ""));
+					grammarRequest.Rules.Add(new Rule_String(MUTAGEN_CAUSED_BY_STRING, ""));
 					grammarRequest.Rules.Add(new Rule_String(MUTAGEN_CAUSE_STRING, ""));
 				}
 

--- a/Source/Pawnmorphs/Esoteria/PMRulePackDefOf.cs
+++ b/Source/Pawnmorphs/Esoteria/PMRulePackDefOf.cs
@@ -24,6 +24,8 @@ namespace Pawnmorph
 
 		public static RulePackDef DefaultHornMutationLogPack;
 
+		public static RulePackDef InjectorCauseLogPack;
+
 		public static RulePackDef GetDefaultPackForMutation(HediffDef mutation)
 		{
 			if (mutation.defName.Contains("Tail")) return DefaultTailMutationLogPack;

--- a/Source/Pawnmorphs/Esoteria/Things/InjectorGenerator.cs
+++ b/Source/Pawnmorphs/Esoteria/Things/InjectorGenerator.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
+using Pawnmorph.DefExtensions;
 using Pawnmorph.Utilities;
 using RimWorld;
 using Verse;
@@ -148,7 +149,20 @@ namespace Pawnmorph.Things
 				comps = comps
 			};
 
+			AddMutagenCause(tDef);
+
 			return tDef;
+		}
+
+		private static void AddMutagenCause(ThingDef tDef)
+		{
+			if (tDef.modExtensions == null)
+				tDef.modExtensions = new List<DefModExtension>();
+
+			tDef.modExtensions.Add(new MutationCauseExtension()
+			{
+				rulePackDef = PMRulePackDefOf.InjectorCauseLogPack
+			});
 		}
 
 		private static string CreateInjectorDefName(MorphDef mDef)

--- a/Source/Pawnmorphs/Esoteria/TransformerUtility.cs
+++ b/Source/Pawnmorphs/Esoteria/TransformerUtility.cs
@@ -289,7 +289,7 @@ namespace Pawnmorph
 				}
 			}
 
-			foreach (MorphTf hediffMorph in hS2.OfType<MorphTf>()) //do this second so the morph hediff can cleanup properly 
+			foreach (Hediff hediffMorph in hS2.Where(x => x is Hediff_MutagenicBase || x is MorphTf)) //do this second so the morph hediff can cleanup properly 
 			{
 				pawn.health.RemoveHediff(hediffMorph); //remove ongoing morph hediffs 
 			}


### PR DESCRIPTION
Added mutation log cause support for milk + egg ingesting and spreading.
Added mutation log support for identifying injectors, ingestibles, and updating location on mutagenic buildup.
Migrated more hediffs to Mutagenic base from MorphTF.